### PR TITLE
Fixed robustness of test in "test_params.jl"

### DIFF
--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -20,24 +20,27 @@ facts("Fixed and freed variables") do
 
 	free!(y)
 	solve!(p)
-	@fact p.optval --> roughly(0, TOL)	
+	@fact p.optval --> roughly(0, TOL)
   end
 
-  context("fix multiplication") do	
+  context("fix multiplication") do
 	a = [1,2,3,2,1]
 	x = Variable(length(a))
 	gamma = Variable(Positive())
-	fix!(gamma, 1)
+	fix!(gamma, 0.7)
 
 	p = minimize(norm(x-a) + gamma*norm(x[1:end-1] - x[2:end]))
 	solve!(p)
 	o1 = p.optval
-
+  # x should be very close to a
+  @fact o1 --> roughly(0.7*norm(a[1:end-1] - a[2:end]), TOL)
 	# increase regularization
-	fix!(gamma, 3)
+	fix!(gamma, 1.0)
 	solve!(p)
 	o2 = p.optval
+  # x should be very close to mean(a)
+  @fact o2 --> roughly(norm(a-mean(a)), TOL)
 
 	@fact o1 <= o2 --> true
-  end  
+  end
 end

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -32,14 +32,14 @@ facts("Fixed and freed variables") do
 	p = minimize(norm(x-a) + gamma*norm(x[1:end-1] - x[2:end]))
 	solve!(p)
 	o1 = p.optval
-  # x should be very close to a
-  @fact o1 --> roughly(0.7*norm(a[1:end-1] - a[2:end]), TOL)
+	# x should be very close to a
+	@fact o1 --> roughly(0.7*norm(a[1:end-1] - a[2:end]), TOL)
 	# increase regularization
 	fix!(gamma, 1.0)
 	solve!(p)
 	o2 = p.optval
-  # x should be very close to mean(a)
-  @fact o2 --> roughly(norm(a-mean(a)), TOL)
+	# x should be very close to mean(a)
+	@fact o2 --> roughly(norm(a-mean(a)), TOL)
 
 	@fact o1 <= o2 --> true
   end


### PR DESCRIPTION
The regularization-parameters in "fix multiplication" was badly chosen, resulting in numerical problems (`o2-o1  ≈ 3e-12` when `eps=1e-12`was set for SCS). The regularization only works reasonable in the range 0.8 to 0.85 as shown in the plot. I changed the test to reflect the expected behavior for larger and smaller regularization parameters.
![Plot](http://i.imgur.com/aEZiVfa.png)