### PR TITLE
Fix Convex on Julia 0.4

### DIFF
--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -86,3 +86,13 @@ end
 function getindex(x::AbstractExpr, I::AbstractVector{Bool})
     return [ x[i] for i in to_index(I) ]
 end
+# Colon methods
+# All rows and columns
+function getindex(x::AbstractExpr, cln_r::Colon, cln_c::Colon)
+  rows, cols = size(x)
+  getindex(x, 1:rows, 1:cols)
+end
+# All rows for this column(s)
+getindex(x::AbstractExpr, cln_r::Colon, col) = getindex(x, 1:size(x)[1], col)
+# All columns for this row(s)
+getindex(x::AbstractExpr, row, cln_c::Colon) = getindex(x, row, 1:size(x)[2])

--- a/src/atoms/dot_sort.jl
+++ b/src/atoms/dot_sort.jl
@@ -57,7 +57,8 @@ function conic_form!(x::DotSortAtom, unique_conic_forms::UniqueConicForms)
   if !has_conic_form(unique_conic_forms, x)
     y = x.children[1]
     w = x.w
-    if all(size(y)) > 1
+    sy = size(y)
+    if sy[1] > 1 && sy[2] > 1 && sy[1] == sy[2] 
       y = vec(y)
     end
     mu = Variable(size(y))


### PR DESCRIPTION
~~This doesn't get Convex passing on 0.4, but, it gets it a bit further.~~

I didn't even know the original behavior worked for that `any` in `dot_sort`,
```
# Julia 0.3 behavior:
#  all((1,3)) --> 0
#  all((1,1)) --> 1
#  all((4,4)) --> 4
```
but this change seems to at least match the old behavior.