### PR TITLE
update quad_form to handle (slightly) complex eigenvalues

### DIFF
--- a/src/atoms/second_order_cone/quad_form.jl
+++ b/src/atoms/second_order_cone/quad_form.jl
@@ -16,7 +16,7 @@ function quad_form(x::AbstractExpr, A::Value)
   if !is_symmetric(A)
     error("Quadratic form only defined for symmetric matrices")
   end
-  V = real(eigvals(full(A)))
+  V = eigvals(Symmetric(full(A)))
 
   if all(V .>= 0)
     factor = 1

--- a/src/atoms/second_order_cone/quad_form.jl
+++ b/src/atoms/second_order_cone/quad_form.jl
@@ -16,7 +16,7 @@ function quad_form(x::AbstractExpr, A::Value)
   if !is_symmetric(A)
     error("Quadratic form only defined for symmetric matrices")
   end
-  V = eigvals(full(A))
+  V = real(eigvals(full(A)))
 
   if all(V .>= 0)
     factor = 1


### PR DESCRIPTION
I was running into problems with quad_form. My A matrix passed the is_symmetric test (tolerance of 1e-6), but the eigenvalues had very small complex parts. The pairwise compare operator in Julia does not like this, so it would choke. I just added a call to real around the eigenvalues. This happens after the check for symmetric matrices, so it should only happen when numerical issues cause small complex parts.