### PR TITLE
Any argument in kron can be an abstractExpr

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,3 +10,4 @@ Examples
 	* `Binary knapsack <http://nbviewer.ipython.org/github/JuliaOpt/Convex.jl/blob/master/examples/binary_knapsack.ipynb>`_
 	* `Entropy maximization <http://nbviewer.ipython.org/github/JuliaOpt/Convex.jl/blob/master/examples/max_entropy.ipynb>`_
 	* `Logistic regression <http://nbviewer.ipython.org/github/JuliaOpt/Convex.jl/blob/master/examples/logistic_regression.ipynb>`_
+    * `Optimization with Complex Variables <http://nbviewer.jupyter.org/github/JuliaOpt/Convex.jl/tree/master/examples/optimization_with_complex_variables/>`_

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -66,7 +66,7 @@ An optimization problem using only these functions can be solved by any LP solve
 +---------------------------+----------------------------+------------+---------------+---------------------------------+
 |:code:`dot(x,y)`           | :math:`\sum_i x_i y_i`     | affine     |increasing     | PR: one argument is constant    |
 +---------------------------+----------------------------+------------+---------------+---------------------------------+
-|:code:`kron(x,y)`          | Kronecker product          | affine     |increasing     | PR: first argument is constant  |
+|:code:`kron(x,y)`          | Kronecker product          | affine     |increasing     | PR: one argument is constant    |
 +---------------------------+----------------------------+------------+---------------+---------------------------------+
 |:code:`vecdot(x,y)`        |:code:`dot(vec(x),vec(y))`  | affine     |increasing     | PR: one argument is constant    |
 +---------------------------+----------------------------+------------+---------------+---------------------------------+

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -1,8 +1,11 @@
 import Base.kron
 export kron
 
+#### TO DO wite the conic_form implemenatatioo
+
 function kron(a::Union{AbstractArray, Convex.Constant}, b::Convex.Variable)
   rows = Convex.AbstractExpr[]
+  a = Constant(a)
   for i in 1:size(a)[1]
     row = Convex.AbstractExpr[]
     for j in 1:size(a)[2]
@@ -12,3 +15,19 @@ function kron(a::Union{AbstractArray, Convex.Constant}, b::Convex.Variable)
   end
   return foldl(vcat, rows)
 end
+
+
+
+function kron(a::Convex.Variable, b::Union{AbstractArray, Convex.Constant})
+  rows = Convex.AbstractExpr[]
+  b = Constant(b)
+  for i in 1:size(a)[1]
+    row = Convex.AbstractExpr[]
+    for j in 1:size(a)[2]
+      push!(row, a[i, j] * b)
+    end
+    push!(rows, foldl(hcat, row))
+  end
+  return foldl(vcat, rows)
+end
+

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -1,15 +1,16 @@
 import Base.kron
 export kron
 
-#### TO DO wite the conic_form implemenatatioo
-
-function kron(a::Union{AbstractArray, Convex.Constant}, b::Convex.Variable)
-  rows = Convex.AbstractExpr[]
-  a = Constant(a)
+function kron(a::Value, b::AbstractExpr)
+  rows = AbstractExpr[]
   for i in 1:size(a)[1]
-    row = Convex.AbstractExpr[]
+    row = AbstractExpr[]
     for j in 1:size(a)[2]
-      push!(row, a[i, j] * b)
+      if isreal(a[i,j])
+        push!(row, real(a[i, j]) * b)
+      else
+        push!(row, a[i, j] * b)
+      end        
     end
     push!(rows, foldl(hcat, row))
   end
@@ -17,17 +18,14 @@ function kron(a::Union{AbstractArray, Convex.Constant}, b::Convex.Variable)
 end
 
 
-
-function kron(a::Convex.Variable, b::Union{AbstractArray, Convex.Constant})
-  rows = Convex.AbstractExpr[]
-  b = Constant(b)
+function kron(a::AbstractExpr, b::Value)
+  rows = AbstractExpr[]
   for i in 1:size(a)[1]
-    row = Convex.AbstractExpr[]
+    row = AbstractExpr[]
     for j in 1:size(a)[2]
-      push!(row, a[i, j] * b)
+      push!(row, a[i, j] .* b)
     end
     push!(rows, foldl(hcat, row))
   end
   return foldl(vcat, rows)
 end
-

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -5,7 +5,7 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import Base.abs
+import Base.abs, Base.abs2
 export abs, abs2
 export sign, curvature, monotonicity, evaluate
 

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -20,7 +20,7 @@ type Constant <: AbstractExpr
 
   function Constant(x::Value, check_sign::Bool=true)
     if check_sign
-      if is_complex(x)
+      if !isreal(x)
         return Constant(x, ComplexSign())
       elseif all(x .>= 0)
         return Constant(x, Positive())
@@ -29,18 +29,6 @@ type Constant <: AbstractExpr
       end
     end
     return Constant(x, NoSign())
-  end
-
-  function is_complex(x::Value)
-    temp = false
-    y = x + 0im
-    for z in y
-      if z.im != 0
-        temp = true
-        break
-      end
-    end
-    return temp    
   end
 end
 #### Constant Definition end   ##### 


### PR DESCRIPTION
* Defined kron for (constant, AbstractExpr)
* Also kron now accepts complex numbers
* Added link to complex-domain example in docs
* Fixed warning for abs2

@peterwittek this PR solves the error in accepting complex numbers as an argument to kron and now the first argument in kron need not to be a constant.
