### PR TITLE
Avoid OutOfMemoryError

### DIFF
--- a/src/constant.jl
+++ b/src/constant.jl
@@ -22,9 +22,9 @@ type Constant <: AbstractExpr
     if check_sign
       if !isreal(x)
         return Constant(x, ComplexSign())
-      elseif all(x .>= 0)
+      elseif all(xi >= 0 for xi in x)
         return Constant(x, Positive())
-      elseif all(x .<= 0)
+      elseif all(xi <= 0 for xi in x)
         return Constant(x, Negative())
       end
     end


### PR DESCRIPTION
These lines causes `OutOfMemoryError` on large problems because of the broadcast (I believe sparse broadcast is still suffering from performance issues). The proposed change uses an explicit iterator over the elements instead. The problem is easily reproduced by, for example:
```julia
n = 50000
x0 = randn(2n)
A = sprandn(n, 2n, 0.0001)
b = A*x0
x = Variable(2n)
p = minimize(norm(A*x-b), sum(x) == sum(x0))
```
all tests passes locally on
Julia Version 0.6.1-pre.0
Commit dcf39a1* (2017-06-19 13:06 UTC)