### PR TITLE
Update portfolio_optimization3_unconstrained_markowitz_efficient_frontier.ipynb

### DIFF
--- a/examples/portfolio_optimization3_unconstrained_markowitz_efficient_frontier.ipynb
+++ b/examples/portfolio_optimization3_unconstrained_markowitz_efficient_frontier.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "#Defining constraints\n",
     "c1 = sum(w) == 1;\n",
-    "c2 = w_lower <= x; \n",
+    "c2 = w_lower <= w; \n",
     "c3 = w <= w_upper;\n",
     "for i in 1:2000\n",
     "    λ = i/2000;\n",


### PR DESCRIPTION
As pointed by @tomasmckelvey, this pull request fixes the typo that is

c2 = w_lower <=w;