### PR TITLE
Correcting diag atom

### DIFF
--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -20,7 +20,7 @@ type DiagAtom <: AbstractExpr
   function DiagAtom(x::AbstractExpr, k::Int=0)
     (num_rows, num_cols) = x.size
 
-    if k >= num_cols || k <= -num_rows
+    if k >= min(num_rows, num_cols) || k <= -min(num_rows, num_cols)
       error("Bounds error in calling diag")
     end
 


### PR DESCRIPTION
x = Variable(4,5)
Presently
y_1 = diag(x,4)
AbstractExpr with
head: diag
size: (0, 1)
sign: Convex.NoSign()
vexity: Convex.AffineVexity()

does not give error but it should be giving ideally as we can't have the kth diagonal where k is greater than or equal to both the number of rows and columns.

This PR fixes the present bug.
y_2 = diag(x,4)
**ERROR: Bounds error in calling diag**