### PR TITLE
Upper bound Julia at 0.7-

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,8 @@ os:
     - osx
 julia:
     - 0.6
-    - 0.7
 notifications:
     email: false
-matrix:
-    allow_failures:
-        - julia: 0.7
-    fast_finish: true
 sudo: false
 addons:
     apt_packages:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7-
 MathProgBase 0.5 0.8
 DataStructures
 Compat 0.24


### PR DESCRIPTION
As it stands, this package does not support Julia 0.7. In order to get a final 0.6-compatible tag into METADATA, we need to apply an upper bound. See https://github.com/JuliaLang/METADATA.jl/pull/19091.