### PR TITLE
Revert "Enable precompile"

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -1,5 +1,3 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
-
 module Convex
 using Compat
 


### PR DESCRIPTION
Reverts JuliaOpt/Convex.jl#98

Woops. I thought I tested it, but apparently not, getting

```
Affine Atoms
     - negate atom
ERROR: LoadError: LoadError: LoadError: TypeError: call: in new, expected Dict{Tuple{Symbol,UInt64},Dict{UInt64,Union{AbstractArray{T,N},Number}}}, got Dict{Tuple{Symbol,UInt64},Dict{UInt64,Union{AbstractArray{T,N},Number}}}
 in call at /Users/idunning/.julia/v0.4/Convex/src/conic_form.jl:70
 in conic_problem at /Users/idunning/.julia/v0.4/Convex/src/problems.jl:110
 in solve! at /Users/idunning/.julia/v0.4/Convex/src/solution.jl:32
 in solve! at /Users/idunning/.julia/v0.4/Convex/src/solution.jl:10
 in anonymous at /Users/idunning/.julia/v0.3/Convex/test/test_affine.jl:12
 in context at /Users/idunning/.julia/v0.4/FactCheck/src/FactCheck.jl:417
 in anonymous at /Users/idunning/.julia/v0.3/Convex/test/test_affine.jl:7
 in facts at /Users/idunning/.julia/v0.4/FactCheck/src/FactCheck.jl:391
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:263
 in anonymous at no file:21
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:263
 in anonymous at no file:36
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:263
 in process_options at ./client.jl:308
 in _start at ./client.jl:411
```