### PR TITLE
remove old norm(,::Symbol) method

### DIFF
--- a/src/atoms/second_order_cone/norm.jl
+++ b/src/atoms/second_order_cone/norm.jl
@@ -40,11 +40,3 @@ end
 function vecnorm(x::AbstractExpr, p::Real=2)
   return norm(vec(x), p)
 end
-
-function norm(x::AbstractExpr, p::Symbol)
-  if p == :fro
-    return norm(vec(x), 2)
-  else
-    error("$p norm is not defined")
-  end
-end


### PR DESCRIPTION
This resolves the following warning on 0.5:
```
julia> using Convex
WARNING: Method definition norm(Convex.AbstractExpr, Symbol) in module Convex at /home/mlubin/.julia/v0.5/Convex/src/atoms/second_order_cone/norm.jl:45 overwritten at deprecated.jl:49.
```
``norm(,::Symbol)`` isn't defined in Julia 0.4 or 0.5. ``vecnorm`` is used for the Frobenius norm.