### PR TITLE
params tests only work with SOCP solvers

### DIFF
--- a/test/runtests_single_solver.jl
+++ b/test/runtests_single_solver.jl
@@ -3,9 +3,8 @@ using FactCheck
 
 tests = ["test_utilities.jl",
          "test_affine.jl",
-         "test_lp.jl",
-         "test_params.jl"]
-tests_socp = ["test_socp.jl"]
+         "test_lp.jl"]
+tests_socp = ["test_socp.jl","test_params.jl"]
 tests_sdp = ["test_sdp.jl"]
 tests_exp = ["test_exp.jl"]
 tests_int = ["test_int.jl"]


### PR DESCRIPTION
Let's see if this passes tests now. Ref https://github.com/JuliaOpt/Convex.jl/issues/109