### PR TITLE
bump upper bound on MathProgBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 DataStructures


### PR DESCRIPTION
The MPB 0.6 release was only breaking for the default solver functionality. No changes seem to be needed in Convex.jl.