### PR TITLE
Explicitly import operators from Base

### DIFF
--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -6,6 +6,7 @@
 # Please read expressions.jl first.
 #############################################################################
 
+import Base.+, Base.-, Base.(.+), Base.(.-)
 export +, -, .+, .-
 export sign, curvature, monotonicity, evaluate
 

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -6,6 +6,7 @@
 # Please read expressions.jl first.
 #############################################################################
 
+import Base.*, Base.(.*), Base./, Base.(./)
 export *, .*
 export sign, monotonicity, curvature, evaluate, conic_form!
 

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -1,3 +1,4 @@
+import Base.+,Base.-,Base.*
 export ConicObj, ConicConstr, UniqueConicForms
 export +, -, *, promote_size, get_row
 export cache_conic_form!, has_conic_form, get_conic_form

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -1,3 +1,4 @@
+import Base.==, Base.<=, Base.>=, Base.<, Base.>
 export EqConstraint, LtConstraint, GtConstraint
 export ==, <=, >=
 

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -10,6 +10,7 @@
 # http://web.stanford.edu/~boyd/papers/disc_cvx_prog.html
 #############################################################################
 
+import Base.-, Base.+, Base.*
 export Vexity, ConstVexity, AffineVexity, ConvexVexity, ConcaveVexity, NotDcp
 export Monotonicity, Nonincreasing, Nondecreasing, NoMonotonicity
 export Sign, Positive, Negative, NoSign


### PR DESCRIPTION
This takes care of these warnings when loading the package...

```
WARNING: module Convex should explicitly import - from Base
WARNING: module Convex should explicitly import + from Base
WARNING: module Convex should explicitly import * from Base
WARNING: module Convex should explicitly import == from Base
WARNING: module Convex should explicitly import <= from Base
WARNING: module Convex should explicitly import < from Base
WARNING: module Convex should explicitly import >= from Base
WARNING: module Convex should explicitly import > from Base
WARNING: module Convex should explicitly import .+ from Base
WARNING: module Convex should explicitly import .- from Base
WARNING: module Convex should explicitly import / from Base
WARNING: module Convex should explicitly import .* from Base
WARNING: module Convex should explicitly import ./ from Base
```