### PR TITLE
Added support for sparse matrices to quadform

### DIFF
--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -1,6 +1,6 @@
 export quadform
 
-function is_symmetric(A::Matrix)
+function is_symmetric(A::AbstractArray)
   TOLERANCE = 1e-6
   return all(A - A' .< TOLERANCE)
 end


### PR DESCRIPTION
Currently, `quadform()` does not support sparse matrices. Changed `is_symmetric` function input type to `::AbstractArray`, which is a supertype for both `::AbstractSparseArray` and `::DenseArray`