### PR TITLE
don't return elementwise square for matrix A*A

### DIFF
--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -95,7 +95,7 @@ function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms)
 end
 
 function *(x::AbstractExpr, y::AbstractExpr)
-  if hash(x) == hash(y)
+  if hash(x) == hash(y) && x.size == (1, 1)
     return square(x)
   end
   return MultiplyAtom(x, y)


### PR DESCRIPTION
`*` is matrix multiplication, not elementwise

todo: add a test