### PR TITLE
relative entropy tests and tweaks

### DIFF
--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -1,6 +1,6 @@
 #############################################################################
 # relative_entropy.jl
-# relative entropy (ie, sum_i( -x_i log (x_i/y_i) ) of expressions x and y
+# relative entropy (ie, sum_i( x_i log (x_i/y_i) ) of expressions x and y
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
@@ -8,15 +8,12 @@
 export relative_entropy, log_perspective
 export sign, curvature, monotonicity, evaluate
 
-### Entropy: sum_i -x_i log (x_i)
-
 # TODO: make this work for a *list* of inputs, rather than just for scalar/vector/matrix inputs
 
-# Entropy atom: -xlogx entrywise
 type RelativeEntropyAtom <: AbstractExpr
   head::Symbol
   id_hash::Uint64
-  children::@compat Tuple{AbstractExpr}
+  children::@compat Tuple{AbstractExpr,AbstractExpr}
   size::@compat Tuple{Int, Int}
 
   function RelativeEntropyAtom(x::AbstractExpr, y::AbstractExpr)
@@ -30,7 +27,7 @@ function sign(x::RelativeEntropyAtom)
 end
 
 function monotonicity(x::RelativeEntropyAtom)
-  return (NoMonotonicity(),)
+  return (NoMonotonicity(),NoMonotonicity())
 end
 
 function curvature(x::RelativeEntropyAtom)
@@ -76,4 +73,5 @@ function conic_form!(e::RelativeEntropyAtom, unique_conic_forms::UniqueConicForm
 end
 
 relative_entropy(x::AbstractExpr, y::AbstractExpr) = sum(RelativeEntropyAtom(x, y))
-log_perspective(x::AbstractExpr, y::AbstractExpr) = -relative_entropy (x, y)
+# y*log(x/y)
+log_perspective(x::AbstractExpr, y::AbstractExpr) = -relative_entropy(y, x)

--- a/test/test_exp.jl
+++ b/test/test_exp.jl
@@ -78,4 +78,24 @@ facts("Exp Atoms") do
     @fact p.optval => roughly(-log(1/5), TOL)
   end
 
+  context("relative entropy atom") do
+    x = Variable(1);
+    y = Variable(1);
+    # x log (x/y)
+    p = minimize(relative_entropy(x,y), y==1, x >= 2)
+    @fact vexity(p) --> ConvexVexity()
+    solve!(p)
+    @fact p.optval --> roughly(2*log(2), TOL)
+  end
+
+  context("log perspective atom") do
+    x = Variable(1);
+    y = Variable(1);
+    # y log (x/y)
+    p = maximize(log_perspective(x,y), y==5, x <= 10)
+    @fact vexity(p) --> ConvexVexity()
+    solve!(p)
+    @fact p.optval --> roughly(5*log(2), TOL)
+  end
+
 end


### PR DESCRIPTION
Pull request against the ``relative_entropy`` branch. Fixed some bugs, added some tests, and adjusted the definition of ``log_perspective(x,y)`` to be ``y*log(x/y)`` which reads better to me.