### PR TITLE
Seed random number stream to improve test reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ os:
     - osx
 julia:
     - 0.6
-    - nightly
+    - 0.7
 notifications:
     email: false
+matrix:
+    allow_failures:
+        - julia: 0.7
+    fast_finish: true
 sudo: false
 addons:
     apt_packages:

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 GLPKMathProgInterface
 ECOS
-SCS
+SCS 0.3.0 0.4.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using Convex
 using Base.Test
 
+# Seed random number stream to improve test reliability
+srand(2)
+
 solvers = Any[]
 
 if isdir(Pkg.dir("ECOS"))


### PR DESCRIPTION
We've seen some inconsistent test failures, seemingly always involving tests that use values computed via `rand`. To make these tests more reliable, we can seed the stream using `srand`. Note that it's `Random.seed!` on 0.7 and up, but Convex's current master branch does not support anything other than 0.6. On a related note, this also removes Travis testing on Julia master, as there is no chance of it working as-is.

I will re-tag v0.7.0 once this is merged. The 0.6 failure on JuliaCIBot for the current v0.7.0 tag failed due to these issues.