### PR TITLE
updated struct and type parameter syntax to julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 MathProgBase 0.5 0.8
 DataStructures
 Compat 0.24

--- a/examples/antidiag.jl
+++ b/examples/antidiag.jl
@@ -14,7 +14,7 @@ export antidiag, sign, monotonicity, curvature, evaluate, conic_form!
 
 ### Diagonal
 ### Represents the kth diagonal of an mxn matrix as a (min(m, n) - k) x 1 vector
-type AntidiagAtom <: AbstractExpr
+struct AntidiagAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -12,7 +12,7 @@ export sign, curvature, monotonicity, evaluate
 
 ### Unary Negation
 
-type NegateAtom <: AbstractExpr
+struct NegateAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}
@@ -53,7 +53,7 @@ end
 
 
 ### Addition
-type AdditionAtom <: AbstractExpr
+struct AdditionAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Array{AbstractExpr, 1}

--- a/src/atoms/affine/conjugate.jl
+++ b/src/atoms/affine/conjugate.jl
@@ -1,7 +1,7 @@
 import Base.conj
 export conj
 export sign, curvature, monotonicity, evaluate, conic_form!
-type ConjugateAtom <: AbstractExpr
+struct ConjugateAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -13,7 +13,7 @@ export diag
 ### Diagonal
 ### Represents the kth diagonal of an mxn matrix as a (min(m, n) - k) x 1 vector
 
-type DiagAtom <: AbstractExpr
+struct DiagAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -8,7 +8,7 @@
 import Base.diagm
 export diagm
 
-type DiagMatrixAtom <: AbstractExpr
+struct DiagMatrixAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -3,7 +3,7 @@ export IndexAtom, getindex
 
 const ArrayOrNothing = Union{AbstractArray, Void}
 
-type IndexAtom <: AbstractExpr
+struct IndexAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}
@@ -78,12 +78,12 @@ end
 
 ## API Definition begins
 
-getindex{T <: Real}(x::AbstractExpr, rows::AbstractArray{T, 1}, cols::AbstractArray{T, 1}) = IndexAtom(x, rows, cols)
-getindex{T <: Real}(x::AbstractExpr, inds::AbstractArray{T, 1}) = IndexAtom(x, inds)
+getindex(x::AbstractExpr, rows::AbstractArray{T, 1}, cols::AbstractArray{T, 1}) where {T <: Real} = IndexAtom(x, rows, cols)
+getindex(x::AbstractExpr, inds::AbstractArray{T, 1}) where {T <: Real} = IndexAtom(x, inds)
 getindex(x::AbstractExpr, ind::Real) = getindex(x, ind:ind)
 getindex(x::AbstractExpr, row::Real, col::Real) = getindex(x, row:row, col:col)
-getindex{T <: Real}(x::AbstractExpr, row::Real, cols::AbstractArray{T, 1}) = getindex(x, row:row, cols)
-getindex{T <: Real}(x::AbstractExpr, rows::AbstractArray{T, 1}, col::Real) = getindex(x, rows, col:col)
+getindex(x::AbstractExpr, row::Real, cols::AbstractArray{T, 1}) where {T <: Real} = getindex(x, row:row, cols)
+getindex(x::AbstractExpr, rows::AbstractArray{T, 1}, col::Real) where {T <: Real} = getindex(x, rows, col:col)
 # XXX todo: speed test; there are lots of possible solutions for this
 function getindex(x::AbstractExpr, I::AbstractArray{Bool,2})
     return [xi for (xi,ii) in zip(x,I) if ii]

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -12,7 +12,7 @@ export sign, monotonicity, curvature, evaluate, conic_form!
 
 ### Scalar and matrix multiplication
 
-type MultiplyAtom <: AbstractExpr
+struct MultiplyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}
@@ -108,7 +108,7 @@ end
 ### .*
 # All constructors of this check (and so this function requires)
 # that the first child be constant to have the expression be DCP
-type DotMultiplyAtom <: AbstractExpr
+struct DotMultiplyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/affine/partialtrace.jl
+++ b/src/atoms/affine/partialtrace.jl
@@ -2,7 +2,7 @@ import Base.sign
 export partialtrace
 export sign, curvature, monotonicity, evaluate
 
-type PartialTraceAtom <: AbstractExpr
+struct PartialTraceAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64
     children::Tuple{AbstractExpr}

--- a/src/atoms/affine/real_imag.jl
+++ b/src/atoms/affine/real_imag.jl
@@ -10,7 +10,7 @@ export sign, monotonicity, curvature, evaluate
 
 
 ### Real
-type RealAtom <: AbstractExpr
+struct RealAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}
@@ -65,7 +65,7 @@ real(x::Value) = RealAtom(Constant(x))
 
 
 ### Imaginary
-type ImaginaryAtom <: AbstractExpr
+struct ImaginaryAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -3,7 +3,7 @@ export reshape, vec
 export sign, curvature, monotonicity, evaluate, conic_form!
 
 
-type ReshapeAtom <: AbstractExpr
+struct ReshapeAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -1,8 +1,8 @@
 import Base.vcat, Base.hcat
-export vcat, hcat, VcatAtom, HcatAtom
+export vcat, hcat, HcatAtom
 export sign, curvature, monotonicity, evaluate, conic_form!
 
-type HcatAtom <: AbstractExpr
+struct HcatAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple
@@ -121,7 +121,7 @@ vcat(args::AbstractExprOrValue...) = transpose(HcatAtom([transpose(convert(Abstr
 vcat(args::Value...) = Base.cat(1, args...) # Note: this makes general vcat slower for anyone using Convex...
 
 
-Base.vect{T<:AbstractExpr}(args::T...) = transpose(HcatAtom([transpose(arg) for arg in args]...))
+Base.vect(args::T...) where {T<:AbstractExpr} = transpose(HcatAtom([transpose(arg) for arg in args]...))
 Base.vect(args::AbstractExpr...) = transpose(HcatAtom([transpose(arg) for arg in args]...))
 Base.vect(args::AbstractExprOrValue...) = transpose(HcatAtom([transpose(convert(AbstractExpr,arg)) for arg in args]...))
 if Base._oldstyle_array_vcat_
@@ -132,6 +132,5 @@ else
     function Base.vect(args::Value...)
         T = Base.promote_typeof(args...)
         return copy!(Array{T}(length(args)), args)
-
     end
 end

--- a/src/atoms/affine/sum.jl
+++ b/src/atoms/affine/sum.jl
@@ -9,7 +9,7 @@ import Base.sum
 export sum
 
 ### Sum Atom
-type SumAtom <: AbstractExpr
+struct SumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/affine/transpose.jl
+++ b/src/atoms/affine/transpose.jl
@@ -9,7 +9,7 @@ import Base.transpose, Base.ctranspose
 export transpose, ctranspose, TransposeAtom, CTransposeAtom
 export sign, curvature, monotonicity, evaluate, conic_form!
 
-type TransposeAtom <: AbstractExpr
+struct TransposeAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}
@@ -72,7 +72,7 @@ transpose(x::AbstractExpr) = TransposeAtom(x)
 
 
 
-type CTransposeAtom <: AbstractExpr
+struct CTransposeAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/exp_+_sdp_cone/logdet.jl
+++ b/src/atoms/exp_+_sdp_cone/logdet.jl
@@ -1,6 +1,6 @@
 import Base.logdet
 
-type LogDetAtom <: AbstractExpr
+struct LogDetAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -11,7 +11,7 @@ export sign, curvature, monotonicity, evaluate
 
 ### Exponential
 
-type ExpAtom <: AbstractExpr
+struct ExpAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -12,7 +12,7 @@ export sign, curvature, monotonicity, evaluate
 
 # TODO: make this work for a *list* of inputs, rather than just for vector/matrix inputs
 
-type LogSumExpAtom <: AbstractExpr
+struct LogSumExpAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -10,7 +10,7 @@ export sign, curvature, monotonicity, evaluate
 
 # TODO: make this work for a *list* of inputs, rather than just for scalar/vector/matrix inputs
 
-type RelativeEntropyAtom <: AbstractExpr
+struct RelativeEntropyAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr,AbstractExpr}

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -11,7 +11,7 @@ export sign, curvature, monotonicity, evaluate
 
 ### Absolute Value
 
-type AbsAtom <: AbstractExpr
+struct AbsAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -10,7 +10,7 @@ export sign, curvature, monotonicity, evaluate
 
 # This atom computes dot(sort(x), sort(w)), where w is constant
 # for example, if w = [1 1 1 0 0 0 ... 0], it computes the sum of the 3 largest elements of x
-type DotSortAtom <: AbstractExpr
+struct DotSortAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/lp_cone/max.jl
+++ b/src/atoms/lp_cone/max.jl
@@ -9,7 +9,7 @@ export max, pos, hinge_loss
 
 # TODO: This can easily be extended to work
 ### Max Atom
-type MaxAtom <: AbstractExpr
+struct MaxAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/lp_cone/maximum.jl
+++ b/src/atoms/lp_cone/maximum.jl
@@ -8,7 +8,7 @@ import Base.maximum
 export maximum
 
 ### Maximum Atom
-type MaximumAtom <: AbstractExpr
+struct MaximumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/lp_cone/min.jl
+++ b/src/atoms/lp_cone/min.jl
@@ -9,7 +9,7 @@ export min, neg
 
 # TODO: This can easily be extended to work
 ### Min Atom
-type MinAtom <: AbstractExpr
+struct MinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/lp_cone/minimum.jl
+++ b/src/atoms/lp_cone/minimum.jl
@@ -8,7 +8,7 @@ import Base.minimum
 export minimum
 
 ### Minimum Atom
-type MinimumAtom <: AbstractExpr
+struct MinimumAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -8,7 +8,7 @@
 export sumlargest, sumsmallest
 export sign, curvature, monotonicity, evaluate
 
-type SumLargestAtom <: AbstractExpr
+struct SumLargestAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/sdp_cone/lambda_min_max.jl
+++ b/src/atoms/sdp_cone/lambda_min_max.jl
@@ -9,7 +9,7 @@ export lambdamax, lambdamin
 
 ### Lambda max
 
-type LambdaMaxAtom <: AbstractExpr
+struct LambdaMaxAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}
@@ -62,7 +62,7 @@ end
 
 ### Lambda min
 
-type LambdaMinAtom <: AbstractExpr
+struct LambdaMinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/sdp_cone/matrixfrac.jl
+++ b/src/atoms/sdp_cone/matrixfrac.jl
@@ -7,7 +7,7 @@
 #############################################################################
 export matrixfrac
 
-type MatrixFracAtom <: AbstractExpr
+struct MatrixFracAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -8,7 +8,7 @@ export nuclearnorm
 
 ### Nuclear norm
 
-type NuclearNormAtom <: AbstractExpr
+struct NuclearNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -9,7 +9,7 @@ export operatornorm, sigmamax
 
 ### Operator norm
 
-type OperatorNormAtom <: AbstractExpr
+struct OperatorNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -10,7 +10,7 @@ export sumlargesteigs
 
 ### sumlargesteigs
 
-type SumLargestEigs <: AbstractExpr
+struct SumLargestEigs <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -2,7 +2,7 @@ import Base.sqrt
 export GeoMeanAtom, geomean, sqrt
 export sign, monotonicity, curvature, conic_form!
 
-type GeoMeanAtom <: AbstractExpr
+struct GeoMeanAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/second_order_cone/huber.jl
+++ b/src/atoms/second_order_cone/huber.jl
@@ -1,6 +1,6 @@
 export huber
 
-type HuberAtom <: AbstractExpr
+struct HuberAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/second_order_cone/norm2.jl
+++ b/src/atoms/second_order_cone/norm2.jl
@@ -9,7 +9,7 @@ export EucNormAtom, norm2, vecnorm
 export sign, monotonicity, curvature, conic_form!
 
 
-type EucNormAtom <: AbstractExpr
+struct EucNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/second_order_cone/power_to_socp.jl
+++ b/src/atoms/second_order_cone/power_to_socp.jl
@@ -15,7 +15,7 @@
 using Compat
 module psocp
 
-type InequalityExpression
+struct InequalityExpression
   # Represents an inequality of the form
   #
   # x^n <= t^{p_1} s^{p_2} u^{p_3},
@@ -39,7 +39,7 @@ type InequalityExpression
   u_var_ind::Int
 end
 
-type SimpleInequalityExpression
+struct SimpleInequalityExpression
   # Represents an inequality of the form
   #
   # x^2 <= t s,

--- a/src/atoms/second_order_cone/power_to_socp.jl
+++ b/src/atoms/second_order_cone/power_to_socp.jl
@@ -15,7 +15,7 @@
 using Compat
 module psocp
 
-struct InequalityExpression
+mutable struct InequalityExpression
   # Represents an inequality of the form
   #
   # x^n <= t^{p_1} s^{p_2} u^{p_3},

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -2,7 +2,7 @@ import Base.broadcast
 export QolElemAtom, qol_elementwise, square, sumsquares, invpos, /
 export sign, monotonicity, curvature, conic_form!, broadcast
 
-type QolElemAtom <: AbstractExpr
+struct QolElemAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/second_order_cone/quadoverlin.jl
+++ b/src/atoms/second_order_cone/quadoverlin.jl
@@ -1,7 +1,7 @@
 export QuadOverLinAtom, quadoverlin
 export sign, monotonicity, curvature, conic_form!
 
-type QuadOverLinAtom <: AbstractExpr
+struct QuadOverLinAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/atoms/second_order_cone/rationalnorm.jl
+++ b/src/atoms/second_order_cone/rationalnorm.jl
@@ -15,7 +15,7 @@ export rationalnorm
 
 ### k-norm for rational k
 
-type RationalNormAtom <: AbstractExpr
+struct RationalNormAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr}

--- a/src/atoms/second_order_cone/scaledgeomean.jl
+++ b/src/atoms/second_order_cone/scaledgeomean.jl
@@ -6,7 +6,7 @@ function power_of_2_gt(n::Int)
   Int(2^ceil(log(2,n)))
 end
 
-type ScaledGeoMeanAtom <: AbstractExpr
+struct ScaledGeoMeanAtom <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr}

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -85,7 +85,7 @@ end
 # we represent the cone as a Symbol (defined in MathProgBase), like :SOC, :LP, etc
 # and we record the sizes of the affine expressions (XXX check...)
 # XXX might it be better to represent objs as a single ConicObj rather than an array of them?
-type ConicConstr
+struct ConicConstr
   objs::Array{ConicObj}
   cone::Symbol
   sizes::Array{Int}
@@ -100,7 +100,7 @@ UniqueConstrMap = DataStructures.OrderedDict{Tuple{Symbol, UInt64}, Int}
 UniqueConstrList = Array{ConicConstr}
 
 # UniqueConicForms caches all the conic forms of expressions we've parsed so far
-type UniqueConicForms
+struct UniqueConicForms
   exp_map::UniqueExpMap
   constr_map::UniqueConstrMap
   constr_list::UniqueConstrList

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -3,9 +3,9 @@
 # Defines Constant, which is a subtype of AbstractExpr
 #############################################################################
 export Constant
-export vexity, evaluate, sign, domain, conic_form!
+export vexity, evaluate, sign, conic_form!
 
-type Constant <: AbstractExpr
+struct Constant <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   value::Value

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -1,7 +1,7 @@
 export ExpConstraint, conic_form!, vexity
 
 ### (Primal) exponential cone constraint ExpConstraint(x,y,z) => y exp(x/y) <= z & y>=0
-type ExpConstraint <: Constraint
+struct ExpConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
   children::Tuple{AbstractExpr, AbstractExpr, AbstractExpr} # (x, y, z)

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -4,7 +4,7 @@ export SDPConstraint, isposdef, in, ⪰, ⪯
 ### Positive semidefinite cone constraint
 
 # TODO: Terrible documentation. Please fix.
-type SDPConstraint <: Constraint
+struct SDPConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
   child::AbstractExpr

--- a/src/constraints/soc_constraints.jl
+++ b/src/constraints/soc_constraints.jl
@@ -3,7 +3,7 @@ export socp
 
 # TODO: Document this. How is this different from SOCElemConstraint? Why do we need both. How does
 # conic form work for SOC constraints.
-type SOCConstraint <: Constraint
+struct SOCConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
   children::Tuple
@@ -30,7 +30,7 @@ end
 # For debugging created this constraint
 socp(args::AbstractExpr...) = SOCConstraint(args::AbstractExpr...)
 
-type SOCElemConstraint <: Constraint
+struct SOCElemConstraint <: Constraint
   head::Symbol
   id_hash::UInt64
   children::Tuple

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -18,12 +18,12 @@ export -, +, *
 
 # Vexity subtypes
 @compat abstract type Vexity end
-type ConstVexity <: Vexity              end
-type AffineVexity <: Vexity             end
-type ConvexVexity <: Vexity             end
-type ConcaveVexity <: Vexity            end
+struct ConstVexity <: Vexity              end
+struct AffineVexity <: Vexity             end
+struct ConvexVexity <: Vexity             end
+struct ConcaveVexity <: Vexity            end
 
-type NotDcp <: Vexity
+struct NotDcp <: Vexity
 	function NotDcp()
 		warn("Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior.")
     return new()
@@ -32,21 +32,21 @@ end
 
 # Monotonocity subtypes
 @compat abstract type Monotonicity end
-type Nonincreasing <: Monotonicity      end
-type Nondecreasing <: Monotonicity      end
-type ConstMonotonicity <: Monotonicity  end
-type NoMonotonicity <: Monotonicity     end
+struct Nonincreasing <: Monotonicity      end
+struct Nondecreasing <: Monotonicity      end
+struct ConstMonotonicity <: Monotonicity  end
+struct NoMonotonicity <: Monotonicity     end
 
 # Sign subtypes
 @compat abstract type Sign end
-type Positive <: Sign                   end
-type Negative <: Sign                   end
-type NoSign <: Sign                     end
+struct Positive <: Sign                   end
+struct Negative <: Sign                   end
+struct NoSign <: Sign                     end
 
 # New coded
 
 # Also create a new subtype of Sign "NotDefined to handle the ComplexSign case"
-type ComplexSign <: Sign                 end
+struct ComplexSign <: Sign                end
 
 
 -(v::Vexity) = v

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -6,7 +6,7 @@ export Float64OrNothing
 const Float64OrNothing = Union{Float64, Void}
 
 # TODO: Cleanup
-type Solution{T<:Number}
+struct Solution{T<:Number}
   primal::Array{T, 1}
   dual::Array{T, 1}
   status::Symbol
@@ -17,7 +17,7 @@ end
 Solution{T}(x::Array{T, 1}, status::Symbol, optval::T) = Solution(x, T[], status, optval, false)
 Solution{T}(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) = Solution(x, y, status, optval, true)
 
-type Problem
+struct Problem
   head::Symbol
   objective::AbstractExpr
   constraints::Array{Constraint}
@@ -193,31 +193,32 @@ Problem(head::Symbol, objective::AbstractExpr, constraints::Constraint...) =
 # Allow users to simply type minimize
 minimize(objective::AbstractExpr, constraints::Constraint...) =
   Problem(:minimize, objective, collect(constraints))
-minimize{T<:Constraint}(objective::AbstractExpr, constraints::Array{T}=Constraint[]) =
+minimize(objective::AbstractExpr, constraints::Array{T}=Constraint[]) where {T<:Constraint} =
   Problem(:minimize, objective, constraints)
 minimize(objective::Value, constraints::Constraint...) =
   minimize(convert(AbstractExpr, objective), collect(constraints))
-minimize{T<:Constraint}(objective::Value, constraints::Array{T}=Constraint[]) =
+minimize(objective::Value, constraints::Array{T}=Constraint[]) where {T<:Constraint} =
   minimize(convert(AbstractExpr, objective), constraints)
 
 # Allow users to simply type maximize
 maximize(objective::AbstractExpr, constraints::Constraint...) =
   Problem(:maximize, objective, collect(constraints))
-maximize{T<:Constraint}(objective::AbstractExpr, constraints::Array{T}=Constraint[]) =
+maximize(objective::AbstractExpr, constraints::Array{T}=Constraint[]) where {T<:Constraint} =
   Problem(:maximize, objective, constraints)
 maximize(objective::Value, constraints::Constraint...) =
   maximize(convert(AbstractExpr, objective), collect(constraints))
-maximize{T<:Constraint}(objective::Value, constraints::Array{T}=Constraint[]) =
+maximize(objective::Value, constraints::Array{T}=Constraint[]) where {T<:Constraint} = 
   maximize(convert(AbstractExpr, objective), constraints)
 
 # Allow users to simply type satisfy (if there is no objective)
 satisfy(constraints::Constraint...) = Problem(:minimize, Constant(0), [constraints...])
-satisfy{T<:Constraint}(constraints::Array{T}=Constraint[]) =
+satisfy(constraints::Array{T}=Constraint[]) where {T<:Constraint} =
   Problem(:minimize, Constant(0), constraints)
 satisfy(constraint::Constraint) = satisfy([constraint])
 
 # +(constraints, constraints) is defined in constraints.jl
-add_constraints!{T<:Constraint}(p::Problem, constraints::Array{T}) = +(p.constraints, constraints)
+add_constraints!(p::Problem, constraints::Array{T}) where {T<:Constraint} = 
+  +(p.constraints, constraints)
 add_constraints!(p::Problem, constraint::Constraint) = add_constraints!(p, [constraint])
 add_constraint! = add_constraints!
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -6,7 +6,7 @@ export Float64OrNothing
 const Float64OrNothing = Union{Float64, Void}
 
 # TODO: Cleanup
-struct Solution{T<:Number}
+mutable struct Solution{T<:Number}
   primal::Array{T, 1}
   dual::Array{T, 1}
   status::Symbol
@@ -14,10 +14,12 @@ struct Solution{T<:Number}
   has_dual::Bool
 end
 
-Solution{T}(x::Array{T, 1}, status::Symbol, optval::T) = Solution(x, T[], status, optval, false)
-Solution{T}(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) = Solution(x, y, status, optval, true)
+Solution(x::Array{T, 1}, status::Symbol, optval::T) where {T} = 
+  Solution(x, T[], status, optval, false)
+Solution(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) where {T} = 
+  Solution(x, y, status, optval, true)
 
-struct Problem
+mutable struct Problem
   head::Symbol
   objective::AbstractExpr
   constraints::Array{Constraint}

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -6,7 +6,7 @@
 export Variable, Semidefinite, ComplexVariable, HermitianSemidefinite
 export vexity, evaluate, sign, conic_form!, fix!, free!
 
-struct Variable <: AbstractExpr
+mutable struct Variable <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   value::ValueOrNothing

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -6,7 +6,7 @@
 export Variable, Semidefinite, ComplexVariable, HermitianSemidefinite
 export vexity, evaluate, sign, conic_form!, fix!, free!
 
-type Variable <: AbstractExpr
+struct Variable <: AbstractExpr
   head::Symbol
   id_hash::UInt64
   value::ValueOrNothing


### PR DESCRIPTION
mostly removed deprecated syntax  
* type X 
* f{T}(x::T)

Deleted exported but undefined expressions:
* VcatAtom
* domain
