### PR TITLE
drop support for julia 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.3
+julia 0.4
 MathProgBase 0.3.8
-Compat 0.4.4
 DataStructures

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -1,5 +1,4 @@
 module Convex
-using Compat
 import DataStructures
 
 importall Base.Operators

--- a/src/atoms/abs.jl
+++ b/src/atoms/abs.jl
@@ -14,8 +14,8 @@ export sign, curvature, monotonicity, evaluate
 type AbsAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function AbsAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -15,8 +15,8 @@ export sign, curvature, monotonicity, evaluate
 type NegateAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function NegateAtom(x::AbstractExpr)
     children = (x,)
@@ -57,7 +57,7 @@ type AdditionAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Array{AbstractExpr, 1}
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
 
   function AdditionAtom(x::AbstractExpr, y::AbstractExpr)
     # find the size of the expression = max of size of x and size of y

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -13,8 +13,8 @@ export diag
 type DiagAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   k::Int
 
   function DiagAtom(x::AbstractExpr, k::Int=0)

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -11,8 +11,8 @@ export diagm
 type DiagMatrixAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function DiagMatrixAtom(x::AbstractExpr)
     (num_rows, num_cols) = x.size

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -1,13 +1,13 @@
 import Base: getindex, to_index
 export IndexAtom, getindex
 
-@compat typealias ArrayOrNothing Union{AbstractArray, Void}
+typealias ArrayOrNothing Union{AbstractArray, Void}
 
 type IndexAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   rows::ArrayOrNothing
   cols::ArrayOrNothing
   inds::ArrayOrNothing

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -15,8 +15,8 @@ export sign, monotonicity, curvature, evaluate, conic_form!
 type MultiplyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MultiplyAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size == (1, 1)
@@ -109,8 +109,8 @@ end
 type DotMultiplyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{Constant, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{Constant, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function DotMultiplyAtom(x::Constant, y::AbstractExpr)
     if x.size != y.size

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -6,8 +6,8 @@ export sign, curvature, monotonicity, evaluate, conic_form!
 type ReshapeAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function ReshapeAtom(x::AbstractExpr, m::Int, n::Int)
     if m * n != get_vectorized_size(x)

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -6,7 +6,7 @@ type HcatAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
 
   function HcatAtom(args::AbstractExpr...)
     num_rows = args[1].size[1]

--- a/src/atoms/affine/sum.jl
+++ b/src/atoms/affine/sum.jl
@@ -12,8 +12,8 @@ export sum
 type SumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function SumAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/affine/transpose.jl
+++ b/src/atoms/affine/transpose.jl
@@ -12,8 +12,8 @@ export sign, curvature, monotonicity, evaluate, conic_form!
 type TransposeAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function TransposeAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/dotsort.jl
+++ b/src/atoms/dotsort.jl
@@ -13,8 +13,8 @@ export sign, curvature, monotonicity, evaluate
 type DotSortAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   w::Value
 
   function DotSortAtom(x::AbstractExpr, w::Value)

--- a/src/atoms/exp_cone/entropy.jl
+++ b/src/atoms/exp_cone/entropy.jl
@@ -16,8 +16,8 @@ export sign, curvature, monotonicity, evaluate
 type EntropyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function EntropyAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -14,8 +14,8 @@ export sign, curvature, monotonicity, evaluate
 type ExpAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function ExpAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/exp_cone/log.jl
+++ b/src/atoms/exp_cone/log.jl
@@ -14,8 +14,8 @@ export sign, curvature, monotonicity, evaluate
 type LogAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function LogAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -15,8 +15,8 @@ export sign, curvature, monotonicity, evaluate
 type LogSumExpAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function LogSumExpAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -13,8 +13,8 @@ export sign, curvature, monotonicity, evaluate
 type RelativeEntropyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr,AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr,AbstractExpr}
+  size::Tuple{Int, Int}
 
   function RelativeEntropyAtom(x::AbstractExpr, y::AbstractExpr)
     children = (x, y)

--- a/src/atoms/huber.jl
+++ b/src/atoms/huber.jl
@@ -3,8 +3,8 @@ export huber
 type HuberAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   M::Real
 
   function HuberAtom(x::AbstractExpr, M::Real)

--- a/src/atoms/logdet.jl
+++ b/src/atoms/logdet.jl
@@ -3,8 +3,8 @@ import Base.logdet
 type LogDetAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function LogDetAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/max.jl
+++ b/src/atoms/max.jl
@@ -12,8 +12,8 @@ export max, pos, hinge_loss
 type MaxAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MaxAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size == y.size

--- a/src/atoms/maximum.jl
+++ b/src/atoms/maximum.jl
@@ -11,8 +11,8 @@ export maximum
 type MaximumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MaximumAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/min.jl
+++ b/src/atoms/min.jl
@@ -12,8 +12,8 @@ export min, neg
 type MinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MinAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size == y.size

--- a/src/atoms/minimum.jl
+++ b/src/atoms/minimum.jl
@@ -11,8 +11,8 @@ export minimum
 type MinimumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MinimumAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/sdp_cone/lambda_min_max.jl
+++ b/src/atoms/sdp_cone/lambda_min_max.jl
@@ -12,8 +12,8 @@ export lambdamax, lambdamin
 type LambdaMaxAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function LambdaMaxAtom(x::AbstractExpr)
     children = (x,)
@@ -65,8 +65,8 @@ end
 type LambdaMinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function LambdaMinAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/sdp_cone/matrixfrac.jl
+++ b/src/atoms/sdp_cone/matrixfrac.jl
@@ -10,8 +10,8 @@ export matrixfrac
 type MatrixFracAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function MatrixFracAtom(x::AbstractExpr, P::AbstractExpr)
     if x.size[2] != 1

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -11,8 +11,8 @@ export nuclearnorm
 type NuclearNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function NuclearNormAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -12,8 +12,8 @@ export operatornorm, sigmamax
 type OperatorNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function OperatorNormAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -13,8 +13,8 @@ export sumlargesteigs
 type SumLargestEigs <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function SumLargestEigs(x::AbstractExpr, k::AbstractExpr)
     children = (x, k)

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -5,8 +5,8 @@ export sign, monotonicity, curvature, conic_form!
 type GeoMeanAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function GeoMeanAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size != y.size

--- a/src/atoms/second_order_cone/norm2.jl
+++ b/src/atoms/second_order_cone/norm2.jl
@@ -12,8 +12,8 @@ export sign, monotonicity, curvature, conic_form!
 type EucNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
 
   function EucNormAtom(x::AbstractExpr)
     children = (x,)

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -4,8 +4,8 @@ export sign, monotonicity, curvature, conic_form!
 type QolElemAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function QolElemAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size != y.size

--- a/src/atoms/second_order_cone/quadoverlin.jl
+++ b/src/atoms/second_order_cone/quadoverlin.jl
@@ -4,8 +4,8 @@ export sign, monotonicity, curvature, conic_form!
 type QuadOverLinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr}
+  size::Tuple{Int, Int}
 
   function QuadOverLinAtom(x::AbstractExpr, y::AbstractExpr)
     if x.size[2] != 1 && y.size != (1, 1)

--- a/src/atoms/second_order_cone/rationalnorm.jl
+++ b/src/atoms/second_order_cone/rationalnorm.jl
@@ -18,8 +18,8 @@ export rationalnorm
 type RationalNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   k::Rational{Int64}
 
   function RationalNormAtom(x::AbstractExpr, k::Rational{Int64})

--- a/src/atoms/sumlargest.jl
+++ b/src/atoms/sumlargest.jl
@@ -11,8 +11,8 @@ export sign, curvature, monotonicity, evaluate
 type SumLargestAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr}
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr}
+  size::Tuple{Int, Int}
   k::Int
 
   function SumLargestAtom(x::AbstractExpr, k::Int)

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -63,8 +63,8 @@ type ConicConstr
   sizes::Array{Int}
 end
 
-UniqueExpMap = DataStructures.OrderedDict{@compat(Tuple{Symbol, UInt64}), ConicObj}
-UniqueConstrMap = DataStructures.OrderedDict{@compat(Tuple{Symbol, UInt64}), Int}
+UniqueExpMap = DataStructures.OrderedDict{Tuple{Symbol, UInt64}, ConicObj}
+UniqueConstrMap = DataStructures.OrderedDict{Tuple{Symbol, UInt64}, Int}
 UniqueConstrList = Array{ConicConstr}
 
 type UniqueConicForms

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -9,7 +9,7 @@ type Constant <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   value::Value
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   vexity::Vexity
   sign::Sign
 

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -10,7 +10,7 @@ type EqConstraint <: Constraint
   id_hash::UInt64
   lhs::AbstractExpr
   rhs::AbstractExpr
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   dual::ValueOrNothing
 
   function EqConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
@@ -57,7 +57,7 @@ type LtConstraint <: Constraint
   id_hash::UInt64
   lhs::AbstractExpr
   rhs::AbstractExpr
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   dual::ValueOrNothing
 
   function LtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
@@ -105,7 +105,7 @@ type GtConstraint <: Constraint
   id_hash::UInt64
   lhs::AbstractExpr
   rhs::AbstractExpr
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   dual::ValueOrNothing
 
   function GtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -4,8 +4,8 @@ export ExpConstraint, conic_form!, vexity
 type ExpConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
-  children::@compat Tuple{AbstractExpr, AbstractExpr, AbstractExpr} # (x, y, z)
-  size::@compat Tuple{Int, Int}
+  children::Tuple{AbstractExpr, AbstractExpr, AbstractExpr} # (x, y, z)
+  size::Tuple{Int, Int}
   dual::ValueOrNothing
 
   function ExpConstraint(x::AbstractExpr, y::AbstractExpr, z::AbstractExpr)

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -8,7 +8,7 @@ type SDPConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
   child::AbstractExpr
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   dual::ValueOrNothing
 
   function SDPConstraint(child::AbstractExpr)

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -97,9 +97,9 @@ function length(x::AbstractExpr)
 end
 
 ### User-defined Unions
-@compat typealias Value Union{Number, AbstractArray}
-@compat typealias ValueOrNothing Union{Value, Void}
-@compat typealias AbstractExprOrValue Union{AbstractExpr, Value}
+typealias Value Union{Number, AbstractArray}
+typealias ValueOrNothing Union{Value, Void}
+typealias AbstractExprOrValue Union{AbstractExpr, Value}
 
 convert(::Type{AbstractExpr}, x::Value) = Constant(x)
 convert(::Type{AbstractExpr}, x::AbstractExpr) = x

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -4,7 +4,7 @@ export Problem, Solution, minimize, maximize, satisfy, add_constraint!, add_cons
 export Float64OrNothing
 export conic_problem
 
-@compat typealias Float64OrNothing Union{Float64, Void}
+typealias Float64OrNothing Union{Float64, Void}
 
 # TODO: Cleanup
 type Solution{T<:Number}
@@ -47,7 +47,7 @@ end
 function find_variable_ranges(constraints)
   index = 0
   constr_size = 0
-  var_to_ranges = Dict{UInt64, @compat Tuple{Int, Int}}()
+  var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
   for constraint in constraints
     for i = 1:length(constraint.objs)
       for (id, val) in constraint.objs[i]
@@ -111,7 +111,7 @@ function conic_problem(p::Problem)
 
   A = spzeros(constr_size, var_size)
   b = spzeros(constr_size, 1)
-  cones = (@compat Tuple{Symbol, UnitRange{Int}})[]
+  cones = Tuple{Symbol, UnitRange{Int}}[]
   constr_index = 0
   for constraint in constraints
     total_constraint_size = 0

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -121,7 +121,7 @@ function populate_solution!(m::MathProgBase.AbstractMathProgModel,
   problem
 end
 
-function populate_variables!(problem::Problem, var_to_ranges::Dict{UInt64, @compat Tuple{Int, Int}})
+function populate_variables!(problem::Problem, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
   x = problem.solution.primal
   for (id, (start_index, end_index)) in var_to_ranges
     var = id_to_variables[id]
@@ -138,7 +138,7 @@ end
 # TODO: it would be super cool to grab the other expressions that appear in the primal solution vector,
 # get their `expression_to_range`,
 # and populate them too using `evaluate`
-@compat function load_primal_solution!(primal::Array{Float64,1}, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
+function load_primal_solution!(primal::Array{Float64,1}, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
   for (id, (start_index, end_index)) in var_to_ranges
     var = id_to_variables[id]
     if var.value != nothing

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -10,12 +10,12 @@ type Variable <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   value::ValueOrNothing
-  size::@compat Tuple{Int, Int}
+  size::Tuple{Int, Int}
   vexity::Vexity
   sign::Sign
   sets::Array{Symbol,1}
 
-  function Variable(size::@compat(Tuple{Int, Int}), sign::Sign=NoSign(), sets::Symbol...)
+  function Variable(size::Tuple{Int, Int}, sign::Sign=NoSign(), sets::Symbol...)
     this = new(:variable, 0, nothing, size, AffineVexity(), sign, Symbol[sets...])
     this.id_hash = object_id(this)
     id_to_variables[this.id_hash] = this
@@ -25,7 +25,7 @@ type Variable <: AbstractExpr
   Variable(m::Int, n::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((m,n), sign, sets...)
   Variable(sign::Sign, sets::Symbol...) = Variable((1, 1), sign, sets...)
   Variable(sets::Symbol...) = Variable((1, 1), NoSign(), sets...)
-  Variable(size::@compat(Tuple{Int, Int}), sets::Symbol...) = Variable(size, NoSign(), sets...)
+  Variable(size::Tuple{Int, Int}, sets::Symbol...) = Variable(size, NoSign(), sets...)
   Variable(size::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((size, 1), sign, sets...)
   Variable(size::Int, sets::Symbol...) = Variable((size, 1), sets...)
 end


### PR DESCRIPTION
Implementing https://github.com/JuliaOpt/MathProgBase.jl/pull/91 will require dropping 0.3 anyway, so this PR is the first piece of that. Also generally makes the code easier to maintain by removing the ``@compat`` weirdness.