### PR TITLE
WIP: Presolve

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -70,4 +70,5 @@ include("atoms/logdet.jl")
 include("utilities/show.jl")
 include("utilities/iteration.jl")
 include("utilities/deprecated.jl")
+include("presolve.jl")
 end

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -7,10 +7,6 @@
 # * don't give up on eliminating integer / boolean variables
 # * eliminate variables and constraints not connected to the objective
 
-# * integers
-# * frob norm
-# * inv_pos optval
-
 function presolve(c, A, b, constrcones, varcones, vartypes, verbose=false)
 	verbose && @show c, full(A), b, constrcones
 	m, n = size(A)

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -1,0 +1,113 @@
+# To do
+
+# * consider how to populate dual variables corresponding to eliminated constraints
+# * allow users to specify which constraint can't be eliminated
+# * populate dual variables for SDPs
+# * stop committing crimes against sparse matrices
+
+function presolve(c, A, b, constrcones, varcones)
+	@show c, full(A), b, constrcones
+	m, n = size(A)
+	tA = copy(A)
+	tb = copy(b)
+	tc = copy(c)
+	# P*[1; new_primal_optimal_solution] = old_primal_optimal_solution
+	P = [eye(n) zeros(n,1)]
+	# Don't drop any of the variables present in the varcones
+	keepme = union([vars for (cone,vars) in varcones])
+	eliminatedconstraints = Int[]
+	eliminatedvars = Int[]
+	for (cone, indices) in constrcones
+		if cone == :Zero			
+			for iconstr in indices
+				rownnz = find(tA[iconstr,:])
+				# note that any variable appearing in a row of A has not previously been eliminated
+				# all zero row can be eliminated
+				if length(rownnz) == 0
+					tb[iconstr] == 0 ? push!(eliminatedconstraints, iconstr) : error("Infeasible")
+				# row with one entry fixes the value of that variable to be a constant
+				elseif length(rownnz) == 1
+					# make sure we don't throw away *all* the variables
+					length(eliminatedvars) == n-1 && break
+					ivar = rownnz[1]
+					P[:,end] += P[:,ivar] * (tb[iconstr] / tA[iconstr,ivar])
+					P[:,ivar] = 0
+					tb += tA[:,ivar] * (tb[iconstr] / tA[iconstr,ivar])
+					tA[:,ivar] = 0
+					tc[ivar] = 0
+					push!(eliminatedconstraints, iconstr)
+					push!(eliminatedvars, ivar)
+				# with two constraints we can always eliminate one variable
+				elseif length(rownnz) == 2
+					if !(rownnz[2] in keepme)
+						# eliminate second variable
+						iv1 = rownnz[1]
+						iv2 = rownnz[2]
+					else
+						# eliminate first variable
+						iv1 = rownnz[1]
+						iv2 = rownnz[2]
+					end
+					bc = tb[iconstr]
+					Acv1 = tA[iconstr, iv1]
+					Acv2 = tA[iconstr, iv2]
+					Av2 = tA[:,iv2]
+					cv1 = tc[iv1]
+					cv2 = tc[iv2]
+					# Acv1*v1 + Acv2*v2 = bc => v2 = bc/Acv2 - Acv1/Acv2*v1
+					P[iv2, end] = bc / Acv2
+					P[iv2, iv2] = 0
+					P[iv2, iv1] = - Acv1/Acv2
+					# Av2*v2 = Av2*(bc/Acv2 - Acv1/Acv2*v1)
+					tb += Av2*(bc/Acv2)
+					tA[:,iv1] -= Av2*(Acv1/Acv2)
+					tA[:,iv2] = 0
+					# cv2*v2 = cv2*(bc/Acv2 - Acv1/Acv2*v1), but ignore the constant term
+					tc[iv1] -= cv2*Acv1/Acv2
+					tc[iv2] = 0
+					push!(eliminatedconstraints, iconstr)
+					push!(eliminatedvars, iv2)
+					push!(eliminatedconstraints, iconstr)
+				end
+			end
+			# in all other cases we need to eliminate variables in terms of other eliminated variables, 
+			# and that sounds dangerously like gaussian elimination, 
+			# which we could certainly do much more intelligently.
+			# also other cases would cause more fill in
+		end
+	end
+
+	## Retain only the informative rows and columns of the new problem data
+	vars = sort(collect(union(keepme, setdiff(Set(1:n), Set(eliminatedvars)))))
+	constrs = sort(collect(setdiff(Set(1:m), Set(eliminatedconstraints))))
+	@show vars, constrs
+
+	# map constraint indices onto new constraint indices in constraintcones
+	constrmap = zeros(Int, m)
+	iconstr = 1
+	for i=1:m
+		if !(i in eliminatedconstraints)
+			constrmap[i] = iconstr
+			iconstr += 1
+		end
+	end
+	newconstrindices(indices) = filter(x->x>0, constrmap[indices])
+	newconstrcones = (Symbol, Any)[]
+	for (cone,indices) in constrcones
+		push!(newconstrcones, (cone, newconstrindices(indices)) )		
+	end
+
+	@show tc[vars], full(tA[constrs, vars]), tb[constrs], newconstrcones, 
+		P[:, [vars..., n+1]]
+	return tc[vars], tA[constrs, vars], tb[constrs], newconstrcones, 
+		sparse(P[:, push!(vars, n+1)]), constrs
+end
+
+
+
+
+
+
+
+
+

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -75,6 +75,10 @@ function presolve(c, A, b, constrcones, varcones)
 			# which we could certainly do much more intelligently.
 			# also other cases would cause more fill in
 		end
+		# btw we can also delete all-zero rows in LP and SOC constraints.
+		# not in SDP constraints.
+		# and this process might introduce new all-zero rows.
+		# so we could check for them in a second loop at the end if that seemed important.
 	end
 
 	## Retain only the informative rows and columns of the new problem data

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -31,7 +31,7 @@ function solve!(problem::Problem,
 
   oc, oA, ob, cones, var_to_ranges, vartypes, conic_constraints = conic_problem(problem)
 
-  c, A, b, cones, P, constrindices = MathProgBase.presolve(oc, oA, ob, cones, [])
+  c, A, b, cones, P, constrindices = presolve(oc, oA, ob, cones, [])
 
   if problem.head == :maximize
     c, oc = -c, -oc

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -31,7 +31,7 @@ function solve!(problem::Problem,
 
   oc, oA, ob, cones, var_to_ranges, vartypes, conic_constraints = conic_problem(problem)
 
-  c, A, b, cones, P, constrindices = presolve(oc, oA, ob, cones, [], vartypes)
+  c, A, b, cones, vartypes, P, constrindices = presolve(oc, oA, ob, cones, [], vartypes)
 
   if problem.head == :maximize
     c, oc = -c, -oc

--- a/test/test_presolve_perf.jl
+++ b/test/test_presolve_perf.jl
@@ -1,0 +1,69 @@
+using Convex
+import Distributions
+using FactCheck
+using SCS
+
+facts("Presolve performance") do
+  context("svm") do
+    function gen_data(n)
+      pos = rand(Distributions.MvNormal([1.0,2.0],1.0),n)
+      neg = rand(Distributions.MvNormal([-1.0,1.0],1.0),n)
+      return pos,neg
+    end
+
+    const N = 2
+    const C = 10
+
+    function svm(pos, neg, use_presolve)
+      w = Variable(N)
+      b = Variable()
+      ξpos = Variable(size(pos,2), Positive())
+      ξneg = Variable(size(neg,2), Positive())
+
+      problem = minimize(sum_squares(w) + C*sum(ξpos) + C*sum(ξneg))
+      for j in 1:size(pos,2)
+        push!(problem.constraints, dot(w,pos[:,j]) - b >= 1 - ξpos[j])
+        #problem.constraints += dot(w,pos[:,j]) - b >= 1 - ξpos[j]
+      end
+      for j in 1:size(neg,2)
+        push!(problem.constraints, -1*(dot(w,neg[:,j]) - b) >= 1-ξneg[j])
+        #problem.constraints += -1*(dot(w,neg[:,j]) - b) >= 1-ξneg[j]
+      end
+      solve!(problem, SCSSolver(verbose=0), use_presolve=use_presolve)
+      return evaluate(w), evaluate(b)
+    end
+
+    # initial compilation
+    pos,neg = gen_data(10)
+    svm(pos, neg, true)
+    # svm(pos, neg, false)
+
+    pos,neg = gen_data(2000)
+    @time w, b = svm(pos, neg, true)
+    @show w,b
+    @time w, b = svm(pos, neg, false)
+    @show w,b
+  end
+
+  context("variables to constants") do
+    # warm up
+    x = Variable()
+    p = minimize(sum(x), [x == 1])
+    solve!(p, SCSSolver(verbose=0))
+
+    x1 = Variable(1000)
+    p1 = minimize(sum(x1), [x1 == [1:1000]])
+    @time solve!(p1, SCSSolver(verbose=0), use_presolve=false)
+
+    x2 = Variable(1000)
+    p2 = minimize(sum(x2), [x2 == [1:1000]])
+    @time solve!(p2, SCSSolver(verbose=0), use_presolve=true)
+  end
+end
+
+
+
+
+
+
+


### PR DESCRIPTION
This is a work in progress to implement a (fast) presolve routine to reduce the size of the problems Convex.jl sends to its solvers. 

This branch adds a keyword argument to `solve!` allowing the user to turn on the presolve (off by default). The presolve routine, in `presolve.jl`, eliminates equality constraints involving two variables or fewer, which can be done without reducing the sparsity of the system. However, it does change the sparsity _pattern_, which makes the current implementation extremely inefficient.

Before this is ready to be merged to master, 
1. We'll need to make the performance _much_ faster. We can test performance using `test_presolve_perf.jl`. 
2. We might also add other kinds of presolve reductions. See, for example, [this paper](http://www.turma-aguia.com/davi/doc/Andersen.pdf) by Anderson and Anderson.
