### PR TITLE
Normalize indentation to 4 spaces

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -87,7 +87,7 @@ function clearmemory()
     global id_to_variables = Dict{UInt64, Variable}()
     global var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
     global conic_constr_to_constr = Dict{ConicConstr, Constraint}()
-    gc()
+    GC.gc()
 end
 
 end

--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -12,108 +12,108 @@ export sign, curvature, monotonicity, evaluate
 ### Unary Negation
 
 struct NegateAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function NegateAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:-, hash(children), children, x.size)
-  end
+    function NegateAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:-, hash(children), children, x.size)
+    end
 end
 
 function sign(x::NegateAtom)
-  return -sign(x.children[1])
+    return -sign(x.children[1])
 end
 
 function monotonicity(x::NegateAtom)
-  return (Nonincreasing(),)
+    return (Nonincreasing(),)
 end
 
 function curvature(x::NegateAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::NegateAtom)
-  return -evaluate(x.children[1])
+    return -evaluate(x.children[1])
 end
 
 -(x::AbstractExpr) = NegateAtom(x)
 
 function conic_form!(x::NegateAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    objective = conic_form!(x.children[1], unique_conic_forms)
-    objective = -objective
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        objective = conic_form!(x.children[1], unique_conic_forms)
+        objective = -objective
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 
 ### Addition
 struct AdditionAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Array{AbstractExpr, 1}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Array{AbstractExpr, 1}
+    size::Tuple{Int, Int}
 
-  function AdditionAtom(x::AbstractExpr, y::AbstractExpr)
-    # find the size of the expression = max of size of x and size of y
-    if x.size == y.size || y.size == (1, 1)
-      sz = x.size
-    elseif x.size == (1, 1)
-      sz = y.size
-    else
-      error("Cannot add expressions of sizes $(x.size) and $(y.size)")
+    function AdditionAtom(x::AbstractExpr, y::AbstractExpr)
+        # find the size of the expression = max of size of x and size of y
+        if x.size == y.size || y.size == (1, 1)
+            sz = x.size
+        elseif x.size == (1, 1)
+            sz = y.size
+        else
+            error("Cannot add expressions of sizes $(x.size) and $(y.size)")
+        end
+        # see if we're forming a sum of more than two terms and condense them
+        children = AbstractExpr[]
+        if isa(x, AdditionAtom)
+            append!(children, x.children)
+        else
+            push!(children, x)
+        end
+        if isa(y, AdditionAtom)
+            append!(children, y.children)
+        else
+            push!(children, y)
+        end
+        return new(:+, hash(children), children, sz)
     end
-    # see if we're forming a sum of more than two terms and condense them
-    children = AbstractExpr[]
-    if isa(x, AdditionAtom)
-      append!(children, x.children)
-    else
-      push!(children, x)
-    end
-    if isa(y, AdditionAtom)
-      append!(children, y.children)
-    else
-      push!(children, y)
-    end
-    return new(:+, hash(children), children, sz)
-  end
 end
 
 function sign(x::AdditionAtom)
-  return sum(Sign[sign(child) for child in x.children])
-  # Creating an array of type Sign and adding all the sign of xhildren of x so if anyone is complex the resultant sign would be complex.
+    return sum(Sign[sign(child) for child in x.children])
+    # Creating an array of type Sign and adding all the sign of xhildren of x so if anyone is complex the resultant sign would be complex.
 end
 
 function monotonicity(x::AdditionAtom)
-  return Monotonicity[Nondecreasing() for child in x.children]
+    return Monotonicity[Nondecreasing() for child in x.children]
 end
 
 function curvature(x::AdditionAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::AdditionAtom)
-  # broadcast function is used here instead of sum to support addition between scalars and arrays
-  return broadcast(+, map(evaluate, x.children)...)
+    # broadcast function is used here instead of sum to support addition between scalars and arrays
+    return broadcast(+, map(evaluate, x.children)...)
 end
 
 function conic_form!(x::AdditionAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    objective = ConicObj()
-    for child in x.children
-      child_objective = conic_form!(child, unique_conic_forms)
-      if x.size != child.size
-        child_objective = promote_size(child_objective, get_vectorized_size(x))
-      end
-      objective += child_objective
+    if !has_conic_form(unique_conic_forms, x)
+        objective = ConicObj()
+        for child in x.children
+            child_objective = conic_form!(child, unique_conic_forms)
+            if x.size != child.size
+                child_objective = promote_size(child_objective, get_vectorized_size(x))
+            end
+            objective += child_objective
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 +(x::AbstractExpr, y::AbstractExpr) = AdditionAtom(x, y)

--- a/src/atoms/affine/conjugate.jl
+++ b/src/atoms/affine/conjugate.jl
@@ -2,44 +2,44 @@ import Base.conj
 export conj
 export sign, curvature, monotonicity, evaluate, conic_form!
 struct ConjugateAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function ConjugateAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:conj, hash(children), children, (x.size[1], x.size[2]))
-  end
+    function ConjugateAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:conj, hash(children), children, (x.size[1], x.size[2]))
+    end
 end
 
 function sign(x::ConjugateAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::ConjugateAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::ConjugateAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::ConjugateAtom)
-  return conj(evaluate(x.children[1]))
+    return conj(evaluate(x.children[1]))
 end
 
 function conic_form!(x::ConjugateAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    objective = conic_form!(x.children[1], unique_conic_forms)
-    for var in keys(objective)
-      x1 = conj(objective[var][1])
-      x2 = conj(objective[var][2])
-      objective[var] = (x1,x2)
+    if !has_conic_form(unique_conic_forms, x)
+        objective = conic_form!(x.children[1], unique_conic_forms)
+        for var in keys(objective)
+            x1 = conj(objective[var][1])
+            x2 = conj(objective[var][2])
+            objective[var] = (x1,x2)
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 

--- a/src/atoms/affine/conv.jl
+++ b/src/atoms/affine/conv.jl
@@ -6,16 +6,16 @@
 export conv
 
 function conv(x::Value, y::AbstractExpr)
-  if (size(x,2) != 1 && length(size(x)) != 1) || size(y,2) != 1
-    error("convolution only supported between two vectors")
-  end
-  m = length(x)
-  n = y.size[1]
-  X = spzeros(m+n - 1, n)
-  for i = 1:n
-    X[i:m+i-1, i] = x
-  end
-  return X*y
+    if (size(x,2) != 1 && length(size(x)) != 1) || size(y,2) != 1
+        error("convolution only supported between two vectors")
+    end
+    m = length(x)
+    n = y.size[1]
+    X = spzeros(m+n - 1, n)
+    for i = 1:n
+        X[i:m+i-1, i] = x
+    end
+    return X*y
 end
 
 conv(x::AbstractExpr, y::Value) = conv(y, x)

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -9,62 +9,62 @@ import LinearAlgebra.diagm, LinearAlgebra.Diagonal
 export diagm, Diagonal
 
 struct DiagMatrixAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function DiagMatrixAtom(x::AbstractExpr)
-    (num_rows, num_cols) = x.size
+    function DiagMatrixAtom(x::AbstractExpr)
+        (num_rows, num_cols) = x.size
 
-    if num_rows == 1
-      sz = num_cols
-    elseif num_cols == 1
-      sz = num_rows
-    else
-      throw(ArgumentError("Only vectors are allowed for diagm/Diagonal. Did you mean to use diag?"))
+        if num_rows == 1
+            sz = num_cols
+        elseif num_cols == 1
+            sz = num_rows
+        else
+            throw(ArgumentError("Only vectors are allowed for diagm/Diagonal. Did you mean to use diag?"))
+        end
+
+        children = (x, )
+        return new(:diagm, hash(children), children, (sz, sz))
     end
-
-    children = (x, )
-    return new(:diagm, hash(children), children, (sz, sz))
-  end
 end
 
 function sign(x::DiagMatrixAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 # The monotonicity
 function monotonicity(x::DiagMatrixAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 # If we have h(x) = f o g(x), the chain rule says h''(x) = g'(x)^T f''(g(x))g'(x) + f'(g(x))g''(x);
 # this represents the first term
 function curvature(x::DiagMatrixAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::DiagMatrixAtom)
-  return Diagonal(vec(evaluate(x.children[1])))
+    return Diagonal(vec(evaluate(x.children[1])))
 end
 
 function diagm((d, x)::Pair{<:Integer, <:AbstractExpr})
-  d == 0 || throw(ArgumentError("only the main diagonal is supported"))
-  return DiagMatrixAtom(x)
+    d == 0 || throw(ArgumentError("only the main diagonal is supported"))
+    return DiagMatrixAtom(x)
 end
 Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
 
 function conic_form!(x::DiagMatrixAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    sz = x.size[1]
+    if !has_conic_form(unique_conic_forms, x)
+        sz = x.size[1]
 
-    I = 1:sz+1:sz*sz
-    J = 1:sz
-    coeff = sparse(I, J, 1.0, sz * sz, sz)
-    objective = conic_form!(x.children[1], unique_conic_forms)
-    new_obj = coeff * objective
-    cache_conic_form!(unique_conic_forms, x, new_obj)
-  end
-  return get_conic_form(unique_conic_forms, x)
+        I = 1:sz+1:sz*sz
+        J = 1:sz
+        coeff = sparse(I, J, 1.0, sz * sz, sz)
+        objective = conic_form!(x.children[1], unique_conic_forms)
+        new_obj = coeff * objective
+        cache_conic_form!(unique_conic_forms, x, new_obj)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/atoms/affine/dot.jl
+++ b/src/atoms/affine/dot.jl
@@ -12,15 +12,15 @@ dot(x::AbstractExpr, y::Value) = (ismatrix(x) || ismatrix(y)) ? error("dot not i
 
 # tests if an array is a matrix (2D array) with both dimensions of size > 1
 function ismatrix(x)
-	sz = size(x)
-	if length(sz) != 2
-		return false
-	else
-		for s in sz
-			if s == 1
-				return false
-			end
-		end
-	end
-	return true
+    sz = size(x)
+    if length(sz) != 2
+        return false
+    else
+        for s in sz
+            if s == 1
+                return false
+            end
+        end
+    end
+    return true
 end

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -4,76 +4,76 @@ export IndexAtom, getindex
 const ArrayOrNothing = Union{AbstractArray, Nothing}
 
 struct IndexAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
-  rows::ArrayOrNothing
-  cols::ArrayOrNothing
-  inds::ArrayOrNothing
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
+    rows::ArrayOrNothing
+    cols::ArrayOrNothing
+    inds::ArrayOrNothing
 
-  function IndexAtom(x::AbstractExpr, rows::AbstractArray, cols::AbstractArray)
-    sz = (length(rows), length(cols))
-    children = (x,)
-    return new(:index, hash((children, rows, cols, nothing)), children, sz, rows, cols, nothing)
-  end
+    function IndexAtom(x::AbstractExpr, rows::AbstractArray, cols::AbstractArray)
+        sz = (length(rows), length(cols))
+        children = (x,)
+        return new(:index, hash((children, rows, cols, nothing)), children, sz, rows, cols, nothing)
+    end
 
-  function IndexAtom(x::AbstractExpr, inds::AbstractArray)
-    sz = (length(inds), 1)
-    children = (x,)
-    return new(:index, hash((children, nothing, nothing, inds)), children, sz, nothing, nothing, inds)
-  end
+    function IndexAtom(x::AbstractExpr, inds::AbstractArray)
+        sz = (length(inds), 1)
+        children = (x,)
+        return new(:index, hash((children, nothing, nothing, inds)), children, sz, nothing, nothing, inds)
+    end
 end
 
 ## Type definition ends here
 
 function sign(x::IndexAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::IndexAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::IndexAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::IndexAtom)
-  if x.inds == nothing
-    return getindex(evaluate(x.children[1]), x.rows, x.cols)
-  else
-    return getindex(evaluate(x.children[1]), x.inds)
-  end
+    if x.inds == nothing
+        return getindex(evaluate(x.children[1]), x.rows, x.cols)
+    else
+        return getindex(evaluate(x.children[1]), x.inds)
+    end
 end
 
 function conic_form!(x::IndexAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    m = get_vectorized_size(x)
-    n = get_vectorized_size(x.children[1])
+    if !has_conic_form(unique_conic_forms, x)
+        m = get_vectorized_size(x)
+        n = get_vectorized_size(x.children[1])
 
-    if x.inds == nothing
-      sz = length(x.cols) * length(x.rows)
-      J = Array{Int}(undef, sz)
-      k = 1
+        if x.inds == nothing
+            sz = length(x.cols) * length(x.rows)
+            J = Array{Int}(undef, sz)
+            k = 1
 
-      num_rows = x.children[1].size[1]
-      for c in x.cols
-        for r in x.rows
-          J[k] = num_rows * (convert(Int, c) - 1) + convert(Int, r)
-          k += 1
+            num_rows = x.children[1].size[1]
+            for c in x.cols
+                for r in x.rows
+                    J[k] = num_rows * (convert(Int, c) - 1) + convert(Int, r)
+                    k += 1
+                end
+            end
+
+            index_matrix = sparse(1:sz, J, 1.0, m, n)
+        else
+            index_matrix = sparse(1:length(x.inds), x.inds, 1.0, m, n)
         end
-      end
-
-      index_matrix = sparse(1:sz, J, 1.0, m, n)
-    else
-      index_matrix = sparse(1:length(x.inds), x.inds, 1.0, m, n)
+        objective = conic_form!(x.children[1], unique_conic_forms)
+        objective = index_matrix * objective
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    objective = conic_form!(x.children[1], unique_conic_forms)
-    objective = index_matrix * objective
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 ## API Definition begins
@@ -94,8 +94,8 @@ end
 # Colon methods
 # All rows and columns
 function getindex(x::AbstractExpr, cln_r::Colon, cln_c::Colon)
-  rows, cols = size(x)
-  getindex(x, 1:rows, 1:cols)
+    rows, cols = size(x)
+    getindex(x, 1:rows, 1:cols)
 end
 # All rows for this column(s)
 getindex(x::AbstractExpr, cln_r::Colon, col) = getindex(x, 1:size(x)[1], col)

--- a/src/atoms/affine/inner_product.jl
+++ b/src/atoms/affine/inner_product.jl
@@ -1,9 +1,9 @@
 export inner_product
 
-function inner_product(x::AbstractExpr,y::AbstractExpr)
-    if x.size==y.size && x.size[1] == x.size[2]
-        return(real(tr(x'*y)))
-    else 
+function inner_product(x::AbstractExpr, y::AbstractExpr)
+    if x.size == y.size && x.size[1] == x.size[2]
+        return real(tr(x'*y))
+    else
         error("Arguments must be square matrix of same dimension")
     end
 end

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -2,30 +2,30 @@ import LinearAlgebra.kron
 export kron
 
 function kron(a::Value, b::AbstractExpr)
-  rows = AbstractExpr[]
-  for i in 1:size(a)[1]
-    row = AbstractExpr[]
-    for j in 1:size(a)[2]
-      if isreal(a[i,j])
-        push!(row, real(a[i, j]) * b)
-      else
-        push!(row, a[i, j] * b)
-      end        
+    rows = AbstractExpr[]
+    for i in 1:size(a)[1]
+        row = AbstractExpr[]
+        for j in 1:size(a)[2]
+            if isreal(a[i,j])
+                push!(row, real(a[i, j]) * b)
+            else
+                push!(row, a[i, j] * b)
+            end
+        end
+        push!(rows, foldl(hcat, row))
     end
-    push!(rows, foldl(hcat, row))
-  end
-  return foldl(vcat, rows)
+    return foldl(vcat, rows)
 end
 
 
 function kron(a::AbstractExpr, b::Value)
-  rows = AbstractExpr[]
-  for i in 1:size(a)[1]
-    row = AbstractExpr[]
-    for j in 1:size(a)[2]
-      push!(row, a[i, j] .* b)
+    rows = AbstractExpr[]
+    for i in 1:size(a)[1]
+        row = AbstractExpr[]
+        for j in 1:size(a)[2]
+            push!(row, a[i, j] .* b)
+        end
+        push!(rows, foldl(hcat, row))
     end
-    push!(rows, foldl(hcat, row))
-  end
-  return foldl(vcat, rows)
+    return foldl(vcat, rows)
 end

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -164,10 +164,10 @@ function conic_form!(x::DotMultiplyAtom, unique_conic_forms::UniqueConicForms=Un
         # and that the sizes are compatible,
         # so if the sizes aren't equal the smaller one is size 1
         var = x.children[2]
-        if size(var,1) < size(coeff,1)
-            var = ones(size(coeff,1))*var
-        elseif size(var,2) < size(coeff,2)
-            var = var*ones(1,size(coeff,1))
+        if size(var, 1) < size(coeff, 1)
+            var = ones(size(coeff, 1)) * var
+        elseif size(var, 2) < size(coeff, 2)
+            var = var * ones(1, size(coeff, 1))
         end
 
         const_multiplier = spdiagm(0 => vec(coeff))
@@ -180,10 +180,10 @@ end
 function broadcasted(::typeof(*), x::Constant, y::AbstractExpr)
     if x.size == (1, 1) || y.size == (1, 1)
         return x * y
-    elseif size(y,1) < size(x,1) && size(y,1) == 1
-        return DotMultiplyAtom(x, ones(size(x,1))*y)
-    elseif size(y,2) < size(x,2) && size(y,2) == 1
-        return DotMultiplyAtom(x, y*ones(1,size(x,1)))
+    elseif size(y, 1) < size(x, 1) && size(y, 1) == 1
+        return DotMultiplyAtom(x, ones(size(x, 1)) * y)
+    elseif size(y, 2) < size(x, 2) && size(y, 2) == 1
+        return DotMultiplyAtom(x, y * ones(1, size(x, 1)))
     else
         return DotMultiplyAtom(x, y)
     end

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -12,92 +12,92 @@ export sign, monotonicity, curvature, evaluate, conic_form!
 ### Scalar and matrix multiplication
 
 struct MultiplyAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MultiplyAtom(x::AbstractExpr, y::AbstractExpr)
-    if x.size == (1, 1)
-      sz = y.size
-    elseif y.size == (1, 1)
-      sz = x.size
-    elseif x.size[2] ==  y.size[1]
-      sz = (x.size[1], y.size[2])
-    else
-      error("Cannot multiply two expressions of sizes $(x.size) and $(y.size)")
+    function MultiplyAtom(x::AbstractExpr, y::AbstractExpr)
+        if x.size == (1, 1)
+            sz = y.size
+        elseif y.size == (1, 1)
+            sz = x.size
+        elseif x.size[2] ==  y.size[1]
+            sz = (x.size[1], y.size[2])
+        else
+            error("Cannot multiply two expressions of sizes $(x.size) and $(y.size)")
+        end
+        children = (x, y)
+        return new(:*, hash(children), children, sz)
     end
-    children = (x, y)
-    return new(:*, hash(children), children, sz)
-  end
 end
 
 function sign(x::MultiplyAtom)
-  return sign(x.children[1]) * sign(x.children[2])
+    return sign(x.children[1]) * sign(x.children[2])
 end
 
 function monotonicity(x::MultiplyAtom)
-  return (sign(x.children[2]) * Nondecreasing(), sign(x.children[1]) * Nondecreasing())
+    return (sign(x.children[2]) * Nondecreasing(), sign(x.children[1]) * Nondecreasing())
 end
 
 # Multiplication has an indefinite hessian, so if neither children are constants,
 # the curvature of the atom will violate DCP.
 function curvature(x::MultiplyAtom)
-  if vexity(x.children[1]) != ConstVexity() && vexity(x.children[2]) != ConstVexity()
-    return NotDcp()
-  else
-    return ConstVexity()
-  end
+    if vexity(x.children[1]) != ConstVexity() && vexity(x.children[2]) != ConstVexity()
+        return NotDcp()
+    else
+        return ConstVexity()
+    end
 end
 
 function evaluate(x::MultiplyAtom)
-  return evaluate(x.children[1]) * evaluate(x.children[2])
+    return evaluate(x.children[1]) * evaluate(x.children[2])
 end
 
 function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    # scalar multiplication
-    if x.children[1].size == (1, 1) || x.children[2].size == (1, 1)
-      if vexity(x.children[1]) == ConstVexity()
-        const_child = x.children[1]
-        expr_child = x.children[2]
-      elseif vexity(x.children[2]) == ConstVexity()
-        const_child = x.children[2]
-        expr_child = x.children[1]
-      else
-        error("multiplication of two non-constant expressions is not DCP compliant")
-      end
-      objective = conic_form!(expr_child, unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        # scalar multiplication
+        if x.children[1].size == (1, 1) || x.children[2].size == (1, 1)
+            if vexity(x.children[1]) == ConstVexity()
+                const_child = x.children[1]
+                expr_child = x.children[2]
+            elseif vexity(x.children[2]) == ConstVexity()
+                const_child = x.children[2]
+                expr_child = x.children[1]
+            else
+                error("multiplication of two non-constant expressions is not DCP compliant")
+            end
+            objective = conic_form!(expr_child, unique_conic_forms)
 
-      # make sure all 1x1 sized objects are interpreted as scalars, since
-      # [1] * [1, 2, 3] is illegal in julia, but 1 * [1, 2, 3] is ok
-      if const_child.size == (1, 1)
-        const_multiplier = evaluate(const_child)[1]
-      else
-        const_multiplier = reshape(evaluate(const_child), get_vectorized_size(const_child), 1)
-      end
+            # make sure all 1x1 sized objects are interpreted as scalars, since
+            # [1] * [1, 2, 3] is illegal in julia, but 1 * [1, 2, 3] is ok
+            if const_child.size == (1, 1)
+                const_multiplier = evaluate(const_child)[1]
+            else
+                const_multiplier = reshape(evaluate(const_child), get_vectorized_size(const_child), 1)
+            end
 
-      objective = const_multiplier * objective
+            objective = const_multiplier * objective
 
-    # left matrix multiplication
-    elseif x.children[1].head == :constant
-      objective = conic_form!(x.children[2], unique_conic_forms)
-      objective = kron(sparse(1.0I, x.size[2], x.size[2]), x.children[1].value) * objective
-    # right matrix multiplication
-    else
-      objective = conic_form!(x.children[1], unique_conic_forms)
-      objective = kron(x.children[2].value', sparse(1.0I, x.size[1], x.size[1])) * objective
+        # left matrix multiplication
+        elseif x.children[1].head == :constant
+            objective = conic_form!(x.children[2], unique_conic_forms)
+            objective = kron(sparse(1.0I, x.size[2], x.size[2]), x.children[1].value) * objective
+        # right matrix multiplication
+        else
+            objective = conic_form!(x.children[1], unique_conic_forms)
+            objective = kron(x.children[2].value', sparse(1.0I, x.size[1], x.size[1])) * objective
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 function *(x::AbstractExpr, y::AbstractExpr)
-  if hash(x) == hash(y) && x.size == (1, 1)
-    return square(x)
-  end
-  return MultiplyAtom(x, y)
+    if hash(x) == hash(y) && x.size == (1, 1)
+        return square(x)
+    end
+    return MultiplyAtom(x, y)
 end
 
 *(x::Value, y::AbstractExpr) = MultiplyAtom(Constant(x), y)
@@ -108,99 +108,99 @@ end
 # All constructors of this check (and so this function requires)
 # that the first child be constant to have the expression be DCP
 struct DotMultiplyAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function DotMultiplyAtom(x::AbstractExpr, y::AbstractExpr)
-    # check that the sizes of x and y are compatible
-    try
-      ones(size(x)) .* ones(size(y))
-    catch
-      error("cannot compute $x .* $y: sizes are not compatible")
+    function DotMultiplyAtom(x::AbstractExpr, y::AbstractExpr)
+        # check that the sizes of x and y are compatible
+        try
+            ones(size(x)) .* ones(size(y))
+        catch
+            error("cannot compute $x .* $y: sizes are not compatible")
+        end
+        children = (x, y)
+        return new(:.*, hash(children), children, y.size)
     end
-    children = (x, y)
-    return new(:.*, hash(children), children, y.size)
-  end
 end
 
 function sign(x::DotMultiplyAtom)
-  return sign(x.children[1]) * sign(x.children[2])
+    return sign(x.children[1]) * sign(x.children[2])
 end
 
 function monotonicity(x::DotMultiplyAtom)
-  return (sign(x.children[2]) * Nondecreasing(), sign(x.children[1]) * Nondecreasing())
+    return (sign(x.children[2]) * Nondecreasing(), sign(x.children[1]) * Nondecreasing())
 end
 
 function curvature(x::DotMultiplyAtom)
-  if vexity(x.children[1]) == ConstVexity()
-    return ConstVexity()
-  else
-    return NotDcp()
-  end
+    if vexity(x.children[1]) == ConstVexity()
+        return ConstVexity()
+    else
+        return NotDcp()
+    end
 end
 
 function evaluate(x::DotMultiplyAtom)
-  return evaluate(x.children[1]) .* evaluate(x.children[2])
+    return evaluate(x.children[1]) .* evaluate(x.children[2])
 end
 
 function conic_form!(x::DotMultiplyAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    if vexity(x.children[1]) != ConstVexity()
-      if vexity(x.children[2]) != ConstVexity()
-        error("multiplication of two non-constant expressions is not DCP compliant")
-      else
-        # make sure first child is the one that's constant
-        x.children[1], x.children[2] = x.children[2], x.children[1]
-      end
-    end
-    # promote the size of the coefficient matrix, so eg
-    # 3 .* x
-    # works regardless of the size of x
-    coeff = x.children[1].value .* ones(size(x.children[2]))
-    # promote the size of the variable
-    # we've previously ensured neither x nor y is 1x1
-    # and that the sizes are compatible,
-    # so if the sizes aren't equal the smaller one is size 1
-    var = x.children[2]
-    if size(var,1) < size(coeff,1)
-      var = ones(size(coeff,1))*var
-    elseif size(var,2) < size(coeff,2)
-      var = var*ones(1,size(coeff,1))
-    end
+    if !has_conic_form(unique_conic_forms, x)
+        if vexity(x.children[1]) != ConstVexity()
+            if vexity(x.children[2]) != ConstVexity()
+                error("multiplication of two non-constant expressions is not DCP compliant")
+            else
+                # make sure first child is the one that's constant
+                x.children[1], x.children[2] = x.children[2], x.children[1]
+            end
+        end
+        # promote the size of the coefficient matrix, so eg
+        # 3 .* x
+        # works regardless of the size of x
+        coeff = x.children[1].value .* ones(size(x.children[2]))
+        # promote the size of the variable
+        # we've previously ensured neither x nor y is 1x1
+        # and that the sizes are compatible,
+        # so if the sizes aren't equal the smaller one is size 1
+        var = x.children[2]
+        if size(var,1) < size(coeff,1)
+            var = ones(size(coeff,1))*var
+        elseif size(var,2) < size(coeff,2)
+            var = var*ones(1,size(coeff,1))
+        end
 
-    const_multiplier = spdiagm(0 => vec(coeff))
-    objective = const_multiplier * conic_form!(var, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+        const_multiplier = spdiagm(0 => vec(coeff))
+        objective = const_multiplier * conic_form!(var, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 function broadcasted(::typeof(*), x::Constant, y::AbstractExpr)
-  if x.size == (1, 1) || y.size == (1, 1)
-    return x * y
-  elseif size(y,1) < size(x,1) && size(y,1) == 1
-    return DotMultiplyAtom(x, ones(size(x,1))*y)
-  elseif size(y,2) < size(x,2) && size(y,2) == 1
-    return DotMultiplyAtom(x, y*ones(1,size(x,1)))
-  else
-    return DotMultiplyAtom(x, y)
-  end
+    if x.size == (1, 1) || y.size == (1, 1)
+        return x * y
+    elseif size(y,1) < size(x,1) && size(y,1) == 1
+        return DotMultiplyAtom(x, ones(size(x,1))*y)
+    elseif size(y,2) < size(x,2) && size(y,2) == 1
+        return DotMultiplyAtom(x, y*ones(1,size(x,1)))
+    else
+        return DotMultiplyAtom(x, y)
+    end
 end
 broadcasted(::typeof(*), y::AbstractExpr, x::Constant) = DotMultiplyAtom(x, y)
 
 # if neither is a constant it's not DCP, but might be nice to support anyway for eg MultiConvex
 function broadcasted(::typeof(*), x::AbstractExpr, y::AbstractExpr)
-  if x.size == (1, 1) || y.size == (1, 1)
-    return x * y
-  elseif vexity(x) == ConstVexity()
-    return DotMultiplyAtom(x, y)
-  elseif hash(x) == hash(y)
-    return square(x)
-  else
-    return DotMultiplyAtom(y, x)
-  end
+    if x.size == (1, 1) || y.size == (1, 1)
+        return x * y
+    elseif vexity(x) == ConstVexity()
+        return DotMultiplyAtom(x, y)
+    elseif hash(x) == hash(y)
+        return square(x)
+    else
+        return DotMultiplyAtom(y, x)
+    end
 end
 broadcasted(::typeof(*), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), y)
 broadcasted(::typeof(*), x::AbstractExpr, y::Value) = DotMultiplyAtom(Constant(y), x)

--- a/src/atoms/affine/partialtrace.jl
+++ b/src/atoms/affine/partialtrace.jl
@@ -27,11 +27,11 @@ struct PartialTraceAtom <: AbstractExpr
 end
 
 function sign(x::PartialTraceAtom)
-     return sign(x.children[1])
- end
+    return sign(x.children[1])
+end
 
 function curvature(x::PartialTraceAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function monotonicity(x::PartialTraceAtom)

--- a/src/atoms/affine/real_imag.jl
+++ b/src/atoms/affine/real_imag.jl
@@ -11,52 +11,52 @@ export sign, monotonicity, curvature, evaluate
 
 ### Real
 struct RealAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function RealAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:real, hash(children), children, x.size)
-  end
+    function RealAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:real, hash(children), children, x.size)
+    end
 end
 
 function sign(x::RealAtom)
-  if sign(x.children[1]) == ComplexSign()
-    return NoSign()
-  else
-    return sign(x.children[1])
-  end
+    if sign(x.children[1]) == ComplexSign()
+        return NoSign()
+    else
+        return sign(x.children[1])
+    end
 end
 
 function monotonicity(x::RealAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::RealAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::RealAtom)
-  return real.(evaluate(x.children[1]))
+    return real.(evaluate(x.children[1]))
 end
 
 function conic_form!(x::RealAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    new_objective = ConicObj()
-    objective = conic_form!(x.children[1], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        new_objective = ConicObj()
+        objective = conic_form!(x.children[1], unique_conic_forms)
 
 
-    for var in keys(objective)
-      re = real.(objective[var][1])
-      im = real.(objective[var][2])
-      new_objective[var] = (re,im)
+        for var in keys(objective)
+            re = real.(objective[var][1])
+            im = real.(objective[var][2])
+            new_objective[var] = (re,im)
+        end
+
+        cache_conic_form!(unique_conic_forms, x, new_objective)
     end
-
-    cache_conic_form!(unique_conic_forms, x, new_objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 real(x::AbstractExpr) = RealAtom(x)
@@ -66,48 +66,48 @@ real(x::Value) = RealAtom(Constant(x))
 
 ### Imaginary
 struct ImaginaryAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function ImaginaryAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:imag, hash(children), children, x.size)
-  end
+    function ImaginaryAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:imag, hash(children), children, x.size)
+    end
 end
 
 function sign(x::ImaginaryAtom)
-  sign(x.children[1]) == ComplexSign()
-  return NoSign()
+    sign(x.children[1]) == ComplexSign()
+    return NoSign()
 end
 
 function monotonicity(x::ImaginaryAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::ImaginaryAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::ImaginaryAtom)
-  return imag.(evaluate(x.children[1]))
+    return imag.(evaluate(x.children[1]))
 end
 
 function conic_form!(x::ImaginaryAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    new_objective = ConicObj()
-    objective = conic_form!(x.children[1], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        new_objective = ConicObj()
+        objective = conic_form!(x.children[1], unique_conic_forms)
 
 
-    for var in keys(objective)
-      re = imag.(objective[var][1])
-      im = imag.(objective[var][2])
-      new_objective[var] = (re,im)
+        for var in keys(objective)
+            re = imag.(objective[var][1])
+            im = imag.(objective[var][2])
+            new_objective[var] = (re,im)
+        end
+        cache_conic_form!(unique_conic_forms, x, new_objective)
     end
-    cache_conic_form!(unique_conic_forms, x, new_objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 imag(x::AbstractExpr) = ImaginaryAtom(x)

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -4,37 +4,37 @@ export sign, curvature, monotonicity, evaluate, conic_form!
 
 
 struct ReshapeAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function ReshapeAtom(x::AbstractExpr, m::Int, n::Int)
-    if m * n != get_vectorized_size(x)
-      error("Cannot reshape expression of size $(x.size) to ($(m), $(n))")
+    function ReshapeAtom(x::AbstractExpr, m::Int, n::Int)
+        if m * n != get_vectorized_size(x)
+            error("Cannot reshape expression of size $(x.size) to ($(m), $(n))")
+        end
+        return new(:reshape, objectid(x), (x,), (m, n))
     end
-    return new(:reshape, objectid(x), (x,), (m, n))
-  end
 end
 
 function sign(x::ReshapeAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::ReshapeAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::ReshapeAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::ReshapeAtom)
-  return reshape(evaluate(x.children[1]), x.size[1], x.size[2])
+    return reshape(evaluate(x.children[1]), x.size[1], x.size[2])
 end
 
 function conic_form!(x::ReshapeAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  return conic_form!(x.children[1], unique_conic_forms)
+    return conic_form!(x.children[1], unique_conic_forms)
 end
 
 

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -3,111 +3,111 @@ export vcat, hcat, hvcat, HcatAtom
 export sign, curvature, monotonicity, evaluate, conic_form!
 
 struct HcatAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple
+    size::Tuple{Int, Int}
 
-  function HcatAtom(args::AbstractExpr...)
-    num_rows = args[1].size[1]
-    num_cols = 0
-    for arg in args
-      if arg.size[1] != num_rows
-        error("Cannot horizontally stack expressions of varying number of rows")
-      end
-      num_cols += arg.size[2]
+    function HcatAtom(args::AbstractExpr...)
+        num_rows = args[1].size[1]
+        num_cols = 0
+        for arg in args
+            if arg.size[1] != num_rows
+                error("Cannot horizontally stack expressions of varying number of rows")
+            end
+            num_cols += arg.size[2]
+        end
+        children = tuple(args...)
+        return new(:hcat, hash(children), children, (num_rows, num_cols))
     end
-    children = tuple(args...)
-    return new(:hcat, hash(children), children, (num_rows, num_cols))
-  end
 end
 
 function sign(x::HcatAtom)
-  return sum(map(sign, x.children))
+    return sum(map(sign, x.children))
 end
 
 function monotonicity(x::HcatAtom)
-  return [Nondecreasing() for c in x.children]
+    return [Nondecreasing() for c in x.children]
 end
 
 function curvature(x::HcatAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::HcatAtom)
-  return hcat(map(evaluate, x.children)...)
+    return hcat(map(evaluate, x.children)...)
 end
 
 
 function conic_form!(x::HcatAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    # build a list of child conic objectives and constraints
-    objectives = ConicObj[]
-    for child in x.children
-      push!(objectives, conic_form!(child, unique_conic_forms))
-    end
-    # build a dict from variable ids to sizes
-    variable_to_sizes = Dict{UInt64, Int}()
-    for objective in objectives
-      for id in keys(objective)
-        if !(id in keys(variable_to_sizes))
-          if id == objectid(:constant)
-            variable_to_sizes[id] = 1
-          else
-            variable_to_sizes[id] = get_vectorized_size(id_to_variables[id])
-          end
+    if !has_conic_form(unique_conic_forms, x)
+        # build a list of child conic objectives and constraints
+        objectives = ConicObj[]
+        for child in x.children
+            push!(objectives, conic_form!(child, unique_conic_forms))
         end
-      end
-    end
-
-    # Suppose the child objectives for two children e1 (2 x 1) and e2 (2 x 2) look something like
-    #  e1: x => 1 2 3
-    #           4 5 6
-    #      y => 2 4
-    #           7 8
-    #  e2: x => 1 1 1
-    #           2 2 2
-    #           3 3 3
-    #           4 4 4
-    # The objective of [e1 e2] will look like
-    #      x => 1 2 3
-    #           4 5 6
-    #           1 1 1
-    #           2 2 2
-    #           3 3 3
-    #           4 4 4
-    #      y => 2 4
-    #           7 8
-    #           0 0
-    #           0 0
-    #           0 0
-    #           0 0
-    # builds the objective by aggregating a list of coefficients for each variable
-    # from each child objective, and then vertically concatenating them
-    objective = ConicObj()
-    for (id, col_size) in variable_to_sizes
-      #temp_tuple = Tuple{Value,Value}
-      x1_value_list = Value[]
-      x2_value_list = Value[]
-
-      for i in 1:length(objectives)
-        row_size = get_vectorized_size(x.children[i])
-        if haskey(objectives[i], id)
-          push!(x1_value_list, objectives[i][id][1])
-          push!(x2_value_list, objectives[i][id][2])
-        else
-          push!(x1_value_list, spzeros(row_size, col_size))
-          push!(x2_value_list, spzeros(row_size, col_size))
+        # build a dict from variable ids to sizes
+        variable_to_sizes = Dict{UInt64, Int}()
+        for objective in objectives
+            for id in keys(objective)
+                if !(id in keys(variable_to_sizes))
+                    if id == objectid(:constant)
+                        variable_to_sizes[id] = 1
+                    else
+                        variable_to_sizes[id] = get_vectorized_size(id_to_variables[id])
+                    end
+                end
+            end
         end
-      end
-      x1 = vcat(x1_value_list...)
-      x2 = vcat(x2_value_list...)
-      objective[id] = (x1,x2)
 
+        # Suppose the child objectives for two children e1 (2 x 1) and e2 (2 x 2) look something like
+        #  e1: x => 1 2 3
+        #           4 5 6
+        #      y => 2 4
+        #           7 8
+        #  e2: x => 1 1 1
+        #           2 2 2
+        #           3 3 3
+        #           4 4 4
+        # The objective of [e1 e2] will look like
+        #            x => 1 2 3
+        #                 4 5 6
+        #                 1 1 1
+        #                 2 2 2
+        #                 3 3 3
+        #                 4 4 4
+        #            y => 2 4
+        #                 7 8
+        #                 0 0
+        #                 0 0
+        #                 0 0
+        #                 0 0
+        # builds the objective by aggregating a list of coefficients for each variable
+        # from each child objective, and then vertically concatenating them
+        objective = ConicObj()
+        for (id, col_size) in variable_to_sizes
+            #temp_tuple = Tuple{Value,Value}
+            x1_value_list = Value[]
+            x2_value_list = Value[]
+
+            for i in 1:length(objectives)
+                row_size = get_vectorized_size(x.children[i])
+                if haskey(objectives[i], id)
+                    push!(x1_value_list, objectives[i][id][1])
+                    push!(x2_value_list, objectives[i][id][2])
+                else
+                    push!(x1_value_list, spzeros(row_size, col_size))
+                    push!(x2_value_list, spzeros(row_size, col_size))
+                end
+            end
+            x1 = vcat(x1_value_list...)
+            x2 = vcat(x2_value_list...)
+            objective[id] = (x1,x2)
+
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 hcat(args::AbstractExpr...) = HcatAtom(args...)

--- a/src/atoms/affine/trace.jl
+++ b/src/atoms/affine/trace.jl
@@ -2,5 +2,5 @@ import LinearAlgebra.tr
 export tr
 
 function tr(e::AbstractExpr)
-  return sum(diag(e))
+    return sum(diag(e))
 end

--- a/src/atoms/affine/transpose.jl
+++ b/src/atoms/affine/transpose.jl
@@ -10,62 +10,62 @@ export transpose, adjoint, TransposeAtom, AdjointAtom
 export sign, curvature, monotonicity, evaluate, conic_form!
 
 struct TransposeAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function TransposeAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:transpose, hash(children), children, (x.size[2], x.size[1]))
-  end
+    function TransposeAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:transpose, hash(children), children, (x.size[2], x.size[1]))
+    end
 end
 
 function sign(x::TransposeAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::TransposeAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::TransposeAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::TransposeAtom)
-  return transpose(evaluate(x.children[1]))
+    return transpose(evaluate(x.children[1]))
 end
 
 # Since everything is vectorized, we simply need to multiply x by a permutation
 # matrix such that coeff * vectorized(x) - vectorized(x') = 0
 function conic_form!(x::TransposeAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    objective = conic_form!(x.children[1], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        objective = conic_form!(x.children[1], unique_conic_forms)
 
-    sz = get_vectorized_size(x)
+        sz = get_vectorized_size(x)
 
-    num_rows = x.size[1]
-    num_cols = x.size[2]
+        num_rows = x.size[1]
+        num_cols = x.size[2]
 
-    I = Array{Int}(undef, sz)
-    J = Array{Int}(undef, sz)
+        I = Array{Int}(undef, sz)
+        J = Array{Int}(undef, sz)
 
-    k = 1
-    for r = 1:num_rows
-      for c = 1:num_cols
-        I[k] = (c - 1) * num_rows + r
-        J[k] = (r - 1) * num_cols + c
-        k += 1
-      end
+        k = 1
+        for r = 1:num_rows
+            for c = 1:num_cols
+                I[k] = (c - 1) * num_rows + r
+                J[k] = (r - 1) * num_cols + c
+                k += 1
+            end
+        end
+
+        transpose_matrix = sparse(I, J, 1.0)
+
+        objective = transpose_matrix * objective
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-
-    transpose_matrix = sparse(I, J, 1.0)
-
-    objective = transpose_matrix * objective
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 transpose(x::AbstractExpr) = TransposeAtom(x)
@@ -73,67 +73,67 @@ transpose(x::AbstractExpr) = TransposeAtom(x)
 
 
 struct AdjointAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function AdjointAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:adjoint, hash(children), children, (x.size[2], x.size[1]))
-  end
+    function AdjointAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:adjoint, hash(children), children, (x.size[2], x.size[1]))
+    end
 end
 
 function sign(x::AdjointAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::AdjointAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::AdjointAtom)
-  return ConstVexity()
+    return ConstVexity()
 end
 
 function evaluate(x::AdjointAtom)
-  return evaluate(x.children[1])'
+    return evaluate(x.children[1])'
 end
 
 # Since everything is vectorized, we simply need to multiply x by a permutation
 # matrix such that coeff * vectorized(x) - vectorized(x') = 0
 function conic_form!(x::AdjointAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    objective = conic_form!(x.children[1], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        objective = conic_form!(x.children[1], unique_conic_forms)
 
-    sz = get_vectorized_size(x)
+        sz = get_vectorized_size(x)
 
-    num_rows = x.size[1]
-    num_cols = x.size[2]
+        num_rows = x.size[1]
+        num_cols = x.size[2]
 
-    I = Array{Int}(undef, sz)
-    J = Array{Int}(undef, sz)
+        I = Array{Int}(undef, sz)
+        J = Array{Int}(undef, sz)
 
-    k = 1
-    for r = 1:num_rows
-      for c = 1:num_cols
-        I[k] = (c - 1) * num_rows + r
-        J[k] = (r - 1) * num_cols + c
-        k += 1
-      end
+        k = 1
+        for r = 1:num_rows
+            for c = 1:num_cols
+                I[k] = (c - 1) * num_rows + r
+                J[k] = (r - 1) * num_cols + c
+                k += 1
+            end
+        end
+
+        transpose_matrix = sparse(I, J, 1.0)
+        objective = transpose_matrix * objective
+
+        for var in keys(objective)
+            x1 = conj(objective[var][1])
+            x2 = conj(objective[var][2])
+            objective[var] = (x1,x2)
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-
-    transpose_matrix = sparse(I, J, 1.0)
-    objective = transpose_matrix * objective
-
-    for var in keys(objective)
-      x1 = conj(objective[var][1])
-      x2 = conj(objective[var][2])
-      objective[var] = (x1,x2)
-    end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 adjoint(x::AbstractExpr) = AdjointAtom(x)

--- a/src/atoms/exp_+_sdp_cone/logdet.jl
+++ b/src/atoms/exp_+_sdp_cone/logdet.jl
@@ -2,64 +2,64 @@ import LinearAlgebra.logdet
 export logdet
 
 struct LogDetAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function LogDetAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:logdet, hash(children), children, (1, 1))
-  end
+    function LogDetAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:logdet, hash(children), children, (1, 1))
+    end
 end
 
 function sign(x::LogDetAtom)
-  return NoSign()
+    return NoSign()
 end
 
 function monotonicity(x::LogDetAtom)
-  return (NoMonotonicity(),)
+    return (NoMonotonicity(),)
 end
 
 function curvature(x::LogDetAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::LogDetAtom)
-  return log(det(evaluate(x.children[1])))
+    return log(det(evaluate(x.children[1])))
 end
 
 function conic_form!(x::LogDetAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    D = Variable(size(A)) # diagonal matrix
-    U = Variable(size(A)) # upper triangular matrix
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        D = Variable(size(A)) # diagonal matrix
+        U = Variable(size(A)) # upper triangular matrix
 
-    # objective given by the sum of the log of diagonal matrix D
-    objective = conic_form!(sum(log(diag(D))), unique_conic_forms)
+        # objective given by the sum of the log of diagonal matrix D
+        objective = conic_form!(sum(log(diag(D))), unique_conic_forms)
 
-    # enforce D and U to be diagonal and upper triangular
-    for i in 1:A.size[1]
-      for j in 1:A.size[2]
-        if i != j
-          conic_form!(D[i,j] == 0, unique_conic_forms)
+        # enforce D and U to be diagonal and upper triangular
+        for i in 1:A.size[1]
+            for j in 1:A.size[2]
+                if i != j
+                    conic_form!(D[i,j] == 0, unique_conic_forms)
+                end
+                if i > j
+                    conic_form!(U[i,j] == 0, unique_conic_forms)
+                end
+            end
         end
-        if i > j
-          conic_form!(U[i,j] == 0, unique_conic_forms)
-        end
-      end
+
+        # diagonals of D and U are the same
+        conic_form!(diag(D) == diag(U), unique_conic_forms)
+
+        # A and [D U; U' A] need to be positive semidefinite
+        conic_form!(isposdef(A), unique_conic_forms)
+        conic_form!(isposdef([D U; U' A]), unique_conic_forms)
+
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-
-    # diagonals of D and U are the same
-    conic_form!(diag(D) == diag(U), unique_conic_forms)
-
-    # A and [D U; U' A] need to be positive semidefinite
-    conic_form!(isposdef(A), unique_conic_forms)
-    conic_form!(isposdef([D U; U' A]), unique_conic_forms)
-
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 logdet(x::AbstractExpr) = LogDetAtom(x)

--- a/src/atoms/exp_cone/entropy.jl
+++ b/src/atoms/exp_cone/entropy.jl
@@ -20,7 +20,7 @@ mutable struct EntropyAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function EntropyAtom(x::AbstractExpr)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("The argument should be real but it's instead complex")
         else
             children = (x,)
@@ -53,9 +53,9 @@ function conic_form!(e::EntropyAtom, unique_conic_forms::UniqueConicForms=Unique
         t = Variable(e.size)
         x = e.children[1]
         objective = conic_form!(t, unique_conic_forms)
-        for i=1:size(x,1)
-            for j=1:size(x,2)
-                conic_form!( ExpConstraint(t[i,j], x[i,j], 1), unique_conic_forms)
+        for i = 1:size(x, 1)
+            for j = 1:size(x, 2)
+                conic_form!(ExpConstraint(t[i, j], x[i, j], 1), unique_conic_forms)
             end
         end
         cache_conic_form!(unique_conic_forms, e, objective)

--- a/src/atoms/exp_cone/entropy.jl
+++ b/src/atoms/exp_cone/entropy.jl
@@ -14,53 +14,53 @@ export sign, curvature, monotonicity, evaluate
 
 # Entropy atom: -xlogx entrywise
 mutable struct EntropyAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function EntropyAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("The argument should be real but it's instead complex")
-    else
-      children = (x,)
-      # TODO check positivity or enforce it
-      return new(:entropy, hash(children), children, size(x))
+    function EntropyAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("The argument should be real but it's instead complex")
+        else
+            children = (x,)
+            # TODO check positivity or enforce it
+            return new(:entropy, hash(children), children, size(x))
+        end
     end
-  end
 end
 
 function sign(x::EntropyAtom)
-  return NoSign()
+    return NoSign()
 end
 
 function monotonicity(x::EntropyAtom)
-  return (NoMonotonicity(),)
+    return (NoMonotonicity(),)
 end
 
 function curvature(x::EntropyAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::EntropyAtom)
-  c = evaluate(x.children[1])
-  return -c .* log.(c)
+    c = evaluate(x.children[1])
+    return -c .* log.(c)
 end
 
 function conic_form!(e::EntropyAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, e)
-    # -x log x >= t  <=>  x exp(t/x) <= 1  <==>  (t,x,1) in exp cone
-    t = Variable(e.size)
-    x = e.children[1]
-    objective = conic_form!(t, unique_conic_forms)
-    for i=1:size(x,1)
-      for j=1:size(x,2)
-        conic_form!( ExpConstraint(t[i,j], x[i,j], 1), unique_conic_forms)
-      end
+    if !has_conic_form(unique_conic_forms, e)
+        # -x log x >= t  <=>  x exp(t/x) <= 1  <==>  (t,x,1) in exp cone
+        t = Variable(e.size)
+        x = e.children[1]
+        objective = conic_form!(t, unique_conic_forms)
+        for i=1:size(x,1)
+            for j=1:size(x,2)
+                conic_form!( ExpConstraint(t[i,j], x[i,j], 1), unique_conic_forms)
+            end
+        end
+        cache_conic_form!(unique_conic_forms, e, objective)
     end
-    cache_conic_form!(unique_conic_forms, e, objective)
-  end
-  return get_conic_form(unique_conic_forms, e)
+    return get_conic_form(unique_conic_forms, e)
 end
 
 entropy(x::AbstractExpr) = sum(EntropyAtom(x))

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -12,48 +12,48 @@ export sign, curvature, monotonicity, evaluate
 ### Exponential
 
 struct ExpAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function ExpAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("The argument should be real but it's instead complex")
-    else
-      children = (x,)
-      return new(:exp, hash(children), children, x.size)
+    function ExpAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("The argument should be real but it's instead complex")
+        else
+            children = (x,)
+            return new(:exp, hash(children), children, x.size)
+        end
     end
-  end
 end
 
 function sign(x::ExpAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::ExpAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::ExpAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::ExpAtom)
-  return exp.(evaluate(x.children[1]))
+    return exp.(evaluate(x.children[1]))
 end
 
 exp(x::AbstractExpr) = ExpAtom(x)
 
 function conic_form!(e::ExpAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, e)
-    # exp(x) \leq z  <=>  (x,ones(),z) \in ExpCone
-    x = e.children[1]
-    y = Constant(ones(size(x)))
-    z = Variable(size(x))
-    objective = conic_form!(z, unique_conic_forms)
-    conic_form!(ExpConstraint(x, y, z), unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, e, objective)
-  end
-  return get_conic_form(unique_conic_forms, e)
+    if !has_conic_form(unique_conic_forms, e)
+        # exp(x) \leq z  <=>  (x,ones(),z) \in ExpCone
+        x = e.children[1]
+        y = Constant(ones(size(x)))
+        z = Variable(size(x))
+        objective = conic_form!(z, unique_conic_forms)
+        conic_form!(ExpConstraint(x, y, z), unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, e, objective)
+    end
+    return get_conic_form(unique_conic_forms, e)
 end

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -18,7 +18,7 @@ struct ExpAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function ExpAtom(x::AbstractExpr)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("The argument should be real but it's instead complex")
         else
             children = (x,)

--- a/src/atoms/exp_cone/log.jl
+++ b/src/atoms/exp_cone/log.jl
@@ -12,49 +12,49 @@ export sign, curvature, monotonicity, evaluate
 ### Logarithm
 
 mutable struct LogAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function LogAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("The argument should be real but it's instead complex")
-    else
-      children = (x,)
-      return new(:log, hash(children), children, x.size)
+    function LogAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("The argument should be real but it's instead complex")
+        else
+            children = (x,)
+            return new(:log, hash(children), children, x.size)
+        end
     end
-  end
 end
 
 function sign(x::LogAtom)
-  return NoSign()
+    return NoSign()
 end
 
 function monotonicity(x::LogAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::LogAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::LogAtom)
-  return log.(evaluate(x.children[1]))
+    return log.(evaluate(x.children[1]))
 end
 
 log(x::AbstractExpr) = LogAtom(x)
 
 function conic_form!(e::LogAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, e)
-    # log(z) \geq x  <=>  (x,ones(),z) \in ExpCone
-    z = e.children[1]
-    y = Constant(ones(size(z)))
-    x = Variable(size(z))
-    objective = conic_form!(x, unique_conic_forms)
-    conic_form!(ExpConstraint(x, y, z), unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, e)
+        # log(z) \geq x  <=>    (x,ones(),z) \in ExpCone
+        z = e.children[1]
+        y = Constant(ones(size(z)))
+        x = Variable(size(z))
+        objective = conic_form!(x, unique_conic_forms)
+        conic_form!(ExpConstraint(x, y, z), unique_conic_forms)
 
-    cache_conic_form!(unique_conic_forms, e, objective)
-  end
-  return get_conic_form(unique_conic_forms, e)
+        cache_conic_form!(unique_conic_forms, e, objective)
+    end
+    return get_conic_form(unique_conic_forms, e)
 end

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -13,58 +13,58 @@ export sign, curvature, monotonicity, evaluate
 # TODO: make this work for a *list* of inputs, rather than just for vector/matrix inputs
 
 struct LogSumExpAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function LogSumExpAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("The argument should be real but it's instead complex")
-    else
-      children = (x,)
-      return new(:logsumexp, hash(children), children, (1,1))
+    function LogSumExpAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("The argument should be real but it's instead complex")
+        else
+            children = (x,)
+            return new(:logsumexp, hash(children), children, (1,1))
+        end
     end
-  end
 end
 
 function sign(x::LogSumExpAtom)
-  return NoSign()
+    return NoSign()
 end
 
 function monotonicity(x::LogSumExpAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::LogSumExpAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::LogSumExpAtom)
-  return log(sum(exp.(evaluate(x.children[1]))))
+    return log(sum(exp.(evaluate(x.children[1]))))
 end
 
 logsumexp(x::AbstractExpr) = LogSumExpAtom(x)
 
 function conic_form!(e::LogSumExpAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, e)
-    # log(sum(exp(x))) <= t  <=>  sum(exp(x)) <= exp(t) <=> sum(exp(x - t)) <= 1
-    t = Variable(e.size)
-    z = sum(exp(e.children[1] - t))
-    objective = conic_form!(t, unique_conic_forms)
-    conic_form!(z, unique_conic_forms)
-    conic_form!(z <= 1, unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, e)
+        # log(sum(exp(x))) <= t  <=>    sum(exp(x)) <= exp(t) <=> sum(exp(x - t)) <= 1
+        t = Variable(e.size)
+        z = sum(exp(e.children[1] - t))
+        objective = conic_form!(t, unique_conic_forms)
+        conic_form!(z, unique_conic_forms)
+        conic_form!(z <= 1, unique_conic_forms)
 
-    cache_conic_form!(unique_conic_forms, e, objective)
-  end
-  return get_conic_form(unique_conic_forms, e)
+        cache_conic_form!(unique_conic_forms, e, objective)
+    end
+    return get_conic_form(unique_conic_forms, e)
 end
 
 function logisticloss(e::AbstractExpr)
-  s = 0
-  length(e)==1 && return logsumexp([e, 0])
-  for i=1:length(e)
-    s += logsumexp([e[i]; 0])
-  end
-  return s
+    s = 0
+    length(e)==1 && return logsumexp([e, 0])
+    for i=1:length(e)
+        s += logsumexp([e[i]; 0])
+    end
+    return s
 end

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -19,7 +19,7 @@ struct LogSumExpAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function LogSumExpAtom(x::AbstractExpr)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("The argument should be real but it's instead complex")
         else
             children = (x,)
@@ -48,7 +48,7 @@ logsumexp(x::AbstractExpr) = LogSumExpAtom(x)
 
 function conic_form!(e::LogSumExpAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, e)
-        # log(sum(exp(x))) <= t  <=>    sum(exp(x)) <= exp(t) <=> sum(exp(x - t)) <= 1
+        # log(sum(exp(x))) <= t  <=>  sum(exp(x)) <= exp(t) <=> sum(exp(x - t)) <= 1
         t = Variable(e.size)
         z = sum(exp(e.children[1] - t))
         objective = conic_form!(t, unique_conic_forms)
@@ -62,8 +62,8 @@ end
 
 function logisticloss(e::AbstractExpr)
     s = 0
-    length(e)==1 && return logsumexp([e, 0])
-    for i=1:length(e)
+    length(e) == 1 && return logsumexp([e, 0])
+    for i = 1:length(e)
         s += logsumexp([e[i]; 0])
     end
     return s

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -17,7 +17,7 @@ struct RelativeEntropyAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function RelativeEntropyAtom(x::AbstractExpr, y::AbstractExpr)
-        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+        if sign(x) == ComplexSign() || sign(y) == ComplexSign()
             error("Both the arguments should be real but these are instead $(sign(x)) and $(sign(y))")
         else
             children = (x, y)

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -11,69 +11,69 @@ export sign, curvature, monotonicity, evaluate
 # TODO: make this work for a *list* of inputs, rather than just for scalar/vector/matrix inputs
 
 struct RelativeEntropyAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr,AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr,AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function RelativeEntropyAtom(x::AbstractExpr, y::AbstractExpr)
-    if sign(x)==ComplexSign() || sign(y)==ComplexSign()
-      error("Both the arguments should be real but these are instead $(sign(x)) and $(sign(y))")
-    else
-      children = (x, y)
-      return new(:entropy, hash(children), children, size(x))
+    function RelativeEntropyAtom(x::AbstractExpr, y::AbstractExpr)
+        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+            error("Both the arguments should be real but these are instead $(sign(x)) and $(sign(y))")
+        else
+            children = (x, y)
+            return new(:entropy, hash(children), children, size(x))
+        end
     end
-  end
 end
 
 function sign(x::RelativeEntropyAtom)
-  return NoSign()
+    return NoSign()
 end
 
 function monotonicity(x::RelativeEntropyAtom)
-  return (NoMonotonicity(),NoMonotonicity())
+    return (NoMonotonicity(),NoMonotonicity())
 end
 
 function curvature(x::RelativeEntropyAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(e::RelativeEntropyAtom)
-  x = evaluate(e.children[1])
-  y = evaluate(e.children[2])
-  if any(isnan, y) return Inf end
+    x = evaluate(e.children[1])
+    y = evaluate(e.children[2])
+    if any(isnan, y) return Inf end
 
-  out = x.*log.(x./y)
-  # fix value when x=0:
-  # out will only be NaN if x=0, in which case the correct value is 0
-  out[isnan.(out)] = 0
-  return out
+    out = x.*log.(x./y)
+    # fix value when x=0:
+    # out will only be NaN if x=0, in which case the correct value is 0
+    out[isnan.(out)] = 0
+    return out
 end
 
 function conic_form!(e::RelativeEntropyAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, e)
-    # transform to conic form:
-    # x log x/y <= z
-    # x log y/x >= -z
-    # log y/x >= -z/x
-    # y/x >= exp(-z/x)
-    # y >= x exp(-z/x)
-    # and cf the standard form for the exponential cone {(x,y,z): y*exp(x/y) <= z}
-    z = Variable(e.size)
-    x = e.children[1]
-    y = e.children[2]
-    objective = conic_form!(z, unique_conic_forms)
-    for i=1:size(x,1)
-      for j=1:size(x,2)
-        conic_form!(ExpConstraint(-z[i,j], x[i,j], y[i,j]), unique_conic_forms)
-      end
+    if !has_conic_form(unique_conic_forms, e)
+        # transform to conic form:
+        # x log x/y <= z
+        # x log y/x >= -z
+        # log y/x >= -z/x
+        # y/x >= exp(-z/x)
+        # y >= x exp(-z/x)
+        # and cf the standard form for the exponential cone {(x,y,z): y*exp(x/y) <= z}
+        z = Variable(e.size)
+        x = e.children[1]
+        y = e.children[2]
+        objective = conic_form!(z, unique_conic_forms)
+        for i=1:size(x,1)
+            for j=1:size(x,2)
+                conic_form!(ExpConstraint(-z[i,j], x[i,j], y[i,j]), unique_conic_forms)
+            end
+        end
+        # need to constrain x>=0 and y>0.
+        # x>=0 we get for free from the form of the exponential cone, so just add
+        conic_form!(y>=0, unique_conic_forms) # nb we don't know how to ask for strict inequality
+        cache_conic_form!(unique_conic_forms, e, objective)
     end
-    # need to constrain x>=0 and y>0.
-    # x>=0 we get for free from the form of the exponential cone, so just add
-    conic_form!(y>=0, unique_conic_forms) # nb we don't know how to ask for strict inequality
-    cache_conic_form!(unique_conic_forms, e, objective)
-  end
-  return get_conic_form(unique_conic_forms, e)
+    return get_conic_form(unique_conic_forms, e)
 end
 
 relative_entropy(x::AbstractExpr, y::AbstractExpr) = sum(RelativeEntropyAtom(x, y))

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -12,49 +12,49 @@ export sign, curvature, monotonicity, evaluate
 ### Absolute Value
 
 struct AbsAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function AbsAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:abs, hash(children), children, x.size)
-  end
+    function AbsAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:abs, hash(children), children, x.size)
+    end
 end
 
 function sign(x::AbsAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::AbsAtom)
-  return (Nondecreasing() * sign(x.children[1]),)
+    return (Nondecreasing() * sign(x.children[1]),)
 end
 
 function curvature(x::AbsAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::AbsAtom)
-  return abs.(evaluate(x.children[1]))
+    return abs.(evaluate(x.children[1]))
 end
 
 function conic_form!(x::AbsAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    c = x.children[1]
-    t = Variable(size(c))
-    objective = conic_form!(t, unique_conic_forms)
-    if sign(x.children[1]) == ComplexSign()
-      for i in 1:length(vec(t))
-        conic_form!(t[i]>=norm2([real(c[i]);imag(c[i])]), unique_conic_forms)
-      end
-    else
-      conic_form!(c<=t, unique_conic_forms)
-      conic_form!(c>=-t, unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        c = x.children[1]
+        t = Variable(size(c))
+        objective = conic_form!(t, unique_conic_forms)
+        if sign(x.children[1]) == ComplexSign()
+            for i in 1:length(vec(t))
+                conic_form!(t[i]>=norm2([real(c[i]);imag(c[i])]), unique_conic_forms)
+            end
+        else
+            conic_form!(c<=t, unique_conic_forms)
+            conic_form!(c>=-t, unique_conic_forms)
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 abs(x::AbstractExpr) = AbsAtom(x)

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -49,8 +49,8 @@ function conic_form!(x::AbsAtom, unique_conic_forms::UniqueConicForms=UniqueConi
                 conic_form!(t[i]>=norm2([real(c[i]);imag(c[i])]), unique_conic_forms)
             end
         else
-            conic_form!(c<=t, unique_conic_forms)
-            conic_form!(c>=-t, unique_conic_forms)
+            conic_form!(c <= t, unique_conic_forms)
+            conic_form!(c >= -t, unique_conic_forms)
         end
         cache_conic_form!(unique_conic_forms, x, objective)
     end

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -18,7 +18,7 @@ struct DotSortAtom <: AbstractExpr
     w::Value
 
     function DotSortAtom(x::AbstractExpr, w::Value)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("Argument should be real instead it is $(sign(x))")
         else
             if !(length(w) == get_vectorized_size(x))
@@ -32,9 +32,9 @@ struct DotSortAtom <: AbstractExpr
 end
 
 function sign(x::DotSortAtom)
-    if all(x.w.>=0)
+    if all(x.w .>= 0)
         return sign(x.children[1])
-    elseif all(x.w.<=0)
+    elseif all(x.w .<= 0)
         return sign(x.children[1])
     else
         return NoSign()
@@ -42,7 +42,7 @@ function sign(x::DotSortAtom)
 end
 
 function monotonicity(x::DotSortAtom)
-    if all(x.w.>=0)
+    if all(x.w .>= 0)
         return (Nondecreasing(), )
     else
         return (NoMonotonicity(), )

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -11,71 +11,71 @@ export sign, curvature, monotonicity, evaluate
 # This atom computes dot(sort(x), sort(w)), where w is constant
 # for example, if w = [1 1 1 0 0 0 ... 0], it computes the sum of the 3 largest elements of x
 struct DotSortAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
-  w::Value
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
+    w::Value
 
-  function DotSortAtom(x::AbstractExpr, w::Value)
-    if sign(x)==ComplexSign()
-      error("Argument should be real instead it is $(sign(x))")
-    else
-      if !(length(w) == get_vectorized_size(x))
-        error("x and w must be the same size")
-      end
-      children = (x,)
-      vecw = reshape(w, get_vectorized_size(x))
-      return new(:dotsort, hash((children, vecw)), children, (1,1), vecw)
+    function DotSortAtom(x::AbstractExpr, w::Value)
+        if sign(x)==ComplexSign()
+            error("Argument should be real instead it is $(sign(x))")
+        else
+            if !(length(w) == get_vectorized_size(x))
+                error("x and w must be the same size")
+            end
+            children = (x,)
+            vecw = reshape(w, get_vectorized_size(x))
+            return new(:dotsort, hash((children, vecw)), children, (1,1), vecw)
+        end
     end
-  end
 end
 
 function sign(x::DotSortAtom)
-  if all(x.w.>=0)
-    return sign(x.children[1])
-  elseif all(x.w.<=0)
-    return sign(x.children[1])
-  else
-    return NoSign()
-  end
+    if all(x.w.>=0)
+        return sign(x.children[1])
+    elseif all(x.w.<=0)
+        return sign(x.children[1])
+    else
+        return NoSign()
+    end
 end
 
 function monotonicity(x::DotSortAtom)
-  if all(x.w.>=0)
-    return (Nondecreasing(), )
-  else
-    return (NoMonotonicity(), )
-  end
+    if all(x.w.>=0)
+        return (Nondecreasing(), )
+    else
+        return (NoMonotonicity(), )
+    end
 end
 
 function curvature(x::DotSortAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::DotSortAtom)
-  return sum(sort(vec(evaluate(x.children[1])), rev=true) .* sort(vec(x.w), rev=true))
+    return sum(sort(vec(evaluate(x.children[1])), rev=true) .* sort(vec(x.w), rev=true))
 end
 
 function conic_form!(x::DotSortAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    y = x.children[1]
-    w = x.w
-    sy = size(y)
-    if sy[1] > 1 && sy[2] > 1
-      y = vec(y)
+    if !has_conic_form(unique_conic_forms, x)
+        y = x.children[1]
+        w = x.w
+        sy = size(y)
+        if sy[1] > 1 && sy[2] > 1
+            y = vec(y)
+        end
+        mu = Variable(size(y))
+        nu = Variable(size(y))
+        onesvec = ones(size(y))
+        # given by the solution to
+        # minimize sum(mu) + sum(nu)
+        # subject to y*w' <= onesvec*nu' + mu*onesvec'
+        objective = conic_form!(sum(mu) + sum(nu), unique_conic_forms)
+        conic_form!(y*w' <= onesvec*nu' + mu*onesvec', unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    mu = Variable(size(y))
-    nu = Variable(size(y))
-    onesvec = ones(size(y))
-    # given by the solution to
-    # minimize sum(mu) + sum(nu)
-    # subject to y*w' <= onesvec*nu' + mu*onesvec'
-    objective = conic_form!(sum(mu) + sum(nu), unique_conic_forms)
-    conic_form!(y*w' <= onesvec*nu' + mu*onesvec', unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 dotsort(a::AbstractExpr, b::Value) = DotSortAtom(a, b)

--- a/src/atoms/lp_cone/max.jl
+++ b/src/atoms/lp_cone/max.jl
@@ -16,7 +16,7 @@ struct MaxAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function MaxAtom(x::AbstractExpr, y::AbstractExpr)
-        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+        if sign(x) == ComplexSign() || sign(y) == ComplexSign()
             error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
         else
             if x.size == y.size

--- a/src/atoms/lp_cone/max.jl
+++ b/src/atoms/lp_cone/max.jl
@@ -10,69 +10,69 @@ export max, pos, hinge_loss
 # TODO: This can easily be extended to work
 ### Max Atom
 struct MaxAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MaxAtom(x::AbstractExpr, y::AbstractExpr)
-    if sign(x)==ComplexSign() || sign(y)==ComplexSign()
-      error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
-    else
-      if x.size == y.size
-        sz = x.size
-      elseif x.size == (1, 1)
-        sz = y.size
-      elseif y.size == (1, 1)
-        sz = x.size
-      else
-        error("Got different sizes for x as $(x.size) and y as $(y.size)")
-      end
+    function MaxAtom(x::AbstractExpr, y::AbstractExpr)
+        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+            error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
+        else
+            if x.size == y.size
+                sz = x.size
+            elseif x.size == (1, 1)
+                sz = y.size
+            elseif y.size == (1, 1)
+                sz = x.size
+            else
+                error("Got different sizes for x as $(x.size) and y as $(y.size)")
+            end
+        end
+
+        children = (x, y)
+        return new(:max, hash(children), children, sz)
     end
-
-    children = (x, y)
-    return new(:max, hash(children), children, sz)
-  end
 end
 
 function sign(x::MaxAtom)
-  sign_one = sign(x.children[1])
-  sign_two = sign(x.children[2])
-  if sign_one == Positive() || sign_two == Positive()
-    return Positive()
-  elseif sign_one == Negative() && sign_two == Negative()
-    return Negative()
-  else
-    return sign_one + sign_two
-  end
+    sign_one = sign(x.children[1])
+    sign_two = sign(x.children[2])
+    if sign_one == Positive() || sign_two == Positive()
+        return Positive()
+    elseif sign_one == Negative() && sign_two == Negative()
+        return Negative()
+    else
+        return sign_one + sign_two
+    end
 end
 
 # The monotonicity
 function monotonicity(x::MaxAtom)
-  return (Nondecreasing(), Nondecreasing())
+    return (Nondecreasing(), Nondecreasing())
 end
 
 # If we have h(x) = f o g(x), the chain rule says h''(x) = g'(x)^T f''(g(x))g'(x) + f'(g(x))g''(x);
 # this represents the first term
 function curvature(x::MaxAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::MaxAtom)
-  return max.(evaluate(x.children[1]), evaluate(x.children[2]))
+    return max.(evaluate(x.children[1]), evaluate(x.children[2]))
 end
 
 # x <= this and y <= this if max(x, y) = this
 function conic_form!(x::MaxAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    this = Variable(x.size[1], x.size[2])
-    objective = conic_form!(this, unique_conic_forms)
-    for child in x.children
-      conic_form!(this >= child, unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        this = Variable(x.size[1], x.size[2])
+        objective = conic_form!(this, unique_conic_forms)
+        for child in x.children
+            conic_form!(this >= child, unique_conic_forms)
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 max(x::AbstractExpr, y::AbstractExpr) = MaxAtom(x, y)

--- a/src/atoms/lp_cone/maximum.jl
+++ b/src/atoms/lp_cone/maximum.jl
@@ -9,50 +9,50 @@ export maximum
 
 ### Maximum Atom
 struct MaximumAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MaximumAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("Argument should be real instead it is $(sign(x))")
-    else 
-      children = (x,)
-      return new(:maximum, hash(children), children, (1, 1))
+    function MaximumAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("Argument should be real instead it is $(sign(x))")
+        else
+            children = (x,)
+            return new(:maximum, hash(children), children, (1, 1))
+        end
     end
-  end
 end
 
 function sign(x::MaximumAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 # The monotonicity
 function monotonicity(x::MaximumAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 # If we have h(x) = f o g(x), the chain rule says h''(x) = g'(x)^T f''(g(x))g'(x) + f'(g(x))g''(x);
 # this represents the first term
 function curvature(x::MaximumAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::MaximumAtom)
-  return Base.maximum(evaluate(x.children[1]))
+    return Base.maximum(evaluate(x.children[1]))
 end
 
 # x <= this if maximum(x) = this
 # so, this - x will be in the :NonNeg cone
 function conic_form!(x::MaximumAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    this = Variable()
-    objective = conic_form!(this, unique_conic_forms)
-    conic_form!(this >= x.children[1], unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        this = Variable()
+        objective = conic_form!(this, unique_conic_forms)
+        conic_form!(this >= x.children[1], unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 maximum(x::AbstractExpr) = MaximumAtom(x)

--- a/src/atoms/lp_cone/min.jl
+++ b/src/atoms/lp_cone/min.jl
@@ -16,7 +16,7 @@ struct MinAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function MinAtom(x::AbstractExpr, y::AbstractExpr)
-        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+        if sign(x) == ComplexSign() || sign(y) == ComplexSign()
             error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
         else
             if x.size == y.size

--- a/src/atoms/lp_cone/min.jl
+++ b/src/atoms/lp_cone/min.jl
@@ -10,69 +10,69 @@ export min, neg
 # TODO: This can easily be extended to work
 ### Min Atom
 struct MinAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MinAtom(x::AbstractExpr, y::AbstractExpr)
-    if sign(x)==ComplexSign() || sign(y)==ComplexSign()
-      error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
-    else
-      if x.size == y.size
-        sz = x.size
-      elseif x.size == (1, 1)
-        sz = y.size
-      elseif y.size == (1, 1)
-        sz = x.size
-      else
-        error("Got different sizes for x as $(x.size) and y as $(y.size)")
-      end
+    function MinAtom(x::AbstractExpr, y::AbstractExpr)
+        if sign(x)==ComplexSign() || sign(y)==ComplexSign()
+            error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
+        else
+            if x.size == y.size
+                sz = x.size
+            elseif x.size == (1, 1)
+                sz = y.size
+            elseif y.size == (1, 1)
+                sz = x.size
+            else
+                error("Got different sizes for x as $(x.size) and y as $(y.size)")
+            end
+        end
+
+        children = (x, y)
+        return new(:min, hash(children), children, sz)
     end
-
-    children = (x, y)
-    return new(:min, hash(children), children, sz)
-  end
 end
 
 function sign(x::MinAtom)
-  sign_one = sign(x.children[1])
-  sign_two = sign(x.children[2])
-  if sign_one == Negative() || sign_two == Negative()
-    return Negative()
-  elseif sign_one == Positive() && sign_two == Positive()
-    return Positive()
-  else
-    return sign_one + sign_two
-  end
+    sign_one = sign(x.children[1])
+    sign_two = sign(x.children[2])
+    if sign_one == Negative() || sign_two == Negative()
+        return Negative()
+    elseif sign_one == Positive() && sign_two == Positive()
+        return Positive()
+    else
+        return sign_one + sign_two
+    end
 end
 
 # The monotonicity
 function monotonicity(x::MinAtom)
-  return (Nondecreasing(), Nondecreasing())
+    return (Nondecreasing(), Nondecreasing())
 end
 
 # If we have h(x) = f o g(x), the chain rule says h''(x) = g'(x)^T f''(g(x))g'(x) + f'(g(x))g''(x);
 # this represents the first term
 function curvature(x::MinAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::MinAtom)
-  return min.(evaluate(x.children[1]), evaluate(x.children[2]))
+    return min.(evaluate(x.children[1]), evaluate(x.children[2]))
 end
 
 # x >= this and y >= this if min(x, y) = this
 function conic_form!(x::MinAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    this = Variable(x.size[1], x.size[2])
-    objective = conic_form!(this, unique_conic_forms)
-    for child in x.children
-      conic_form!(this <= child, unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, x)
+        this = Variable(x.size[1], x.size[2])
+        objective = conic_form!(this, unique_conic_forms)
+        for child in x.children
+            conic_form!(this <= child, unique_conic_forms)
+        end
+        cache_conic_form!(unique_conic_forms, x, objective)
     end
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 min(x::AbstractExpr, y::AbstractExpr) = MinAtom(x, y)

--- a/src/atoms/lp_cone/minimum.jl
+++ b/src/atoms/lp_cone/minimum.jl
@@ -15,7 +15,7 @@ struct MinimumAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function MinimumAtom(x::AbstractExpr)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("Argument should be real instead it is $(sign(x))")
         else
             children = (x,)

--- a/src/atoms/lp_cone/minimum.jl
+++ b/src/atoms/lp_cone/minimum.jl
@@ -9,50 +9,50 @@ export minimum
 
 ### Minimum Atom
 struct MinimumAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MinimumAtom(x::AbstractExpr)
-    if sign(x)==ComplexSign()
-      error("Argument should be real instead it is $(sign(x))")
-    else
-      children = (x,)
-      return new(:minimum, hash(children), children, (1, 1))
+    function MinimumAtom(x::AbstractExpr)
+        if sign(x)==ComplexSign()
+            error("Argument should be real instead it is $(sign(x))")
+        else
+            children = (x,)
+            return new(:minimum, hash(children), children, (1, 1))
+        end
     end
-  end
 end
 
 function sign(x::MinimumAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 # The monotonicity
 function monotonicity(x::MinimumAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 # If we have h(x) = f o g(x), the chain rule says h''(x) = g'(x)^T f''(g(x))g'(x) + f'(g(x))g''(x);
 # this represents the first term
 function curvature(x::MinimumAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::MinimumAtom)
-  return Base.minimum(evaluate(x.children[1]))
+    return Base.minimum(evaluate(x.children[1]))
 end
 
 # x >= this if minimum(x) = this
 # so, x - this will be in the :NonNeg cone
 function conic_form!(x::MinimumAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    this = Variable()
-    objective = conic_form!(this, unique_conic_forms)
-    conic_form!(this <= x.children[1], unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        this = Variable()
+        objective = conic_form!(this, unique_conic_forms)
+        conic_form!(this <= x.children[1], unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 minimum(x::AbstractExpr) = MinimumAtom(x)

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -9,58 +9,58 @@ export sumlargest, sumsmallest
 export sign, curvature, monotonicity, evaluate
 
 struct SumLargestAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
-  k::Int
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
+    k::Int
 
-  function SumLargestAtom(x::AbstractExpr, k::Int)
-    if sign(x)==ComplexSign()
-      error("Argument should be real instead it is $(sign(x))")
-    else
-      if k <= 0
-        error("sumlargest and sumsmallest only support positive values of k")
-      end
-      if k > get_vectorized_size(x)
-        error("k cannot be larger than the number of entries in x")
-      end
-      children = (x,)
-      return new(:sumlargest, hash((children, k)), children, (1,1), k)
+    function SumLargestAtom(x::AbstractExpr, k::Int)
+        if sign(x)==ComplexSign()
+            error("Argument should be real instead it is $(sign(x))")
+        else
+            if k <= 0
+                error("sumlargest and sumsmallest only support positive values of k")
+            end
+            if k > get_vectorized_size(x)
+                error("k cannot be larger than the number of entries in x")
+            end
+            children = (x,)
+            return new(:sumlargest, hash((children, k)), children, (1,1), k)
+        end
     end
-  end
 end
 
 function sign(x::SumLargestAtom)
-  return sign(x.children[1])
+    return sign(x.children[1])
 end
 
 function monotonicity(x::SumLargestAtom)
-  return (Nondecreasing(), )
+    return (Nondecreasing(), )
 end
 
 function curvature(x::SumLargestAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::SumLargestAtom)
-  return sum(sort(vec(evaluate(x.children[1])), rev=true)[1:x.k])
+    return sum(sort(vec(evaluate(x.children[1])), rev=true)[1:x.k])
 end
 
 function conic_form!(x::SumLargestAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    c = x.children[1]
-    t = Variable(size(c))
-    q = Variable()
-    # sum k largest given by the solution to
-    # minimize sum(t) + k*q
-    # subject to c <= t + q, t >= 0
-    objective = conic_form!(sum(t) + x.k*q, unique_conic_forms)
-    conic_form!(c <= t + q, unique_conic_forms)
-    conic_form!(t >= 0, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        c = x.children[1]
+        t = Variable(size(c))
+        q = Variable()
+        # sum k largest given by the solution to
+        # minimize sum(t) + k*q
+        # subject to c <= t + q, t >= 0
+        objective = conic_form!(sum(t) + x.k*q, unique_conic_forms)
+        conic_form!(c <= t + q, unique_conic_forms)
+        conic_form!(t >= 0, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 sumlargest(x::AbstractExpr, k::Int) = SumLargestAtom(x, k)

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -16,7 +16,7 @@ struct SumLargestAtom <: AbstractExpr
     k::Int
 
     function SumLargestAtom(x::AbstractExpr, k::Int)
-        if sign(x)==ComplexSign()
+        if sign(x) == ComplexSign()
             error("Argument should be real instead it is $(sign(x))")
         else
             if k <= 0

--- a/src/atoms/sdp_cone/lambda_min_max.jl
+++ b/src/atoms/sdp_cone/lambda_min_max.jl
@@ -10,36 +10,36 @@ export lambdamax, lambdamin
 ### Lambda max
 
 struct LambdaMaxAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function LambdaMaxAtom(x::AbstractExpr)
-    children = (x,)
-    m,n = size(x)
-    if m==n
-      return new(:lambdamax, hash(children), children, (1,1))
-    else
-      error("lambdamax can only be applied to a square matrix.")
+    function LambdaMaxAtom(x::AbstractExpr)
+        children = (x,)
+        m,n = size(x)
+        if m==n
+            return new(:lambdamax, hash(children), children, (1,1))
+        else
+            error("lambdamax can only be applied to a square matrix.")
+        end
     end
-  end
 end
 
 function sign(x::LambdaMaxAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::LambdaMaxAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::LambdaMaxAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::LambdaMaxAtom)
-  eigvals(evaluate(x.children[1]))[end]
+    eigvals(evaluate(x.children[1]))[end]
 end
 
 lambdamax(x::AbstractExpr) = LambdaMaxAtom(x)
@@ -50,49 +50,49 @@ lambdamax(x::AbstractExpr) = LambdaMaxAtom(x)
 #            tI - A is positive semidefinite
 #            A      is positive semidefinite
 function conic_form!(x::LambdaMaxAtom, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    m, n = size(A)
-    t = Variable()
-    p = minimize(t, t*Matrix(1.0I, n, n) - A ⪰ 0)
-    cache_conic_form!(unique_conic_forms, x, p)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        m, n = size(A)
+        t = Variable()
+        p = minimize(t, t*Matrix(1.0I, n, n) - A ⪰ 0)
+        cache_conic_form!(unique_conic_forms, x, p)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 ### Lambda min
 
 struct LambdaMinAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function LambdaMinAtom(x::AbstractExpr)
-    children = (x,)
-    m,n = size(x)
-    if m==n
-      return new(:lambdamin, hash(children), children, (1,1))
-    else
-      error("lambdamin can only be applied to a square matrix.")
+    function LambdaMinAtom(x::AbstractExpr)
+        children = (x,)
+        m,n = size(x)
+        if m==n
+            return new(:lambdamin, hash(children), children, (1,1))
+        else
+            error("lambdamin can only be applied to a square matrix.")
+        end
     end
-  end
 end
 
 function sign(x::LambdaMinAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::LambdaMinAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(x::LambdaMinAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(x::LambdaMinAtom)
-  eigvals(evaluate(x.children[1]))[1]
+    eigvals(evaluate(x.children[1]))[1]
 end
 
 lambdamin(x::AbstractExpr) = LambdaMinAtom(x)
@@ -103,12 +103,12 @@ lambdamin(x::AbstractExpr) = LambdaMinAtom(x)
 #            A - tI is positive semidefinite
 #            A      is positive semidefinite
 function conic_form!(x::LambdaMinAtom, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    m, n = size(A)
-    t = Variable()
-    p = maximize(t, A - t*Matrix(1.0I, n, n) ⪰ 0)
-    cache_conic_form!(unique_conic_forms, x, p)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        m, n = size(A)
+        t = Variable()
+        p = maximize(t, A - t*Matrix(1.0I, n, n) ⪰ 0)
+        cache_conic_form!(unique_conic_forms, x, p)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/atoms/sdp_cone/lambda_min_max.jl
+++ b/src/atoms/sdp_cone/lambda_min_max.jl
@@ -17,9 +17,9 @@ struct LambdaMaxAtom <: AbstractExpr
 
     function LambdaMaxAtom(x::AbstractExpr)
         children = (x,)
-        m,n = size(x)
-        if m==n
-            return new(:lambdamax, hash(children), children, (1,1))
+        m, n = size(x)
+        if m == n
+            return new(:lambdamax, hash(children), children, (1, 1))
         else
             error("lambdamax can only be applied to a square matrix.")
         end
@@ -70,8 +70,8 @@ struct LambdaMinAtom <: AbstractExpr
 
     function LambdaMinAtom(x::AbstractExpr)
         children = (x,)
-        m,n = size(x)
-        if m==n
+        m, n = size(x)
+        if m == n
             return new(:lambdamin, hash(children), children, (1,1))
         else
             error("lambdamin can only be applied to a square matrix.")

--- a/src/atoms/sdp_cone/matrixfrac.jl
+++ b/src/atoms/sdp_cone/matrixfrac.jl
@@ -8,39 +8,39 @@
 export matrixfrac
 
 struct MatrixFracAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function MatrixFracAtom(x::AbstractExpr, P::AbstractExpr)
-    if x.size[2] != 1
-      error("first argument of matrix frac must be a vector")
-    elseif P.size[1] != P.size[2]
-      error("second argument of matrix frac must be square")
-    elseif x.size[1] != P.size[1]
-      error("sizes must agree for arguments of matrix frac")
+    function MatrixFracAtom(x::AbstractExpr, P::AbstractExpr)
+        if x.size[2] != 1
+            error("first argument of matrix frac must be a vector")
+        elseif P.size[1] != P.size[2]
+            error("second argument of matrix frac must be square")
+        elseif x.size[1] != P.size[1]
+            error("sizes must agree for arguments of matrix frac")
+        end
+        children = (x, P)
+        return new(:matrixfrac, hash(children), children, (1,1))
     end
-    children = (x, P)
-    return new(:matrixfrac, hash(children), children, (1,1))
-  end
 end
 
 function sign(m::MatrixFracAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(m::MatrixFracAtom)
-  return (NoMonotonicity(), NoMonotonicity())
+    return (NoMonotonicity(), NoMonotonicity())
 end
 
 function curvature(m::MatrixFracAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(m::MatrixFracAtom)
-  x = evaluate(m.children[1])
-  return x'*inv(evaluate(m.children[2]))*x
+    x = evaluate(m.children[1])
+    return x'*inv(evaluate(m.children[2]))*x
 end
 
 matrixfrac(x::AbstractExpr, P::AbstractExpr) = MatrixFracAtom(x, P)
@@ -48,14 +48,14 @@ matrixfrac(x::Value, P::AbstractExpr) = MatrixFracAtom(Constant(x), P)
 matrixfrac(x::AbstractExpr, P::Value) = MatrixFracAtom(x, Constant(P))
 
 function conic_form!(m::MatrixFracAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, m)
-    x = m.children[1]
-    P = m.children[2]
-    t = Variable()
-    # the matrix [t x'; x P] has Schur complement t - x'*P^{-1}*x
-    # this matrix is PSD <=> t >= x'*P^{-1}*x
-    p = minimize(t, [t x'; x P] ⪰ 0)
-    cache_conic_form!(unique_conic_forms, m, p)
-  end
-  return get_conic_form(unique_conic_forms, m)
+    if !has_conic_form(unique_conic_forms, m)
+        x = m.children[1]
+        P = m.children[2]
+        t = Variable()
+        # the matrix [t x'; x P] has Schur complement t - x'*P^{-1}*x
+        # this matrix is PSD <=> t >= x'*P^{-1}*x
+        p = minimize(t, [t x'; x P] ⪰ 0)
+        cache_conic_form!(unique_conic_forms, m, p)
+    end
+    return get_conic_form(unique_conic_forms, m)
 end

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -9,32 +9,32 @@ export nuclearnorm
 ### Nuclear norm
 
 struct NuclearNormAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function NuclearNormAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:nuclearnorm, hash(children), children, (1,1))
-  end
+    function NuclearNormAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:nuclearnorm, hash(children), children, (1,1))
+    end
 end
 
 function sign(x::NuclearNormAtom)
-  return Positive()
+    return Positive()
 end
 
 # The monotonicity
 function monotonicity(x::NuclearNormAtom)
-  return (NoMonotonicity(),)
+    return (NoMonotonicity(),)
 end
 
 function curvature(x::NuclearNormAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::NuclearNormAtom)
-  return sum(svdvals(evaluate(x.children[1])))
+    return sum(svdvals(evaluate(x.children[1])))
 end
 
 nuclearnorm(x::AbstractExpr) = NuclearNormAtom(x)
@@ -46,13 +46,13 @@ nuclearnorm(x::AbstractExpr) = NuclearNormAtom(x)
 # see eg Recht, Fazel, Parillo 2008 "Guaranteed Minimum-Rank Solutions of Linear Matrix Equations via Nuclear Norm Minimization"
 # http://arxiv.org/pdf/0706.4138v1.pdf
 function conic_form!(x::NuclearNormAtom, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    m, n = size(A)
-    U = Variable(m,m)
-    V = Variable(n,n)
-    p = minimize(.5*(tr(U) + tr(V)), [U A; A' V] ⪰ 0)
-    cache_conic_form!(unique_conic_forms, x, p)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        m, n = size(A)
+        U = Variable(m,m)
+        V = Variable(n,n)
+        p = minimize(.5*(tr(U) + tr(V)), [U A; A' V] ⪰ 0)
+        cache_conic_form!(unique_conic_forms, x, p)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -11,50 +11,50 @@ export sigmamax
 ### Operator norm
 
 struct OperatorNormAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function OperatorNormAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:opnorm, hash(children), children, (1,1))
-  end
+    function OperatorNormAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:opnorm, hash(children), children, (1,1))
+    end
 end
 
 function sign(x::OperatorNormAtom)
-  return Positive()
+    return Positive()
 end
 
 # The monotonicity
 function monotonicity(x::OperatorNormAtom)
-  return (NoMonotonicity(),)
+    return (NoMonotonicity(),)
 end
 
 function curvature(x::OperatorNormAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 # in julia, `norm` on matrices is the operator norm
 function evaluate(x::OperatorNormAtom)
-  opnorm(evaluate(x.children[1]), 2)
+    opnorm(evaluate(x.children[1]), 2)
 end
 
 sigmamax(x::AbstractExpr) = OperatorNormAtom(x)
 
 function opnorm(x::AbstractExpr, p::Real=2)
-  if length(size(x)) <= 1 || minimum(size(x)) == 1
-    throw(ArgumentError("argument to `opnorm` must be a matrix"))
-  end
-  if p == 1
-    return maximum(sum(abs(x), dims=1))
-  elseif p == 2
-    return OperatorNormAtom(x)
-  elseif p == Inf
-    return maximum(sum(abs(x), dims=2))
-  else
-    throw(ArgumentError("matrix p-norms only defined for p = 1, 2, and Inf"))
-  end
+    if length(size(x)) <= 1 || minimum(size(x)) == 1
+        throw(ArgumentError("argument to `opnorm` must be a matrix"))
+    end
+    if p == 1
+        return maximum(sum(abs(x), dims=1))
+    elseif p == 2
+        return OperatorNormAtom(x)
+    elseif p == Inf
+        return maximum(sum(abs(x), dims=2))
+    else
+        throw(ArgumentError("matrix p-norms only defined for p = 1, 2, and Inf"))
+    end
 end
 
 Base.@deprecate operatornorm(x::AbstractExpr) opnorm(x)
@@ -66,12 +66,12 @@ Base.@deprecate operatornorm(x::AbstractExpr) opnorm(x)
 # see eg Recht, Fazel, Parillo 2008 "Guaranteed Minimum-Rank Solutions of Linear Matrix Equations via Nuclear Norm Minimization"
 # http://arxiv.org/pdf/0706.4138v1.pdf
 function conic_form!(x::OperatorNormAtom, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    m, n = size(A)
-    t = Variable()
-    p = minimize(t, [t*sparse(1.0I, m, m) A; A' t*sparse(1.0I, n, n)] ⪰ 0)
-    cache_conic_form!(unique_conic_forms, x, p)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        m, n = size(A)
+        t = Variable()
+        p = minimize(t, [t*sparse(1.0I, m, m) A; A' t*sparse(1.0I, n, n)] ⪰ 0)
+        cache_conic_form!(unique_conic_forms, x, p)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -11,36 +11,36 @@ export sumlargesteigs
 ### sumlargesteigs
 
 struct SumLargestEigs <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function SumLargestEigs(x::AbstractExpr, k::AbstractExpr)
-    children = (x, k)
-    m,n = size(x)
-    if m==n
-      return new(:sumlargesteigs, hash(children), children, (1,1))
-    else
-      error("sumlargesteigs can only be applied to a square matrix.")
+    function SumLargestEigs(x::AbstractExpr, k::AbstractExpr)
+        children = (x, k)
+        m,n = size(x)
+        if m==n
+            return new(:sumlargesteigs, hash(children), children, (1,1))
+        else
+            error("sumlargesteigs can only be applied to a square matrix.")
+        end
     end
-  end
 end
 
 function sign(x::SumLargestEigs)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::SumLargestEigs)
-  return (Nondecreasing(), NoMonotonicity())
+    return (Nondecreasing(), NoMonotonicity())
 end
 
 function curvature(x::SumLargestEigs)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::SumLargestEigs)
-  eigvals(evaluate(x.children[1]))[end-x.children[2]:end]
+    eigvals(evaluate(x.children[1]))[end-x.children[2]:end]
 end
 
 sumlargesteigs(x::AbstractExpr, k::Int) = SumLargestEigs(x, Constant(k))
@@ -55,16 +55,16 @@ sumlargesteigs(x::AbstractExpr, k::Int) = SumLargestEigs(x, Constant(k))
 # Example 18.c
 
 function conic_form!(x::SumLargestEigs, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    A = x.children[1]
-    k = x.children[2]
-    m, n = size(A)
-    Z = Variable(n, n)
-    s = Variable()
-    p = minimize(s*k + tr(Z), 
-                 Z + s*Matrix(1.0I, n, n) - A ⪰ 0,
-                 A ⪰ 0, Z ⪰ 0)
-    cache_conic_form!(unique_conic_forms, x, p)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        A = x.children[1]
+        k = x.children[2]
+        m, n = size(A)
+        Z = Variable(n, n)
+        s = Variable()
+        p = minimize(s*k + tr(Z),
+                     Z + s*Matrix(1.0I, n, n) - A ⪰ 0,
+                     A ⪰ 0, Z ⪰ 0)
+        cache_conic_form!(unique_conic_forms, x, p)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -18,8 +18,8 @@ struct SumLargestEigs <: AbstractExpr
 
     function SumLargestEigs(x::AbstractExpr, k::AbstractExpr)
         children = (x, k)
-        m,n = size(x)
-        if m==n
+        m, n = size(x)
+        if m == n
             return new(:sumlargesteigs, hash(children), children, (1,1))
         else
             error("sumlargesteigs can only be applied to a square matrix.")

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -3,51 +3,51 @@ export GeoMeanAtom, geomean, sqrt
 export sign, monotonicity, curvature, conic_form!
 
 struct GeoMeanAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function GeoMeanAtom(x::AbstractExpr, y::AbstractExpr)
-    if x.size != y.size
-      error("geo mean must take two arguments of the same size")
-    elseif sign(x)==ComplexSign() || sign(y)==ComplexSign()
-      error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
-    else
-      children = (x, y)
-      return new(:geomean, hash(children), children, x.size)
-      end
-  end
+    function GeoMeanAtom(x::AbstractExpr, y::AbstractExpr)
+        if x.size != y.size
+            error("geo mean must take two arguments of the same size")
+        elseif sign(x)==ComplexSign() || sign(y)==ComplexSign()
+            error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
+        else
+            children = (x, y)
+            return new(:geomean, hash(children), children, x.size)
+        end
+    end
 end
 
 function sign(q::GeoMeanAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(q::GeoMeanAtom)
-  return (Nondecreasing(), Nondecreasing())
+    return (Nondecreasing(), Nondecreasing())
 end
 
 function curvature(q::GeoMeanAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(q::GeoMeanAtom)
-  return sqrt.(evaluate(q.children[1]) .* evaluate(q.children[2]))
+    return sqrt.(evaluate(q.children[1]) .* evaluate(q.children[2]))
 end
 
 function conic_form!(q::GeoMeanAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, q)
-    sz = q.children[1].size
-    t = Variable(sz[1], sz[2])
-    qol_objective = conic_form!(t, unique_conic_forms)
-    x, y = q.children
-    conic_form!(SOCElemConstraint(y + x, y - x, 2 * t), unique_conic_forms)
-    conic_form!(x >= 0, unique_conic_forms)
-    conic_form!(y >= 0, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, q, qol_objective)
-  end
-  return get_conic_form(unique_conic_forms, q)
+    if !has_conic_form(unique_conic_forms, q)
+        sz = q.children[1].size
+        t = Variable(sz[1], sz[2])
+        qol_objective = conic_form!(t, unique_conic_forms)
+        x, y = q.children
+        conic_form!(SOCElemConstraint(y + x, y - x, 2 * t), unique_conic_forms)
+        conic_form!(x >= 0, unique_conic_forms)
+        conic_form!(y >= 0, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, q, qol_objective)
+    end
+    return get_conic_form(unique_conic_forms, q)
 end
 
 geomean(x::AbstractExpr, y::AbstractExpr) = GeoMeanAtom(x, y)

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -11,7 +11,7 @@ struct GeoMeanAtom <: AbstractExpr
     function GeoMeanAtom(x::AbstractExpr, y::AbstractExpr)
         if x.size != y.size
             error("geo mean must take two arguments of the same size")
-        elseif sign(x)==ComplexSign() || sign(y)==ComplexSign()
+        elseif sign(x) == ComplexSign() || sign(y) == ComplexSign()
             error("Both the arguments should be real instead they are $(sign(x)) and $(sign(y))")
         else
             children = (x, y)

--- a/src/atoms/second_order_cone/huber.jl
+++ b/src/atoms/second_order_cone/huber.jl
@@ -1,60 +1,60 @@
 export huber
 
 struct HuberAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
-  M::Real
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
+    M::Real
 
-  function HuberAtom(x::AbstractExpr, M::Real)
-    if sign(x) == ComplexSign()
-      error("Arguemt must be real")
-    elseif M <= 0
-      error("Huber parameter must by a positive scalar")
+    function HuberAtom(x::AbstractExpr, M::Real)
+        if sign(x) == ComplexSign()
+            error("Arguemt must be real")
+        elseif M <= 0
+            error("Huber parameter must by a positive scalar")
+        end
+        children = (x,)
+        return new(:huber, hash((children, M)), children, x.size, M)
     end
-    children = (x,)
-    return new(:huber, hash((children, M)), children, x.size, M)
-  end
 end
 
 function sign(x::HuberAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::HuberAtom)
-  return (Nondecreasing() * sign(x.children[1]),)
+    return (Nondecreasing() * sign(x.children[1]),)
 end
 
 function curvature(x::HuberAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::HuberAtom)
-  c = evaluate(x.children[1])
-  for i in 1:length(c)
-    if c[i] <= x.M
-      c[i] = c[i]^2
-    else
-      c[i] = 2*x.M*c[i] - x.M^2
+    c = evaluate(x.children[1])
+    for i in 1:length(c)
+        if c[i] <= x.M
+            c[i] = c[i]^2
+        else
+            c[i] = 2*x.M*c[i] - x.M^2
+        end
     end
-  end
-  return c
+    return c
 end
 
 function conic_form!(x::HuberAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    c = x.children[1]
-    s = Variable(c.size)
-    n = Variable(c.size)
+    if !has_conic_form(unique_conic_forms, x)
+        c = x.children[1]
+        s = Variable(c.size)
+        n = Variable(c.size)
 
-    # objective given by s.^2 + 2 * M * |n|
-    objective = conic_form!(square(s) + 2 * x.M * abs(n), unique_conic_forms)
-    conic_form!(c == s + n, unique_conic_forms)
+        # objective given by s.^2 + 2 * M * |n|
+        objective = conic_form!(square(s) + 2 * x.M * abs(n), unique_conic_forms)
+        conic_form!(c == s + n, unique_conic_forms)
 
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 huber(x::AbstractExpr, M::Real=1.0) = HuberAtom(x, M)

--- a/src/atoms/second_order_cone/norm.jl
+++ b/src/atoms/second_order_cone/norm.jl
@@ -10,31 +10,31 @@ norm_fro(x::AbstractExpr) = norm2(vec(x))
 # * vector norms for vectors
 # * operator norms for matrices
 function norm(x::AbstractExpr, p::Real=2)
-  if length(size(x)) <= 1 || minimum(size(x))==1
-    # x is a vector
-    if p == 1
-      return norm_1(x)
-    elseif p == 2
-      return norm2(x)
-    elseif p == Inf
-      return norm_inf(x)
-    elseif p > 1
-      # TODO: allow tolerance in the rationalize step
-      return rationalnorm(x, rationalize(Int, float(p)))
+    if length(size(x)) <= 1 || minimum(size(x))==1
+        # x is a vector
+        if p == 1
+            return norm_1(x)
+        elseif p == 2
+            return norm2(x)
+        elseif p == Inf
+            return norm_inf(x)
+        elseif p > 1
+            # TODO: allow tolerance in the rationalize step
+            return rationalnorm(x, rationalize(Int, float(p)))
+        else
+            error("vector p-norms not defined for p < 1")
+        end
     else
-      error("vector p-norms not defined for p < 1")
+        # TODO: After the deprecation period, allow this again but make it consistent with
+        # LinearAlgebra, i.e. make norm(x, p) for x a matrix the same as norm(vec(x), p).
+        Base.depwarn("`norm(x, p)` for matrices will in the future be equivalent to " *
+                     "`norm(vec(x), p)`. Use `opnorm(x, p)` for the Julia 0.6 behavior of " *
+                     "computing the operator norm for matrices.", :norm)
+        return opnorm(x, p)
     end
-  else
-    # TODO: After the deprecation period, allow this again but make it consistent with
-    # LinearAlgebra, i.e. make norm(x, p) for x a matrix the same as norm(vec(x), p).
-    Base.depwarn("`norm(x, p)` for matrices will in the future be equivalent to " *
-                 "`norm(vec(x), p)`. Use `opnorm(x, p)` for the Julia 0.6 behavior of " *
-                 "computing the operator norm for matrices.", :norm)
-    return opnorm(x, p)
-  end
 end
 
 if isdefined(LinearAlgebra, :vecnorm) # deprecated but defined
-  import LinearAlgebra: vecnorm
+    import LinearAlgebra: vecnorm
 end
 Base.@deprecate vecnorm(x::AbstractExpr, p::Real=2) norm(vec(x), p)

--- a/src/atoms/second_order_cone/norm2.jl
+++ b/src/atoms/second_order_cone/norm2.jl
@@ -10,50 +10,50 @@ export sign, monotonicity, curvature, conic_form!
 
 
 struct EucNormAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function EucNormAtom(x::AbstractExpr)
-    children = (x,)
-    return new(:norm2, hash(children), children, (1, 1))
-  end
+    function EucNormAtom(x::AbstractExpr)
+        children = (x,)
+        return new(:norm2, hash(children), children, (1, 1))
+    end
 end
 
 function sign(x::EucNormAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(x::EucNormAtom)
-  return (sign(x.children[1]) * Nondecreasing(),)
+    return (sign(x.children[1]) * Nondecreasing(),)
 end
 
 function curvature(x::EucNormAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::EucNormAtom)
-  return norm(vec(evaluate(x.children[1])))
+    return norm(vec(evaluate(x.children[1])))
 end
 
 
 ## Create a new variable euc_norm to represent the norm
 ## Additionally, create the second order conic constraint (euc_norm, x) in SOC
 function conic_form!(x::EucNormAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    euc_norm = Variable()
-    objective = conic_form!(euc_norm, unique_conic_forms)
-    conic_form!(SOCConstraint(euc_norm, x.children[1]), unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        euc_norm = Variable()
+        objective = conic_form!(euc_norm, unique_conic_forms)
+        conic_form!(SOCConstraint(euc_norm, x.children[1]), unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end
 
 function norm2(x::AbstractExpr)
-  if sign(x) == ComplexSign()
-    return EucNormAtom([real(x);imag(x)])
-  else 
-    return EucNormAtom(x)
-  end
+    if sign(x) == ComplexSign()
+        return EucNormAtom([real(x);imag(x)])
+    else
+        return EucNormAtom(x)
+    end
 end

--- a/src/atoms/second_order_cone/power_to_socp.jl
+++ b/src/atoms/second_order_cone/power_to_socp.jl
@@ -15,44 +15,44 @@
 module psocp
 
 mutable struct InequalityExpression
-  # Represents an inequality of the form
-  #
-  # x^n <= t^{p_1} s^{p_2} u^{p_3},
-  #
-  # where we always have p_1 + p_2 + p_3 == n, and we must have p_3
-  # belonging to {0, 1, 2}. This allows a particular form of recursive
-  # enumeration of inequalities.
+    # Represents an inequality of the form
+    #
+    # x^n <= t^{p_1} s^{p_2} u^{p_3},
+    #
+    # where we always have p_1 + p_2 + p_3 == n, and we must have p_3
+    # belonging to {0, 1, 2}. This allows a particular form of recursive
+    # enumeration of inequalities.
 
-  # The powers p_1, p_2, p_3
-  power1::Int
-  power2::Int
-  power3::Int
+    # The powers p_1, p_2, p_3
+    power1::Int
+    power2::Int
+    power3::Int
 
-  # Index for variable represented by x in the above equation
-  left_var_ind::Int
-  # Index for variable represented by t
-  t_var_ind::Int
-  # Index for variable represented by s
-  s_var_ind::Int
-  # Index for variable represented by u (may be -1 if power3 == 0).
-  u_var_ind::Int
+    # Index for variable represented by x in the above equation
+    left_var_ind::Int
+    # Index for variable represented by t
+    t_var_ind::Int
+    # Index for variable represented by s
+    s_var_ind::Int
+    # Index for variable represented by u (may be -1 if power3 == 0).
+    u_var_ind::Int
 end
 
 struct SimpleInequalityExpression
-  # Represents an inequality of the form
-  #
-  # x^2 <= t s,
-  #
-  # which is representable as the SOCP norm([2 x, t - s]) <= t + s. A
-  # list of these is the first of the tuple returned by the method
-  # ProductToSimpleInequalities.
+    # Represents an inequality of the form
+    #
+    # x^2 <= t s,
+    #
+    # which is representable as the SOCP norm([2 x, t - s]) <= t + s. A
+    # list of these is the first of the tuple returned by the method
+    # ProductToSimpleInequalities.
 
-  # Index for variable represented by x in the above equation
-  left_var_ind::Int
-  # Index for variable represented by t
-  t_var_ind::Int
-  # Index for variable represented by s
-  s_var_ind::Int
+    # Index for variable represented by x in the above equation
+    left_var_ind::Int
+    # Index for variable represented by t
+    t_var_ind::Int
+    # Index for variable represented by s
+    s_var_ind::Int
 end
 
 # ProductToSimpleInequalities(first_power, second_power)
@@ -70,15 +70,15 @@ end
 # inequalities, the second of the tuple (the array vars) is an array
 # of all the variable indices in the inequalities.
 function ProductToSimpleInequalities(first_power::Int, second_power::Int)
-  # Construct the first InequalityExpression, which is an inequality
-  # of the form x^n <= t^p1 s^p2.
-  @assert first_power > 0 && second_power > 0;
-  n = first_power + second_power;
-  var_list = [1, 2, 3];
-  init_inequality = InequalityExpression(first_power, second_power, 0,
-                                         1, 2, 3, -1);
-  return ReducePowers(init_inequality, Array{SimpleInequalityExpression}(undef, 0),
-                      var_list);
+    # Construct the first InequalityExpression, which is an inequality
+    # of the form x^n <= t^p1 s^p2.
+    @assert first_power > 0 && second_power > 0;
+    n = first_power + second_power;
+    var_list = [1, 2, 3];
+    init_inequality = InequalityExpression(first_power, second_power, 0,
+                                                                                 1, 2, 3, -1);
+    return ReducePowers(init_inequality, Array{SimpleInequalityExpression}(undef, 0),
+                                            var_list);
 end
 
 # ReducePowers(curr_inequality::InequalityExpression,
@@ -102,32 +102,32 @@ end
 function ReducePowers(curr_inequality::InequalityExpression,
                       ineq_array::Array{SimpleInequalityExpression, 1},
                       variable_array::Array{Int, 1})
-  ReArrangePowers!(curr_inequality);
-  p1 = curr_inequality.power1;
-  p2 = curr_inequality.power2;
-  p3 = curr_inequality.power3;
-  n = (p1 + p2 + p3);
-  @assert p1 >= 1;  # , "Must have at least 1 on first power");
-  @assert p2 >= 1;  # , "Must have at least 1 on second power");
-  # Evaluate cases for variables
-  if (p3 == 0)
-    # Double check if we have p1 == 1, p2 == 1
-    if (p1 == 1 && p2 == 1)
-      new_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
-                                            curr_inequality.t_var_ind,
-                                            curr_inequality.s_var_ind);
-      return (vcat(ineq_array, new_ineq), variable_array);
+    ReArrangePowers!(curr_inequality);
+    p1 = curr_inequality.power1;
+    p2 = curr_inequality.power2;
+    p3 = curr_inequality.power3;
+    n = (p1 + p2 + p3);
+    @assert p1 >= 1;  # , "Must have at least 1 on first power");
+    @assert p2 >= 1;  # , "Must have at least 1 on second power");
+    # Evaluate cases for variables
+    if (p3 == 0)
+        # Double check if we have p1 == 1, p2 == 1
+        if (p1 == 1 && p2 == 1)
+            new_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
+                                                  curr_inequality.t_var_ind,
+                                                  curr_inequality.s_var_ind);
+            return (vcat(ineq_array, new_ineq), variable_array);
+        end
+        return ReduceThirdZero(curr_inequality,
+                               ineq_array, variable_array);
+    elseif (p3 == 1)
+        return ReduceThirdOne(curr_inequality, ineq_array, variable_array);
+    elseif (p3 == 2)
+        return ReduceThirdTwo(curr_inequality, ineq_array, variable_array);
+    else
+        error("Third power in inequality (", curr_inequality.power3,
+              ") must be 0, 1, or 2");
     end
-    return ReduceThirdZero(curr_inequality,
-                           ineq_array, variable_array);
-  elseif (p3 == 1)
-    return ReduceThirdOne(curr_inequality, ineq_array, variable_array);
-  elseif (p3 == 2)
-    return ReduceThirdTwo(curr_inequality, ineq_array, variable_array);
-  else
-    error("Third power in inequality (", curr_inequality.power3,
-          ") must be 0, 1, or 2");
-  end
 end
 
 # ReArrangePowers!(current_inequality::InequalityExpression)
@@ -136,35 +136,35 @@ end
 # variables so that the variable with smallest power is stored as
 # u_var_ind. Also divides each power by their gcd.
 function ReArrangePowers!(inequality::InequalityExpression)
-  p1 = inequality.power1;
-  p2 = inequality.power2;
-  p3 = inequality.power3;
-  divisor = gcd(p1, p2, p3);
-  if (divisor > 1)
-    inequality.power1 /= divisor;
-    inequality.power2 /= divisor;
-    inequality.power3 /= divisor;
     p1 = inequality.power1;
     p2 = inequality.power2;
     p3 = inequality.power3;
-  end
-  if (p1 <= min(p2, p3))
-    # Swap t and u
-    inequality.power3 = p1;
-    inequality.power1 = p3;
-    ind1 = inequality.t_var_ind;
-    ind3 = inequality.u_var_ind;
-    inequality.t_var_ind = ind3;
-    inequality.u_var_ind = ind1;
-  elseif (p2 <= min(p1, p3))
-    # Swap s and u
-    inequality.power3 = p2;
-    inequality.power2 = p3;
-    ind2 = inequality.s_var_ind;
-    ind3 = inequality.u_var_ind;
-    inequality.s_var_ind = ind3;
-    inequality.u_var_ind = ind2;
-  end  # In this case, p3 <= min(p1, p2), so no swap necessary
+    divisor = gcd(p1, p2, p3);
+    if (divisor > 1)
+        inequality.power1 /= divisor;
+        inequality.power2 /= divisor;
+        inequality.power3 /= divisor;
+        p1 = inequality.power1;
+        p2 = inequality.power2;
+        p3 = inequality.power3;
+    end
+    if (p1 <= min(p2, p3))
+        # Swap t and u
+        inequality.power3 = p1;
+        inequality.power1 = p3;
+        ind1 = inequality.t_var_ind;
+        ind3 = inequality.u_var_ind;
+        inequality.t_var_ind = ind3;
+        inequality.u_var_ind = ind1;
+    elseif (p2 <= min(p1, p3))
+        # Swap s and u
+        inequality.power3 = p2;
+        inequality.power2 = p3;
+        ind2 = inequality.s_var_ind;
+        ind3 = inequality.u_var_ind;
+        inequality.s_var_ind = ind3;
+        inequality.u_var_ind = ind2;
+    end  # In this case, p3 <= min(p1, p2), so no swap necessary
 end
 
 # ReduceThirdZero(curr_inequality::InequalityExpression,
@@ -176,75 +176,75 @@ end
 function ReduceThirdZero(curr_inequality::InequalityExpression,
                          ineq_array::Array{SimpleInequalityExpression, 1},
                          var_array::Array{Int, 1})
-  p1 = curr_inequality.power1;
-  p2 = curr_inequality.power2;
-  p3 = curr_inequality.power3;
-  n = (p1 + p2);
-  @assert p3 == 0;
-  @assert n >= 2;
-  if (mod(n, 2) == 0)
-    # n is even, so check even-ness of power1, power2
-    if (p1 == p2)
-      # We are seriously done
-      new_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
-                                            curr_inequality.t_var_ind,
-                                            curr_inequality.s_var_ind);
-      return (vcat(ineq_array, new_ineq), var_array);
-    end
-    if (mod(p1, 2) == 0)
-      # Both are even, reduce and repeat
-      curr_inequality.power1 /= 2;
-      curr_inequality.power2 /= 2;
-      return ReducePowers(curr_inequality, ineq_array, var_array);
-    else
-      # p1 is odd, p2 is odd, and they are unequal. Go to two
-      # equations, which are
-      #
-      # x^(n / 2) <= t^((p1 - 1)/2) s^((p2 - 1)/2) u,
-      # u^2 <= ts
-      #
-      # If n/2 == 2, then do not recurse, but simply catenate the
-      # inequality on and return
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.t_var_ind,
-                                            curr_inequality.s_var_ind);
-      curr_inequality.power1 = (p1 - 1) / 2;
-      curr_inequality.power2 = (p2 - 1) / 2;
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      # Recurse on the reduced inequality
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
-    end  # if (mod(p1, 2) == 0)
-  else  # n is odd, and we must recurse differently.
-    if (mod(p1, 2) == 1)
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.t_var_ind,
-                                            curr_inequality.left_var_ind);
-      curr_inequality.power1 = (p1 - 1) / 2;
-      curr_inequality.power2 = p2 / 2;
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
-    else  # mod(p2, 2) == 1
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.s_var_ind,
-                                            curr_inequality.left_var_ind);
-      curr_inequality.power1 = p1 / 2;
-      curr_inequality.power2 = (p2 - 1) / 2;
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
-    end
-  end  # if mod(n, 2) == 0
+    p1 = curr_inequality.power1;
+    p2 = curr_inequality.power2;
+    p3 = curr_inequality.power3;
+    n = (p1 + p2);
+    @assert p3 == 0;
+    @assert n >= 2;
+    if (mod(n, 2) == 0)
+        # n is even, so check even-ness of power1, power2
+        if (p1 == p2)
+            # We are seriously done
+            new_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
+                                                  curr_inequality.t_var_ind,
+                                                  curr_inequality.s_var_ind);
+            return (vcat(ineq_array, new_ineq), var_array);
+        end
+        if (mod(p1, 2) == 0)
+            # Both are even, reduce and repeat
+            curr_inequality.power1 /= 2;
+            curr_inequality.power2 /= 2;
+            return ReducePowers(curr_inequality, ineq_array, var_array);
+        else
+            # p1 is odd, p2 is odd, and they are unequal. Go to two
+            # equations, which are
+            #
+            # x^(n / 2) <= t^((p1 - 1)/2) s^((p2 - 1)/2) u,
+            # u^2 <= ts
+            #
+            # If n/2 == 2, then do not recurse, but simply catenate the
+            # inequality on and return
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.t_var_ind,
+                                                  curr_inequality.s_var_ind);
+            curr_inequality.power1 = (p1 - 1) / 2;
+            curr_inequality.power2 = (p2 - 1) / 2;
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            # Recurse on the reduced inequality
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        end  # if (mod(p1, 2) == 0)
+    else    # n is odd, and we must recurse differently.
+        if (mod(p1, 2) == 1)
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.t_var_ind,
+                                                  curr_inequality.left_var_ind);
+            curr_inequality.power1 = (p1 - 1) / 2;
+            curr_inequality.power2 = p2 / 2;
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        else    # mod(p2, 2) == 1
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.s_var_ind,
+                                                  curr_inequality.left_var_ind);
+            curr_inequality.power1 = p1 / 2;
+            curr_inequality.power2 = (p2 - 1) / 2;
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        end
+    end  # if mod(n, 2) == 0
 end
 
 # ReduceThirdOne(curr_inequality::InequalityExpression,
@@ -256,101 +256,99 @@ end
 function ReduceThirdOne(curr_inequality::InequalityExpression,
                         ineq_array::Array{SimpleInequalityExpression, 1},
                         var_array::Array{Int, 1})
-  p1 = curr_inequality.power1;
-  p2 = curr_inequality.power2;
-  p3 = curr_inequality.power3;
-  n = (p1 + p2 + p3);
-  @assert p3 == 1; # , "Must have third power 1");
-  @assert n >= 3; #  "Must have power n >= 3");
-  if (mod(n, 2) == 0)
-    # Exactly one of p1, p2 is odd, find it and reduce
-    if (mod(p1, 2) == 1)
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.t_var_ind,
-                                            curr_inequality.u_var_ind);
-      curr_inequality.power1 = (p1 - 1)/2;
-      curr_inequality.power2 = (p2 / 2);
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
-    else  # mod(p2, 2) == 1
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.s_var_ind,
-                                            curr_inequality.u_var_ind);
-      curr_inequality.power1 = p1 / 2;
-      curr_inequality.power2 = (p2 - 1) / 2;
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
+    p1 = curr_inequality.power1;
+    p2 = curr_inequality.power2;
+    p3 = curr_inequality.power3;
+    n = (p1 + p2 + p3);
+    @assert p3 == 1; # , "Must have third power 1");
+    @assert n >= 3; #  "Must have power n >= 3");
+    if (mod(n, 2) == 0)
+        # Exactly one of p1, p2 is odd, find it and reduce
+        if (mod(p1, 2) == 1)
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.t_var_ind,
+                                                  curr_inequality.u_var_ind);
+            curr_inequality.power1 = (p1 - 1)/2;
+            curr_inequality.power2 = (p2 / 2);
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        else    # mod(p2, 2) == 1
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.s_var_ind,
+                                                  curr_inequality.u_var_ind);
+            curr_inequality.power1 = p1 / 2;
+            curr_inequality.power2 = (p2 - 1) / 2;
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        end
+    else    # mod(n, 2) == 1
+        # Either both of p1, p2 are odd or both are even
+        if (mod(p1, 2) == 0)
+            new_ind = var_array[end] + 1;
+            new_ineq = SimpleInequalityExpression(new_ind,
+                                                  curr_inequality.left_var_ind,
+                                                  curr_inequality.u_var_ind);
+            curr_inequality.power1 = p1 / 2;
+            curr_inequality.power2 = p2 / 2;
+            curr_inequality.power3 = 1;
+            curr_inequality.u_var_ind = new_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, new_ineq),
+                                vcat(var_array, new_ind));
+        else    # mod(p1, 2) == 1, so mod(p2, 2) == 1
+            if (p1 == 1 && p2 == 1)
+                # There is a simpler reduction to return: we replace
+                #
+                # x^3 <= tsu
+                #
+                # with the three inequalities
+                #
+                # x^4 <= w^2 v^2,  w^2 <= ts,  v^2 <= ux,
+                #
+                # which is equivalent to x^2 <= wv, w^2 <= ts, v^2 <= ux
+                new_w_ind = var_array[end] + 1;
+                new_v_ind = var_array[end] + 2;
+                new_x_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
+                                                        new_w_ind, new_v_ind);
+                new_w_ineq = SimpleInequalityExpression(new_w_ind,
+                                                        curr_inequality.t_var_ind,
+                                                        curr_inequality.s_var_ind);
+                new_v_ineq = SimpleInequalityExpression(new_v_ind,
+                                                        curr_inequality.u_var_ind,
+                                                        curr_inequality.left_var_ind);
+                return (vcat(ineq_array, [new_x_ineq, new_w_ineq, new_v_ineq]),
+                        vcat(var_array, [new_w_ind, new_v_ind]));
+            else
+                # Do the full reduction
+                new_w_ind = var_array[end] + 1;
+                new_v_ind = var_array[end] + 2;
+                new_y_ind = var_array[end] + 3;
+                new_y_ineq = SimpleInequalityExpression(new_y_ind,
+                                                        new_w_ind, new_v_ind);
+                new_w_ineq = SimpleInequalityExpression(new_w_ind,
+                                                        curr_inequality.t_var_ind,
+                                                        curr_inequality.s_var_ind);
+                new_v_ineq = SimpleInequalityExpression(new_v_ind,
+                                                        curr_inequality.u_var_ind,
+                                                        curr_inequality.left_var_ind);
+                curr_inequality.power1 = (p1 - 1) / 2;
+                curr_inequality.power2 = (p2 - 1) / 2;
+                curr_inequality.power3 = 2;
+                curr_inequality.u_var_ind = new_y_ind;
+                return ReducePowers(curr_inequality,
+                                    vcat(ineq_array, [new_y_ineq, new_w_ineq, new_v_ineq]),
+                                    vcat(var_array, [new_w_ind, new_v_ind, new_y_ind]));
+            end
+        end
     end
-  else  # mod(n, 2) == 1
-    # Either both of p1, p2 are odd or both are even
-    if (mod(p1, 2) == 0)
-      new_ind = var_array[end] + 1;
-      new_ineq = SimpleInequalityExpression(new_ind,
-                                            curr_inequality.left_var_ind,
-                                            curr_inequality.u_var_ind);
-      curr_inequality.power1 = p1 / 2;
-      curr_inequality.power2 = p2 / 2;
-      curr_inequality.power3 = 1;
-      curr_inequality.u_var_ind = new_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, new_ineq),
-                          vcat(var_array, new_ind));
-    else  # mod(p1, 2) == 1, so mod(p2, 2) == 1
-      if (p1 == 1 && p2 == 1)
-        # There is a simpler reduction to return: we replace
-        #
-        # x^3 <= tsu
-        #
-        # with the three inequalities
-        #
-        # x^4 <= w^2 v^2,  w^2 <= ts,  v^2 <= ux,
-        #
-        # which is equivalent to x^2 <= wv, w^2 <= ts, v^2 <= ux
-        new_w_ind = var_array[end] + 1;
-        new_v_ind = var_array[end] + 2;
-        new_x_ineq = SimpleInequalityExpression(curr_inequality.left_var_ind,
-                                                new_w_ind, new_v_ind);
-        new_w_ineq = SimpleInequalityExpression(new_w_ind,
-                                                curr_inequality.t_var_ind,
-                                                curr_inequality.s_var_ind);
-        new_v_ineq = SimpleInequalityExpression(new_v_ind,
-                                                curr_inequality.u_var_ind,
-                                                curr_inequality.left_var_ind);
-        return (vcat(ineq_array, [new_x_ineq, new_w_ineq, new_v_ineq]),
-                vcat(var_array, [new_w_ind, new_v_ind]));
-      else
-        # Do the full reduction
-        new_w_ind = var_array[end] + 1;
-        new_v_ind = var_array[end] + 2;
-        new_y_ind = var_array[end] + 3;
-        new_y_ineq = SimpleInequalityExpression(new_y_ind,
-                                                new_w_ind, new_v_ind);
-        new_w_ineq = SimpleInequalityExpression(new_w_ind,
-                                                curr_inequality.t_var_ind,
-                                                curr_inequality.s_var_ind);
-        new_v_ineq = SimpleInequalityExpression(new_v_ind,
-                                                curr_inequality.u_var_ind,
-                                                curr_inequality.left_var_ind);
-        curr_inequality.power1 = (p1 - 1) / 2;
-        curr_inequality.power2 = (p2 - 1) / 2;
-        curr_inequality.power3 = 2;
-        curr_inequality.u_var_ind = new_y_ind;
-        return ReducePowers(curr_inequality,
-                            vcat(ineq_array,
-                                 [new_y_ineq, new_w_ineq, new_v_ineq]),
-                            vcat(var_array,
-                                 [new_w_ind, new_v_ind, new_y_ind]));
-      end
-    end
-  end
 end
 
 # ReduceThirdTwo(curr_inequality::InequalityExpression,
@@ -362,74 +360,74 @@ end
 function ReduceThirdTwo(curr_inequality::InequalityExpression,
                         ineq_array::Array{SimpleInequalityExpression, 1},
                         var_array::Array{Int, 1})
-  p1 = curr_inequality.power1;
-  p2 = curr_inequality.power2;
-  p3 = curr_inequality.power3;
-  n = (p1 + p2 + p3);
-  @assert p3 == 2;  # , "Must have third power 2");
-  @assert n >= 6;  # , "Must have power n >= 6");
-  @assert p1 >= 2 && p2 >= 2;  # , "Did not rearrange powers properly");
-  if (mod(n, 2) == 0)
-    # Either both p1, p2 are even or both are odd
-    if (mod(p1, 2) == 0)
-      # Simply reduce powers on everything by a factor of two
-      curr_inequality.power1 /= 2;
-      curr_inequality.power2 /= 2;
-      curr_inequality.power3 /= 2;
-      return ReducePowers(curr_inequality, ineq_array, var_array);
-    else
-      # Both are odd, so introduce two new variables
-      new_y_ind = var_array[end] + 1;
-      new_w_ind = var_array[end] + 2;
-      new_y_ineq = SimpleInequalityExpression(new_y_ind,
-                                              curr_inequality.u_var_ind,
-                                              new_w_ind);
-      new_w_ineq = SimpleInequalityExpression(new_w_ind,
-                                              curr_inequality.s_var_ind,
-                                              curr_inequality.t_var_ind);
-      curr_inequality.power1 = (p1 - 1) / 2;
-      curr_inequality.power2 = (p2 - 1) / 2;
-      curr_inequality.power3 = 2;
-      curr_inequality.u_var_ind = new_y_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, [new_y_ineq, new_w_ineq]),
-                          vcat(var_array, [new_y_ind, new_w_ind]));
+    p1 = curr_inequality.power1;
+    p2 = curr_inequality.power2;
+    p3 = curr_inequality.power3;
+    n = (p1 + p2 + p3);
+    @assert p3 == 2;  # , "Must have third power 2");
+    @assert n >= 6;  # , "Must have power n >= 6");
+    @assert p1 >= 2 && p2 >= 2;  # , "Did not rearrange powers properly");
+    if (mod(n, 2) == 0)
+        # Either both p1, p2 are even or both are odd
+        if (mod(p1, 2) == 0)
+            # Simply reduce powers on everything by a factor of two
+            curr_inequality.power1 /= 2;
+            curr_inequality.power2 /= 2;
+            curr_inequality.power3 /= 2;
+            return ReducePowers(curr_inequality, ineq_array, var_array);
+        else
+            # Both are odd, so introduce two new variables
+            new_y_ind = var_array[end] + 1;
+            new_w_ind = var_array[end] + 2;
+            new_y_ineq = SimpleInequalityExpression(new_y_ind,
+                                                    curr_inequality.u_var_ind,
+                                                    new_w_ind);
+            new_w_ineq = SimpleInequalityExpression(new_w_ind,
+                                                    curr_inequality.s_var_ind,
+                                                    curr_inequality.t_var_ind);
+            curr_inequality.power1 = (p1 - 1) / 2;
+            curr_inequality.power2 = (p2 - 1) / 2;
+            curr_inequality.power3 = 2;
+            curr_inequality.u_var_ind = new_y_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, [new_y_ineq, new_w_ineq]),
+                                vcat(var_array, [new_y_ind, new_w_ind]));
+        end
+    else    # mod(n, 2) == 1, so exactly one of p1 and p2 is odd
+        if (mod(p1, 2) == 1)
+            new_y_ind = var_array[end] + 1;
+            new_w_ind = var_array[end] + 2;
+            new_y_ineq = SimpleInequalityExpression(new_y_ind,
+                                                    curr_inequality.u_var_ind,
+                                                    new_w_ind);
+            new_w_ineq = SimpleInequalityExpression(new_w_ind,
+                                                    curr_inequality.left_var_ind,
+                                                    curr_inequality.t_var_ind);
+            curr_inequality.power1 = (p1 - 1) / 2;
+            curr_inequality.power2 = p2 / 2;
+            curr_inequality.power3 = 2;
+            curr_inequality.u_var_ind = new_y_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, [new_y_ineq, new_w_ineq]),
+                                vcat(var_array, [new_y_ind, new_w_ind]));
+        else    # mod(p2, 2) == 1
+            new_y_ind = var_array[end] + 1;
+            new_w_ind = var_array[end] + 2;
+            new_y_ineq = SimpleInequalityExpression(new_y_ind,
+                                                    curr_inequality.u_var_ind,
+                                                    new_w_ind);
+            new_w_ineq = SimpleInequalityExpression(new_w_ind,
+                                                    curr_inequality.left_var_ind,
+                                                    curr_inequality.s_var_ind);
+            curr_inequality.power1 = p1 / 2;
+            curr_inequality.power2 = (p2 - 1) / 2;
+            curr_inequality.power3 = 2;
+            curr_inequality.u_var_ind = new_y_ind;
+            return ReducePowers(curr_inequality,
+                                vcat(ineq_array, [new_y_ineq, new_w_ineq]),
+                                vcat(var_array, [new_y_ind, new_w_ind]));
+        end
     end
-  else  # mod(n, 2) == 1, so exactly one of p1 and p2 is odd
-    if (mod(p1, 2) == 1)
-      new_y_ind = var_array[end] + 1;
-      new_w_ind = var_array[end] + 2;
-      new_y_ineq = SimpleInequalityExpression(new_y_ind,
-                                              curr_inequality.u_var_ind,
-                                              new_w_ind);
-      new_w_ineq = SimpleInequalityExpression(new_w_ind,
-                                              curr_inequality.left_var_ind,
-                                              curr_inequality.t_var_ind);
-      curr_inequality.power1 = (p1 - 1) / 2;
-      curr_inequality.power2 = p2 / 2;
-      curr_inequality.power3 = 2;
-      curr_inequality.u_var_ind = new_y_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, [new_y_ineq, new_w_ineq]),
-                          vcat(var_array, [new_y_ind, new_w_ind]));
-    else  # mod(p2, 2) == 1
-      new_y_ind = var_array[end] + 1;
-      new_w_ind = var_array[end] + 2;
-      new_y_ineq = SimpleInequalityExpression(new_y_ind,
-                                              curr_inequality.u_var_ind,
-                                              new_w_ind);
-      new_w_ineq = SimpleInequalityExpression(new_w_ind,
-                                              curr_inequality.left_var_ind,
-                                              curr_inequality.s_var_ind);
-      curr_inequality.power1 = p1 / 2;
-      curr_inequality.power2 = (p2 - 1) / 2;
-      curr_inequality.power3 = 2;
-      curr_inequality.u_var_ind = new_y_ind;
-      return ReducePowers(curr_inequality,
-                          vcat(ineq_array, [new_y_ineq, new_w_ineq]),
-                          vcat(var_array, [new_y_ind, new_w_ind]));
-    end
-  end
 end
 
 end  # module PSOCP

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -3,48 +3,48 @@ export QolElemAtom, qol_elementwise, square, sumsquares, invpos, /
 export sign, monotonicity, curvature, conic_form!
 
 struct QolElemAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function QolElemAtom(x::AbstractExpr, y::AbstractExpr)
-    if x.size != y.size
-      error("elementwise quad over lin must take two arguments of the same size")
+    function QolElemAtom(x::AbstractExpr, y::AbstractExpr)
+        if x.size != y.size
+            error("elementwise quad over lin must take two arguments of the same size")
+        end
+        children = (x, y)
+        return new(:qol_elem, hash(children), children, x.size)
     end
-    children = (x, y)
-    return new(:qol_elem, hash(children), children, x.size)
-  end
 end
 
 function sign(q::QolElemAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(q::QolElemAtom)
-  return (sign(q.children[1]) * Nondecreasing(), Nonincreasing())
+    return (sign(q.children[1]) * Nondecreasing(), Nonincreasing())
 end
 
 function curvature(q::QolElemAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(q::QolElemAtom)
-  return (evaluate(q.children[1]).^2) ./ evaluate(q.children[2])
+    return (evaluate(q.children[1]).^2) ./ evaluate(q.children[2])
 end
 
 function conic_form!(q::QolElemAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, q)
-    sz = q.children[1].size
-    t = Variable(sz[1], sz[2])
-    qol_objective = conic_form!(t, unique_conic_forms)
-    x, y = q.children
-    conic_form!(SOCElemConstraint(y + t, y - t, 2 * x), unique_conic_forms)
-    # add implicit constraint y >= 0
-    conic_form!(y >= 0, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, q, qol_objective)
-  end
-  return get_conic_form(unique_conic_forms, q)
+    if !has_conic_form(unique_conic_forms, q)
+        sz = q.children[1].size
+        t = Variable(sz[1], sz[2])
+        qol_objective = conic_form!(t, unique_conic_forms)
+        x, y = q.children
+        conic_form!(SOCElemConstraint(y + t, y - t, 2 * x), unique_conic_forms)
+        # add implicit constraint y >= 0
+        conic_form!(y >= 0, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, q, qol_objective)
+    end
+    return get_conic_form(unique_conic_forms, q)
 end
 
 qol_elementwise(x::AbstractExpr, y::AbstractExpr) = QolElemAtom(x, y)
@@ -57,9 +57,9 @@ broadcasted(::typeof(/), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x
 sumsquares(x::AbstractExpr) = square(norm2(x))
 
 function square(x::AbstractExpr)
-  if sign(x) == ComplexSign()
-    error("Square of complex number is not DCP. Did you mean square_modulus?")
-  else
-    QolElemAtom(x, Constant(ones(x.size[1], x.size[2])))
-  end
+    if sign(x) == ComplexSign()
+        error("Square of complex number is not DCP. Did you mean square_modulus?")
+    else
+        QolElemAtom(x, Constant(ones(x.size[1], x.size[2])))
+    end
 end

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -1,26 +1,26 @@
 export quadform
 
 function quadform(x::Value, A::AbstractExpr)
-  return x' * A * x
+    return x' * A * x
 end
 
 function quadform(x::AbstractExpr, A::Value)
-  if length(size(A)) != 2 || size(A, 1) != size(A, 2)
-    error("Quadratic form only takes square matrices")
-  end
-  if !issymmetric(A)
-    error("Quadratic form only defined for symmetric matrices")
-  end
-  V = eigvals(Symmetric(Matrix(A)))
+    if length(size(A)) != 2 || size(A, 1) != size(A, 2)
+        error("Quadratic form only takes square matrices")
+    end
+    if !issymmetric(A)
+        error("Quadratic form only defined for symmetric matrices")
+    end
+    V = eigvals(Symmetric(Matrix(A)))
 
-  if all(V .>= 0)
-    factor = 1
-  elseif all(V .<= 0)
-    factor = -1
-  else
-    error("Quadratic forms supported only for semidefinite matrices")
-  end
+    if all(V .>= 0)
+        factor = 1
+    elseif all(V .<= 0)
+        factor = -1
+    else
+        error("Quadratic forms supported only for semidefinite matrices")
+    end
 
-  P = real(sqrt(Matrix(factor * A)))
-  return factor * square(norm2(P * x))
+    P = real(sqrt(Matrix(factor * A)))
+    return factor * square(norm2(P * x))
 end

--- a/src/atoms/second_order_cone/quadoverlin.jl
+++ b/src/atoms/second_order_cone/quadoverlin.jl
@@ -2,47 +2,47 @@ export QuadOverLinAtom, quadoverlin
 export sign, monotonicity, curvature, conic_form!
 
 struct QuadOverLinAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function QuadOverLinAtom(x::AbstractExpr, y::AbstractExpr)
-    if x.size[2] != 1 && y.size != (1, 1)
-      error("quad over lin arguments must be a vector and a scalar")
+    function QuadOverLinAtom(x::AbstractExpr, y::AbstractExpr)
+        if x.size[2] != 1 && y.size != (1, 1)
+            error("quad over lin arguments must be a vector and a scalar")
+        end
+        children = (x,y)
+        return new(:qol, hash(children), children, (1, 1))
     end
-    children = (x,y)
-    return new(:qol, hash(children), children, (1, 1))
-  end
 end
 
 function sign(q::QuadOverLinAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(q::QuadOverLinAtom)
-  return (sign(q.children[1]) * Nondecreasing(), Nonincreasing())
+    return (sign(q.children[1]) * Nondecreasing(), Nonincreasing())
 end
 
 function curvature(q::QuadOverLinAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(q::QuadOverLinAtom)
-  x = evaluate(q.children[1])
-  return x'*x / evaluate(q.children[2])
+    x = evaluate(q.children[1])
+    return x'*x / evaluate(q.children[2])
 end
 
 function conic_form!(q::QuadOverLinAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, q)
-    t = Variable()
-    qol_objective = conic_form!(t, unique_conic_forms)
-    x, y = q.children
-    conic_form!(SOCConstraint(y + t, y - t, 2 * x), unique_conic_forms)
-    conic_form!(y >= 0, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, q, qol_objective)
-  end
-  return get_conic_form(unique_conic_forms, q)
+    if !has_conic_form(unique_conic_forms, q)
+        t = Variable()
+        qol_objective = conic_form!(t, unique_conic_forms)
+        x, y = q.children
+        conic_form!(SOCConstraint(y + t, y - t, 2 * x), unique_conic_forms)
+        conic_form!(y >= 0, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, q, qol_objective)
+    end
+    return get_conic_form(unique_conic_forms, q)
 end
 
 quadoverlin(x::AbstractExpr, y::AbstractExpr) = QuadOverLinAtom(x, y)

--- a/src/atoms/second_order_cone/rationalnorm.jl
+++ b/src/atoms/second_order_cone/rationalnorm.jl
@@ -16,21 +16,21 @@ export rationalnorm
 ### k-norm for rational k
 
 struct RationalNormAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr}
-  size::Tuple{Int, Int}
-  k::Rational{Int64}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr}
+    size::Tuple{Int, Int}
+    k::Rational{Int64}
 
-  function RationalNormAtom(x::AbstractExpr, k::Rational{Int})
-    children = (x,)
-    k >= 1 || error("p-norms not defined for p < 1")
-    return new(:rationalnorm, hash(children), children, (1,1), k)
-  end
+    function RationalNormAtom(x::AbstractExpr, k::Rational{Int})
+        children = (x,)
+        k >= 1 || error("p-norms not defined for p < 1")
+        return new(:rationalnorm, hash(children), children, (1,1), k)
+    end
 end
 
 function sign(x::RationalNormAtom)
-  return Positive()
+    return Positive()
 end
 
 # The monotonicity
@@ -39,11 +39,11 @@ function monotonicity(x::RationalNormAtom)
 end
 
 function curvature(x::RationalNormAtom)
-  return ConvexVexity()
+    return ConvexVexity()
 end
 
 function evaluate(x::RationalNormAtom)
-  return sum(abs.(evaluate(x.children[1])).^x.k)^(1/x.k);
+    return sum(abs.(evaluate(x.children[1])).^x.k)^(1/x.k);
 end
 
 
@@ -63,69 +63,68 @@ end
 # delineated in Duchi & Namkoong (2014) to reduce the last constraint
 # into SOC constraints.
 function conic_form!(x::RationalNormAtom, unique_conic_forms)
-  if !has_conic_form(unique_conic_forms, x)
-    # Add extra variables and constraints
-    d = length(x.children[1]);
-    v = Variable(d, 1);
-    s = Variable(d, 1);
-    t = Variable(1);
+    if !has_conic_form(unique_conic_forms, x)
+        # Add extra variables and constraints
+        d = length(x.children[1]);
+        v = Variable(d, 1);
+        s = Variable(d, 1);
+        t = Variable(1);
 
-    # Adding non-negativity constraints for all variables to problem
-    obj = conic_form!(t, unique_conic_forms);
-    conic_form!(v >= abs(x.children[1]), unique_conic_forms)
-    # conic_form!(t >= 0, unique_conic_forms)
-    conic_form!(s >= 0, unique_conic_forms)
-    conic_form!(sum(s) <= t, unique_conic_forms)
+        # Adding non-negativity constraints for all variables to problem
+        obj = conic_form!(t, unique_conic_forms);
+        conic_form!(v >= abs(x.children[1]), unique_conic_forms)
+        # conic_form!(t >= 0, unique_conic_forms)
+        conic_form!(s >= 0, unique_conic_forms)
+        conic_form!(sum(s) <= t, unique_conic_forms)
 
-    # Reduce to SOC constraints (get powers for each element)
-    num = Int(numerator(x.k));
-    denom = Int(denominator(x.k));
-    # Construct list of inequalities of form u^2 <= vw, where the list
-    # is given by triples in ineq_list.
-    (ineq_list,
-     var_list) = psocp.ProductToSimpleInequalities(denom,
-                                                   num - denom);
-    if (length(ineq_list) > 10)
-      @warn string("Rational norm generating ", length(ineq_list),
-                  " intermediate constraints.\n\tIncreasing ",
-                  ":max_iters or decreasing solver tolerance\n\tmay give ",
-                  "more accurate solutions")
+        # Reduce to SOC constraints (get powers for each element)
+        num = Int(numerator(x.k));
+        denom = Int(denominator(x.k));
+        # Construct list of inequalities of form u^2 <= vw, where the list
+        # is given by triples in ineq_list.
+        (ineq_list,
+         var_list) = psocp.ProductToSimpleInequalities(denom, num - denom);
+        if (length(ineq_list) > 10)
+            @warn string("Rational norm generating ", length(ineq_list),
+                         " intermediate constraints.\n\tIncreasing ",
+                         ":max_iters or decreasing solver tolerance\n\tmay give ",
+                         "more accurate solutions")
+        end
+        # u corresponds to "introduced" variables; make a matrix of them
+        # and then add equality constraints for the first and second
+        # variable in the matrix (i.e. first and second columns), as they
+        # correspond to s and v.
+        u = Variable(length(var_list), d);
+        # v is the first variable
+        conic_form!(v == u[var_list[1], :]', unique_conic_forms)
+        # s[jj] is the second variable
+        conic_form!(s == u[var_list[2], :]', unique_conic_forms)
+
+        for jj = 1:d
+            # t is the third variable
+            conic_form!(t == u[var_list[3], jj], unique_conic_forms)
+            for ii = 1:length(ineq_list)
+                temp1 = u[ineq_list[ii].left_var_ind, jj];
+                temp2 = u[ineq_list[ii].t_var_ind, jj];
+                temp3 = u[ineq_list[ii].s_var_ind, jj];
+                # Want: t1^2 <= t2 * t3, so add constraints of form
+                # norm([2 * t1, t2 - t3], 2) <= t2 + t3.
+                conic_form!(SOCElemConstraint(temp2 + temp3,
+                                              temp2 - temp3, 2 * temp1),
+                            unique_conic_forms);
+            end
+        end
+        cache_conic_form!(unique_conic_forms, x, obj)
     end
-    # u corresponds to "introduced" variables; make a matrix of them
-    # and then add equality constraints for the first and second
-    # variable in the matrix (i.e. first and second columns), as they
-    # correspond to s and v.
-    u = Variable(length(var_list), d);
-    # v is the first variable
-    conic_form!(v == u[var_list[1], :]', unique_conic_forms)
-    # s[jj] is the second variable
-    conic_form!(s == u[var_list[2], :]', unique_conic_forms)
-
-    for jj = 1:d
-      # t is the third variable
-      conic_form!(t == u[var_list[3], jj], unique_conic_forms)
-      for ii = 1:length(ineq_list)
-        temp1 = u[ineq_list[ii].left_var_ind, jj];
-        temp2 = u[ineq_list[ii].t_var_ind, jj];
-        temp3 = u[ineq_list[ii].s_var_ind, jj];
-        # Want: t1^2 <= t2 * t3, so add constraints of form
-        # norm([2 * t1, t2 - t3], 2) <= t2 + t3.
-        conic_form!(SOCElemConstraint(temp2 + temp3,
-                                      temp2 - temp3, 2 * temp1),
-                    unique_conic_forms);
-      end
-    end
-    cache_conic_form!(unique_conic_forms, x, obj)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 function rationalnorm(x::AbstractExpr, k::Rational{Int})
-  if sign(x) == ComplexSign()
-    row,col = size(x)
-    if row == 1 || col == 1
-      return RationalNormAtom(abs(x),k)
+    if sign(x) == ComplexSign()
+        row,col = size(x)
+        if row == 1 || col == 1
+            return RationalNormAtom(abs(x),k)
+        end
+    else
+        return RationalNormAtom(x,k)
     end
-  else
-    return RationalNormAtom(x,k)
-  end
 end

--- a/src/atoms/second_order_cone/scaledgeomean.jl
+++ b/src/atoms/second_order_cone/scaledgeomean.jl
@@ -3,57 +3,57 @@ export ScaledGeoMeanAtom, scaledgeomean, sqrt
 export sign, monotonicity, curvature, conic_form!
 
 function power_of_2_gt(n::Int)
-  Int(2^ceil(log(2,n)))
+    Int(2^ceil(log(2,n)))
 end
 
 struct ScaledGeoMeanAtom <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr}
-  size::Tuple{Int, Int}
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr}
+    size::Tuple{Int, Int}
 
-  function ScaledGeoMeanAtom(x::AbstractExpr)
-    children = (x)
-    return new(:scaledgeomean, hash(children), children, x.size)
-  end
+    function ScaledGeoMeanAtom(x::AbstractExpr)
+        children = (x)
+        return new(:scaledgeomean, hash(children), children, x.size)
+    end
 end
 
 function sign(q::ScaledGeoMeanAtom)
-  return Positive()
+    return Positive()
 end
 
 function monotonicity(q::ScaledGeoMeanAtom)
-  return (Nondecreasing(),)
+    return (Nondecreasing(),)
 end
 
 function curvature(q::ScaledGeoMeanAtom)
-  return ConcaveVexity()
+    return ConcaveVexity()
 end
 
 function evaluate(q::ScaledGeoMeanAtom)
-  nbar = power_of_2_gt(length(q.children))
-  return prod(evaluate(q.children[1]))^(1/nbar)
+    nbar = power_of_2_gt(length(q.children))
+    return prod(evaluate(q.children[1]))^(1/nbar)
 end
 
 function conic_form!(q::ScaledGeoMeanAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, q)
-    t = Variable()
-    qol_objective = conic_form!(t, unique_conic_forms)
-    x, y = q.children
-    conic_form!(SOCElemConstraint(y + x, y - x, 2 * t), unique_conic_forms)
-    conic_form!(x >= 0, unique_conic_forms)
-    conic_form!(y >= 0, unique_conic_forms)
-    cache_conic_form!(unique_conic_forms, q, qol_objective)
-  end
-  return get_conic_form(unique_conic_forms, q)
+    if !has_conic_form(unique_conic_forms, q)
+        t = Variable()
+        qol_objective = conic_form!(t, unique_conic_forms)
+        x, y = q.children
+        conic_form!(SOCElemConstraint(y + x, y - x, 2 * t), unique_conic_forms)
+        conic_form!(x >= 0, unique_conic_forms)
+        conic_form!(y >= 0, unique_conic_forms)
+        cache_conic_form!(unique_conic_forms, q, qol_objective)
+    end
+    return get_conic_form(unique_conic_forms, q)
 end
 
 function scaledgeomean(x::AbstractExpr)
-  if length(x) > 2
-    return ScaledGeoMeanAtom(x)
-  elseif length(x) == 2
-    return geomean(x[1],x[2])
-  else
-    return x
-  end
+    if length(x) > 2
+        return ScaledGeoMeanAtom(x)
+    elseif length(x) == 2
+        return geomean(x[1],x[2])
+    else
+        return x
+    end
 end

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -6,63 +6,63 @@ export Constant
 export vexity, evaluate, sign, conic_form!
 
 struct Constant <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  value::Value
-  size::Tuple{Int, Int}
-  vexity::Vexity
-  sign::Sign
+    head::Symbol
+    id_hash::UInt64
+    value::Value
+    size::Tuple{Int, Int}
+    vexity::Vexity
+    sign::Sign
 
-  function Constant(x::Value, sign::Sign)
-    sz = (size(x, 1), size(x, 2))
-    return new(:constant, objectid(x), x, sz, ConstVexity(), sign)
-  end
-
-  function Constant(x::Value, check_sign::Bool=true)
-    if check_sign
-      if !isreal(x)
-        return Constant(x, ComplexSign())
-      elseif all(xi >= 0 for xi in x)
-        return Constant(x, Positive())
-      elseif all(xi <= 0 for xi in x)
-        return Constant(x, Negative())
-      end
+    function Constant(x::Value, sign::Sign)
+        sz = (size(x, 1), size(x, 2))
+        return new(:constant, objectid(x), x, sz, ConstVexity(), sign)
     end
-    return Constant(x, NoSign())
-  end
+
+    function Constant(x::Value, check_sign::Bool=true)
+        if check_sign
+            if !isreal(x)
+                return Constant(x, ComplexSign())
+            elseif all(xi >= 0 for xi in x)
+                return Constant(x, Positive())
+            elseif all(xi <= 0 for xi in x)
+                return Constant(x, Negative())
+            end
+        end
+        return Constant(x, NoSign())
+    end
 end
-#### Constant Definition end   ##### 
+#### Constant Definition end     #####
 
 function vexity(x::Constant)
-  return x.vexity
+    return x.vexity
 end
 
 function evaluate(x::Constant)
-  return x.value
+    return x.value
 end
 
 function sign(x::Constant)
-  return x.sign
+    return x.sign
 end
 
 
 function real_conic_form(x::Constant)
-  return vec([real(x.value);])
+    return vec([real(x.value);])
 end
 
 function imag_conic_form(x::Constant)
-  return im*vec([imag(x.value);])
+    return im*vec([imag(x.value);])
 end
 
 
-  
+
 function conic_form!(x::Constant, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    #real_Value = real_conic_form(x)
-    #imag_Value = imag_conic_form(x) 
-    objective = ConicObj()
-    objective[objectid(:constant)] = (real_conic_form(x), imag_conic_form(x))
-    cache_conic_form!(unique_conic_forms, x, objective)
-  end
-  return get_conic_form(unique_conic_forms, x)
+    if !has_conic_form(unique_conic_forms, x)
+        #real_Value = real_conic_form(x)
+        #imag_Value = imag_conic_form(x)
+        objective = ConicObj()
+        objective[objectid(:constant)] = (real_conic_form(x), imag_conic_form(x))
+        cache_conic_form!(unique_conic_forms, x, objective)
+    end
+    return get_conic_form(unique_conic_forms, x)
 end

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -6,54 +6,54 @@ conic_constr_to_constr = Dict{ConicConstr, Constraint}()
 
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  lhs::AbstractExpr
-  rhs::AbstractExpr
-  size::Tuple{Int, Int}
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    lhs::AbstractExpr
+    rhs::AbstractExpr
+    size::Tuple{Int, Int}
+    dual::ValueOrNothing
 
-  function EqConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
-    if lhs.size == rhs.size || lhs.size == (1, 1)
-      sz = rhs.size
-    elseif rhs.size == (1, 1)
-      sz = lhs.size
-    else
-      error("Cannot create equality constraint between expressions of size $(lhs.size) and $(rhs.size)")
+    function EqConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
+        if lhs.size == rhs.size || lhs.size == (1, 1)
+            sz = rhs.size
+        elseif rhs.size == (1, 1)
+            sz = lhs.size
+        else
+            error("Cannot create equality constraint between expressions of size $(lhs.size) and $(rhs.size)")
+        end
+        id_hash = hash((lhs, rhs, :(==)))
+        return new(:(==), id_hash, lhs, rhs, sz, nothing)
     end
-    id_hash = hash((lhs, rhs, :(==)))
-    return new(:(==), id_hash, lhs, rhs, sz, nothing)
-  end
 end
 
 function vexity(c::EqConstraint)
-  vex = vexity(c.lhs) + (-vexity(c.rhs))
-  # You can't have equality constraints with concave/convex expressions
-  if vex == ConvexVexity() || vex == ConcaveVexity()
-    vex = NotDcp()
-  end
-  return vex
+    vex = vexity(c.lhs) + (-vexity(c.rhs))
+    # You can't have equality constraints with concave/convex expressions
+    if vex == ConvexVexity() || vex == ConcaveVexity()
+        vex = NotDcp()
+    end
+    return vex
 end
 
 function conic_form!(c::EqConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    if !(sign(c.lhs) == ComplexSign() || sign(c.rhs) == ComplexSign())
-    
-      expr = c.lhs - c.rhs
-      objective = conic_form!(expr, unique_conic_forms)
-      new_constraint = ConicConstr([objective], :Zero, [c.size[1] * c.size[2]])
-      conic_constr_to_constr[new_constraint] = c
-    else
-      real_expr = real(c.lhs - c.rhs)
-      imag_expr = imag(c.lhs - c.rhs)
-      real_objective = conic_form!(real_expr, unique_conic_forms)
-      imag_objective = conic_form!(imag_expr, unique_conic_forms)
-      new_constraint = ConicConstr([real_objective, imag_objective], :Zero, [c.size[1] * c.size[2], c.size[1] * c.size[2]])
-      conic_constr_to_constr[new_constraint] = c
+    if !has_conic_form(unique_conic_forms, c)
+        if !(sign(c.lhs) == ComplexSign() || sign(c.rhs) == ComplexSign())
+
+            expr = c.lhs - c.rhs
+            objective = conic_form!(expr, unique_conic_forms)
+            new_constraint = ConicConstr([objective], :Zero, [c.size[1] * c.size[2]])
+            conic_constr_to_constr[new_constraint] = c
+        else
+            real_expr = real(c.lhs - c.rhs)
+            imag_expr = imag(c.lhs - c.rhs)
+            real_objective = conic_form!(real_expr, unique_conic_forms)
+            imag_objective = conic_form!(imag_expr, unique_conic_forms)
+            new_constraint = ConicConstr([real_objective, imag_objective], :Zero, [c.size[1] * c.size[2], c.size[1] * c.size[2]])
+            conic_constr_to_constr[new_constraint] = c
+        end
+        cache_conic_form!(unique_conic_forms, c, new_constraint)
     end
-    cache_conic_form!(unique_conic_forms, c, new_constraint)
-  end
-  return get_conic_form(unique_conic_forms, c)
+    return get_conic_form(unique_conic_forms, c)
 end
 
 ==(lhs::AbstractExpr, rhs::AbstractExpr) = EqConstraint(lhs, rhs)
@@ -63,47 +63,47 @@ end
 
 ### Linear inequality constraints
 mutable struct LtConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  lhs::AbstractExpr
-  rhs::AbstractExpr
-  size::Tuple{Int, Int}
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    lhs::AbstractExpr
+    rhs::AbstractExpr
+    size::Tuple{Int, Int}
+    dual::ValueOrNothing
 
-  function LtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
-    if sign(lhs) == ComplexSign() || sign(rhs) == ComplexSign()
-      error("Cannot create inequality constraint between expressions of sign $(sign(lhs)) and $(sign(rhs))")
-    else
-      if lhs.size == rhs.size || lhs.size == (1, 1)
-        sz = rhs.size
-      elseif rhs.size == (1, 1)
-        sz = lhs.size
-      else
-        error("Cannot create inequality constraint between expressions of size $(lhs.size) and $(rhs.size)")
-      end
+    function LtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
+        if sign(lhs) == ComplexSign() || sign(rhs) == ComplexSign()
+            error("Cannot create inequality constraint between expressions of sign $(sign(lhs)) and $(sign(rhs))")
+        else
+            if lhs.size == rhs.size || lhs.size == (1, 1)
+                sz = rhs.size
+            elseif rhs.size == (1, 1)
+                sz = lhs.size
+            else
+                error("Cannot create inequality constraint between expressions of size $(lhs.size) and $(rhs.size)")
+            end
+        end
+        id_hash = hash((lhs, rhs, :(<=)))
+        return new(:(<=), id_hash, lhs, rhs, sz, nothing)
     end
-    id_hash = hash((lhs, rhs, :(<=)))
-    return new(:(<=), id_hash, lhs, rhs, sz, nothing)
-  end
 end
 
 function vexity(c::LtConstraint)
-  vex = vexity(c.lhs) + (-vexity(c.rhs))
-  if vex == ConcaveVexity()
-    vex = NotDcp()
-  end
-  return vex
+    vex = vexity(c.lhs) + (-vexity(c.rhs))
+    if vex == ConcaveVexity()
+        vex = NotDcp()
+    end
+    return vex
 end
 
 function conic_form!(c::LtConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    expr = c.rhs - c.lhs
-    objective = conic_form!(expr, unique_conic_forms)
-    new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
-    conic_constr_to_constr[new_constraint] = c
-    cache_conic_form!(unique_conic_forms, c, new_constraint)
-  end
-  return get_conic_form(unique_conic_forms, c)
+    if !has_conic_form(unique_conic_forms, c)
+        expr = c.rhs - c.lhs
+        objective = conic_form!(expr, unique_conic_forms)
+        new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
+        conic_constr_to_constr[new_constraint] = c
+        cache_conic_form!(unique_conic_forms, c, new_constraint)
+    end
+    return get_conic_form(unique_conic_forms, c)
 end
 
 <=(lhs::AbstractExpr, rhs::AbstractExpr) = LtConstraint(lhs, rhs)
@@ -115,47 +115,47 @@ end
 
 
 mutable struct GtConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  lhs::AbstractExpr
-  rhs::AbstractExpr
-  size::Tuple{Int, Int}
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    lhs::AbstractExpr
+    rhs::AbstractExpr
+    size::Tuple{Int, Int}
+    dual::ValueOrNothing
 
-  function GtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
-    if sign(lhs) == ComplexSign() || sign(rhs) == ComplexSign()
-      error("Cannot create inequality constraint between expressions of sign $(sign(lhs)) and $(sign(rhs))")
-    else
-      if lhs.size == rhs.size || lhs.size == (1, 1)
-        sz = rhs.size
-      elseif rhs.size == (1, 1)
-        sz = lhs.size
-      else
-        error("Cannot create inequality constraint between expressions of size $(lhs.size) and $(rhs.size)")
-      end
+    function GtConstraint(lhs::AbstractExpr, rhs::AbstractExpr)
+        if sign(lhs) == ComplexSign() || sign(rhs) == ComplexSign()
+            error("Cannot create inequality constraint between expressions of sign $(sign(lhs)) and $(sign(rhs))")
+        else
+            if lhs.size == rhs.size || lhs.size == (1, 1)
+                sz = rhs.size
+            elseif rhs.size == (1, 1)
+                sz = lhs.size
+            else
+                error("Cannot create inequality constraint between expressions of size $(lhs.size) and $(rhs.size)")
+            end
+        end
+        id_hash = hash((lhs, rhs, :(>=)))
+        return new(:(>=), id_hash, lhs, rhs, sz, nothing)
     end
-    id_hash = hash((lhs, rhs, :(>=)))
-    return new(:(>=), id_hash, lhs, rhs, sz, nothing)
-  end
 end
 
 function vexity(c::GtConstraint)
-  vex = -vexity(c.lhs) + (vexity(c.rhs))
-  if vex == ConcaveVexity()
-    vex = NotDcp()
-  end
-  return vex
+    vex = -vexity(c.lhs) + (vexity(c.rhs))
+    if vex == ConcaveVexity()
+        vex = NotDcp()
+    end
+    return vex
 end
 
 function conic_form!(c::GtConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    expr = c.lhs - c.rhs
-    objective = conic_form!(expr, unique_conic_forms)
-    new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
-    conic_constr_to_constr[new_constraint] = c
-    cache_conic_form!(unique_conic_forms, c, new_constraint)
-  end
-  return get_conic_form(unique_conic_forms, c)
+    if !has_conic_form(unique_conic_forms, c)
+        expr = c.lhs - c.rhs
+        objective = conic_form!(expr, unique_conic_forms)
+        new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
+        conic_constr_to_constr[new_constraint] = c
+        cache_conic_form!(unique_conic_forms, c, new_constraint)
+    end
+    return get_conic_form(unique_conic_forms, c)
 end
 
 >=(lhs::AbstractExpr, rhs::AbstractExpr) = GtConstraint(lhs, rhs)
@@ -166,11 +166,11 @@ end
 >(lhs::Value, rhs::AbstractExpr) = >=(Constant(lhs), rhs)
 
 function +(constraints_one::Array{<:Constraint}, constraints_two::Array{<:Constraint})
-  constraints = append!(Constraint[], constraints_one)
-  return append!(constraints, constraints_two)
+    constraints = append!(Constraint[], constraints_one)
+    return append!(constraints, constraints_two)
 end
 +(constraint_one::Constraint, constraint_two::Constraint) = [constraint_one] + [constraint_two]
 +(constraint_one::Constraint, constraints_two::Array{<:Constraint}) =
-  [constraint_one] + constraints_two
+    [constraint_one] + constraints_two
 +(constraints_one::Array{<:Constraint}, constraint_two::Constraint) =
-  constraints_one + [constraint_two]
+    constraints_one + [constraint_two]

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -2,21 +2,21 @@ export ExpConstraint, conic_form!, vexity
 
 ### (Primal) exponential cone constraint ExpConstraint(x,y,z) => y exp(x/y) <= z & y>=0
 struct ExpConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple{AbstractExpr, AbstractExpr, AbstractExpr} # (x, y, z)
-  size::Tuple{Int, Int}
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple{AbstractExpr, AbstractExpr, AbstractExpr} # (x, y, z)
+    size::Tuple{Int, Int}
+    dual::ValueOrNothing
 
-  function ExpConstraint(x::AbstractExpr, y::AbstractExpr, z::AbstractExpr)
-    @assert(x.size == y.size == z.size,
-           "Exponential constraint requires x, y, and z to be of same size")
-    # @assert(x.size == (1,1),
-    #        "Exponential constraint requires x, y, and z to be scalar for now")
-    sz = x.size
-    id_hash = hash((x,y,z, :exp))
-    return new(:exp, id_hash, (x, y, z), sz, nothing)
-  end
+    function ExpConstraint(x::AbstractExpr, y::AbstractExpr, z::AbstractExpr)
+        @assert(x.size == y.size == z.size,
+                "Exponential constraint requires x, y, and z to be of same size")
+        # @assert(x.size == (1,1),
+        #         "Exponential constraint requires x, y, and z to be scalar for now")
+        sz = x.size
+        id_hash = hash((x,y,z, :exp))
+        return new(:exp, id_hash, (x, y, z), sz, nothing)
+    end
 end
 
 ExpConstraint(x::AbstractExpr, y, z::AbstractExpr) = ExpConstraint(x, Constant(y), z)
@@ -24,40 +24,40 @@ ExpConstraint(x::AbstractExpr, y::AbstractExpr, z) = ExpConstraint(x, y, Constan
 ExpConstraint(x, y::AbstractExpr, z::AbstractExpr) = ExpConstraint(Constant(x), y, z)
 
 function vexity(c::ExpConstraint)
-  # TODO: check these...
-  if vexity(c.x) == ConcaveVexity()
-    error("Exponential constraint requires x to be convex")
-  end
-  if vexity(c.y)!=ConstVexity()
-    error("Exponential constraint requires y to be constant")
-  end
-  if vexity(c.z) == ConvexVexity()
-    error("Exponential constraint requires z to be concave")
-  end
-  return ConvexVexity()
+    # TODO: check these...
+    if vexity(c.x) == ConcaveVexity()
+        error("Exponential constraint requires x to be convex")
+    end
+    if vexity(c.y)!=ConstVexity()
+        error("Exponential constraint requires y to be constant")
+    end
+    if vexity(c.z) == ConvexVexity()
+        error("Exponential constraint requires z to be concave")
+    end
+    return ConvexVexity()
 end
 
 function conic_form!(c::ExpConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    conic_constrs = ConicConstr[]
-    if c.size == (1, 1)
-      objectives = Array{ConicObj}(undef, 3)
-      for iobj=1:3
-        objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
-      end
-      push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))
-    else
-      for i=1:c.size[1]
-        for j=1:c.size[2]
-          objectives = Array{ConicObj}(undef, 3)
-          for iobj=1:3
-            objectives[iobj] = conic_form!(c.children[iobj][i,j], unique_conic_forms)
-          end
-          push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))
+    if !has_conic_form(unique_conic_forms, c)
+        conic_constrs = ConicConstr[]
+        if c.size == (1, 1)
+            objectives = Array{ConicObj}(undef, 3)
+            for iobj=1:3
+                objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
+            end
+            push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))
+        else
+            for i=1:c.size[1]
+                for j=1:c.size[2]
+                    objectives = Array{ConicObj}(undef, 3)
+                    for iobj=1:3
+                        objectives[iobj] = conic_form!(c.children[iobj][i,j], unique_conic_forms)
+                    end
+                    push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))
+                end
+            end
         end
-      end
+        cache_conic_form!(unique_conic_forms, c, conic_constrs)
     end
-    cache_conic_form!(unique_conic_forms, c, conic_constrs)
-  end
-  return get_conic_form(unique_conic_forms, c)
+    return get_conic_form(unique_conic_forms, c)
 end

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -6,29 +6,29 @@ export SDPConstraint, isposdef, in, ⪰, ⪯
 
 # TODO: Terrible documentation. Please fix.
 struct SDPConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  child::AbstractExpr
-  size::Tuple{Int, Int}
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    child::AbstractExpr
+    size::Tuple{Int, Int}
+    dual::ValueOrNothing
 
-  function SDPConstraint(child::AbstractExpr)
-    sz = child.size
-    if sz[1] != sz[2]
-      error("Positive semidefinite expressions must be square")
+    function SDPConstraint(child::AbstractExpr)
+        sz = child.size
+        if sz[1] != sz[2]
+            error("Positive semidefinite expressions must be square")
+        end
+        id_hash = hash((child, :sdp))
+        return new(:sdp, id_hash, child, sz, nothing)
     end
-    id_hash = hash((child, :sdp))
-    return new(:sdp, id_hash, child, sz, nothing)
-  end
 end
 
 function vexity(c::SDPConstraint)
-  vex = vexity(c.child)
-  if vex == AffineVexity() || vex == ConstVexity()
-    return AffineVexity()
-  else
-    return NotDcp()
-  end
+    vex = vexity(c.child)
+    if vex == AffineVexity() || vex == ConstVexity()
+        return AffineVexity()
+    else
+        return NotDcp()
+    end
 end
 
 # users specify SDPs as `A in :SDP` where A is an n x n square matrix
@@ -37,114 +37,114 @@ end
 # and we need the corresponding upper elements to match the lower elements,
 # which we enforce via equality constraints
 function conic_form!(c::SDPConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  # TODO:
-    # 1) propagate dual values
-    # 2) presolve to eliminate (many) variables --- variables on upper triangular part often don't matter at all
-  if !has_conic_form(unique_conic_forms, c)
-    n = c.size[1]
-    # construct linear indices to pick out the lower triangular part (including diagonal),
-    # the upper triangular part (not including diagonal)
-    # and the corresponding entries in the lower triangular part, so
-    # symmetry => c.child[upperpart]
-    # scale off-diagonal elements by sqrt(2)
-    rescale = sqrt(2)*tril(ones(n,n))
-    rescale[diagind(n, n)] .= 1.0
-    diagandlowerpart = findall(!iszero, vec(rescale))
-    lowerpart = Array{Int}(undef, div(n*(n-1),2))
-    upperpart = Array{Int}(undef, div(n*(n-1),2))
-    klower = 0
-    # diagandlowerpart in column-major order:
-    # ie the (1,1), (2,1), ..., (n,1), (2,2), (3,2), ...
-    # consider using  and find(triu(ones(3,3)))
-    for j = 1:n
-      for i = j+1:n
-        klower += 1
-        upperpart[klower] = n*(i-1) + j # (j,i)th element
-        lowerpart[klower] = n*(j-1) + i # (i,j)th element
-      end
+    # TODO:
+        # 1) propagate dual values
+        # 2) presolve to eliminate (many) variables --- variables on upper triangular part often don't matter at all
+    if !has_conic_form(unique_conic_forms, c)
+        n = c.size[1]
+        # construct linear indices to pick out the lower triangular part (including diagonal),
+        # the upper triangular part (not including diagonal)
+        # and the corresponding entries in the lower triangular part, so
+        # symmetry => c.child[upperpart]
+        # scale off-diagonal elements by sqrt(2)
+        rescale = sqrt(2)*tril(ones(n,n))
+        rescale[diagind(n, n)] .= 1.0
+        diagandlowerpart = findall(!iszero, vec(rescale))
+        lowerpart = Array{Int}(undef, div(n*(n-1),2))
+        upperpart = Array{Int}(undef, div(n*(n-1),2))
+        klower = 0
+        # diagandlowerpart in column-major order:
+        # ie the (1,1), (2,1), ..., (n,1), (2,2), (3,2), ...
+        # consider using  and find(triu(ones(3,3)))
+        for j = 1:n
+            for i = j+1:n
+                klower += 1
+                upperpart[klower] = n*(i-1) + j # (j,i)th element
+                lowerpart[klower] = n*(j-1) + i # (i,j)th element
+            end
+        end
+        objective = conic_form!((broadcast(*,rescale,c.child))[diagandlowerpart], unique_conic_forms)
+        sdp_constraint = ConicConstr([objective], :SDP, [div(n*(n+1),2)])
+        cache_conic_form!(unique_conic_forms, c, sdp_constraint)
+        # make sure upper and lower triangular part match in the solution
+        # note that this introduces all-zero rows into the constraint matrix
+        # if the matrix we require to be PSD has already been constructed to be symmetric
+        equality_constraint = conic_form!(c.child[lowerpart] == c.child[upperpart], unique_conic_forms)
+
+        # for computing duals --- won't work b/c
+            # 1) sizes are wrong (will be n(n+1)/2, expects n^2), and
+            # 2) the "correct" dual is the sum of the sdp dual and the equality constraint dual (so yes, dual of sdp constraint is *not* symmetric)
+        # conic_constr_to_constr[sdp_constraint] = c
+
     end
-    objective = conic_form!((broadcast(*,rescale,c.child))[diagandlowerpart], unique_conic_forms)
-    sdp_constraint = ConicConstr([objective], :SDP, [div(n*(n+1),2)])
-    cache_conic_form!(unique_conic_forms, c, sdp_constraint)
-    # make sure upper and lower triangular part match in the solution
-    # note that this introduces all-zero rows into the constraint matrix
-    # if the matrix we require to be PSD has already been constructed to be symmetric
-    equality_constraint = conic_form!(c.child[lowerpart] == c.child[upperpart], unique_conic_forms)
-
-    # for computing duals --- won't work b/c
-      # 1) sizes are wrong (will be n(n+1)/2, expects n^2), and
-      # 2) the "correct" dual is the sum of the sdp dual and the equality constraint dual (so yes, dual of sdp constraint is *not* symmetric)
-    # conic_constr_to_constr[sdp_constraint] = c
-
-  end
-  return get_conic_form(unique_conic_forms, c)
+    return get_conic_form(unique_conic_forms, c)
 end
 
 # TODO: Remove isposdef, change tests to use in. Update documentation and notebooks
 function isposdef(x::AbstractExpr)
-  if sign(x) == ComplexSign()
-    SDPConstraint([real(x) -imag(x);imag(x) real(x)])
-  else
-    SDPConstraint(x)
-  end
+    if sign(x) == ComplexSign()
+        SDPConstraint([real(x) -imag(x);imag(x) real(x)])
+    else
+        SDPConstraint(x)
+    end
 end
 
 # TODO: Throw error if symbol is invalid.
 function in(x::AbstractExpr, y::Symbol)
-  if y == :semidefinite || y == :SDP
-    if sign(x) == ComplexSign()
-      SDPConstraint([real(x) -imag(x);imag(x) real(x)])
-    else
-      SDPConstraint(x)
+    if y == :semidefinite || y == :SDP
+        if sign(x) == ComplexSign()
+            SDPConstraint([real(x) -imag(x);imag(x) real(x)])
+        else
+            SDPConstraint(x)
+        end
     end
-  end
 end
 
 function ⪰(x::AbstractExpr, y::AbstractExpr)
-  if sign(x) == ComplexSign() || sign(y) == ComplexSign()
-    SDPConstraint([real(x-y) -imag(x-y);imag(x-y) real(x-y)])
-  else
-    SDPConstraint(x-y)
-  end
+    if sign(x) == ComplexSign() || sign(y) == ComplexSign()
+        SDPConstraint([real(x-y) -imag(x-y);imag(x-y) real(x-y)])
+    else
+        SDPConstraint(x-y)
+    end
 end
 
 function ⪯(x::AbstractExpr, y::AbstractExpr)
-  if sign(x) == ComplexSign() || sign(y) == ComplexSign()
-    SDPConstraint([real(y-x) -imag(y-x);imag(y-x) real(y-x)])
-  else
-    SDPConstraint(y-x)
-  end
+    if sign(x) == ComplexSign() || sign(y) == ComplexSign()
+        SDPConstraint([real(y-x) -imag(y-x);imag(y-x) real(y-x)])
+    else
+        SDPConstraint(y-x)
+    end
 end
 
 function ⪰(x::AbstractExpr, y::Value)
-  if sign(x) == ComplexSign() || !isreal(y)
-    all(y .== 0) ? SDPConstraint([real(x) -imag(x);imag(x) real(x)]) : SDPConstraint([real(x-Constant(y)) -imag(x-Constant(y));imag(x-Constant(y)) real(x-Constant(y))])
-  else
-    all(y .== 0) ? SDPConstraint(x) : SDPConstraint(x - Constant(y))
-  end
+    if sign(x) == ComplexSign() || !isreal(y)
+        all(y .== 0) ? SDPConstraint([real(x) -imag(x);imag(x) real(x)]) : SDPConstraint([real(x-Constant(y)) -imag(x-Constant(y));imag(x-Constant(y)) real(x-Constant(y))])
+    else
+        all(y .== 0) ? SDPConstraint(x) : SDPConstraint(x - Constant(y))
+    end
 
 end
 
 function ⪰(x::Value, y::AbstractExpr)
-  if sign(y) == ComplexSign() || !isreal(x)
-    all(x .== 0) ? SDPConstraint([real(-y) -imag(-y);imag(-y) real(-y)]) : SDPConstraint([real(Constant(x)-y) -imag(Constant(x)-y);imag(Constant(x)-y) real(Constant(x)-y)])
-  else
-    all(x .== 0) ? SDPConstraint(-y) : SDPConstraint(Constant(x) - y)
-  end
+    if sign(y) == ComplexSign() || !isreal(x)
+        all(x .== 0) ? SDPConstraint([real(-y) -imag(-y);imag(-y) real(-y)]) : SDPConstraint([real(Constant(x)-y) -imag(Constant(x)-y);imag(Constant(x)-y) real(Constant(x)-y)])
+    else
+        all(x .== 0) ? SDPConstraint(-y) : SDPConstraint(Constant(x) - y)
+    end
 end
 
 function ⪯(x::Value, y::AbstractExpr)
-  if sign(y) == ComplexSign() || !isreal(x)
-    all(x .== 0) ? SDPConstraint([real(y) -imag(y);imag(y) real(y)]) : SDPConstraint([real(y-Constant(x)) -imag(y-Constant(x));imag(y-Constant(x)) real(y-Constant(x))])
-  else
-    all(x .== 0) ? SDPConstraint(y) : SDPConstraint(y - Constant(x))
-  end
+    if sign(y) == ComplexSign() || !isreal(x)
+        all(x .== 0) ? SDPConstraint([real(y) -imag(y);imag(y) real(y)]) : SDPConstraint([real(y-Constant(x)) -imag(y-Constant(x));imag(y-Constant(x)) real(y-Constant(x))])
+    else
+        all(x .== 0) ? SDPConstraint(y) : SDPConstraint(y - Constant(x))
+    end
 end
 
 function ⪯(x::AbstractExpr, y::Value)
-  if sign(x) == ComplexSign() || !isreal(y)
-    all(y .== 0) ? SDPConstraint([real(-x) -imag(-x);imag(-x) real(-x)]) : SDPConstraint([real(Constant(y)-x) -imag(Constant(y)-x);imag(Constant(y)-x) real(Constant(y)-x)])
-  else
-    all(y .== 0) ? SDPConstraint(-x) : SDPConstraint(Constant(y) - x)
-  end
+    if sign(x) == ComplexSign() || !isreal(y)
+        all(y .== 0) ? SDPConstraint([real(-x) -imag(-x);imag(-x) real(-x)]) : SDPConstraint([real(Constant(y)-x) -imag(Constant(y)-x);imag(Constant(y)-x) real(Constant(y)-x)])
+    else
+        all(y .== 0) ? SDPConstraint(-x) : SDPConstraint(Constant(y) - x)
+    end
 end

--- a/src/constraints/signs_and_sets.jl
+++ b/src/constraints/signs_and_sets.jl
@@ -4,11 +4,11 @@ conic_form!(s::Positive, x::Variable, unique_conic_forms) = conic_form!(x>=0, un
 conic_form!(s::Negative, x::Variable, unique_conic_forms) = conic_form!(x<=0, unique_conic_forms)
 
 function conic_form!(set::Symbol, x::Variable, unique_conic_forms)
-	if set==:Semidefinite
+    if set==:Semidefinite
         if sign(x) == ComplexVariable()
             conic_form!(SDPConstraint([real(x) -imag(x);imag(x) real(x)]), unique_conic_forms)
         else
             conic_form!(SDPConstraint(x), unique_conic_forms)
         end
-	end
+    end
 end

--- a/src/constraints/soc_constraints.jl
+++ b/src/constraints/soc_constraints.jl
@@ -4,59 +4,59 @@ export socp
 # TODO: Document this. How is this different from SOCElemConstraint? Why do we need both. How does
 # conic form work for SOC constraints.
 struct SOCConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple
+    dual::ValueOrNothing
 
-  function SOCConstraint(args::AbstractExpr...)
-    children = tuple(args...)
-    id_hash = hash((children, :soc))
-    return new(:soc, id_hash, children, nothing)
-  end
+    function SOCConstraint(args::AbstractExpr...)
+        children = tuple(args...)
+        id_hash = hash((children, :soc))
+        return new(:soc, id_hash, children, nothing)
+    end
 end
 
 function conic_form!(c::SOCConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    objectives = Array{ConicObj}(undef, length(c.children))
-    for iobj=1:length(c.children)
-      objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, c)
+        objectives = Array{ConicObj}(undef, length(c.children))
+        for iobj=1:length(c.children)
+            objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
+        end
+        cache_conic_form!(unique_conic_forms, c, ConicConstr(objectives, :SOC, [get_vectorized_size(x) for x in c.children]))
     end
-    cache_conic_form!(unique_conic_forms, c, ConicConstr(objectives, :SOC, [get_vectorized_size(x) for x in c.children]))
-  end
-  return get_conic_form(unique_conic_forms, c)
+    return get_conic_form(unique_conic_forms, c)
 end
 
 # For debugging created this constraint
 socp(args::AbstractExpr...) = SOCConstraint(args::AbstractExpr...)
 
 struct SOCElemConstraint <: Constraint
-  head::Symbol
-  id_hash::UInt64
-  children::Tuple
-  dual::ValueOrNothing
+    head::Symbol
+    id_hash::UInt64
+    children::Tuple
+    dual::ValueOrNothing
 
-  function SOCElemConstraint(args::AbstractExpr...)
-    children = tuple(args...)
-    id_hash = hash((children, :soc_elem))
-    return new(:soc_elem, id_hash, children, nothing)
-  end
+    function SOCElemConstraint(args::AbstractExpr...)
+        children = tuple(args...)
+        id_hash = hash((children, :soc_elem))
+        return new(:soc_elem, id_hash, children, nothing)
+    end
 end
 
 function conic_form!(c::SOCElemConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, c)
-    num_constrs = get_vectorized_size(c.children[1])
-    num_children = length(c.children)
-    conic_constrs = Array{ConicConstr}(undef, num_constrs)
-    objectives = Array{ConicObj}(undef, num_children)
-    for iobj = 1:num_children
-      objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
+    if !has_conic_form(unique_conic_forms, c)
+        num_constrs = get_vectorized_size(c.children[1])
+        num_children = length(c.children)
+        conic_constrs = Array{ConicConstr}(undef, num_constrs)
+        objectives = Array{ConicObj}(undef, num_children)
+        for iobj = 1:num_children
+            objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
+        end
+        for row = 1:num_constrs
+            objectives_by_row = [get_row(obj, row) for obj in objectives]
+            conic_constrs[row] = ConicConstr(objectives_by_row, :SOC, [1, 1, 1])
+        end
+        cache_conic_form!(unique_conic_forms, c, conic_constrs)
     end
-    for row = 1:num_constrs
-      objectives_by_row = [get_row(obj, row) for obj in objectives]
-      conic_constrs[row] = ConicConstr(objectives_by_row, :SOC, [1, 1, 1])
-    end
-    cache_conic_form!(unique_conic_forms, c, conic_constrs)
-  end
-  return get_conic_form(unique_conic_forms, c)
+    return get_conic_form(unique_conic_forms, c)
 end

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -24,10 +24,10 @@ struct ConvexVexity <: Vexity             end
 struct ConcaveVexity <: Vexity            end
 
 struct NotDcp <: Vexity
-	function NotDcp()
+    function NotDcp()
         @warn "Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior."
         return new()
-	end
+    end
 end
 
 # Monotonocity subtypes

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -47,12 +47,12 @@ export hash
 
 const hashaa_seed = UInt === UInt64 ? 0x7f53e68ceb575e76 : 0xeb575e7
 function hash(a::Array{AbstractExpr}, h::UInt)
-  h += hashaa_seed
-  h += hash(size(a))
-  for x in a
-    h = hash(x, h)
-  end
-  return h
+    h += hashaa_seed
+    h += hash(size(a))
+    for x in a
+        h = hash(x, h)
+    end
+    return h
 end
 
 
@@ -60,42 +60,42 @@ end
 # h''(x) = g'(x)^T f''(g(x)) g'(x) + f'(g(x))g''(x)
 # We calculate the vexity according to this
 function vexity(x::AbstractExpr)
-  monotonicities = monotonicity(x)
-  vex = curvature(x)
-  for i = 1:length(x.children)
-    vex += monotonicities[i] * vexity(x.children[i])
-  end
-  return vex
+    monotonicities = monotonicity(x)
+    vex = curvature(x)
+    for i = 1:length(x.children)
+        vex += monotonicities[i] * vexity(x.children[i])
+    end
+    return vex
 end
 
 
 
 # This function should never be reached
 function monotonicity(x::AbstractExpr)
-  error("monotonicity not implemented for $(x.head).")
+    error("monotonicity not implemented for $(x.head).")
 end
 
 # This function should never be reached
 function curvature(x::AbstractExpr)
-  error("curvature not implemented for $(x.head).")
+    error("curvature not implemented for $(x.head).")
 end
 
 # This function should never be reached
 function evaluate(x::AbstractExpr)
-  error("evaluate not implemented for $(x.head).")
+    error("evaluate not implemented for $(x.head).")
 end
 
 # This function should never be reached
 function sign(x::AbstractExpr)
-  error("sign not implemented for $(x.head).")
+    error("sign not implemented for $(x.head).")
 end
 
 function size(x::AbstractExpr)
-  return x.size
+    return x.size
 end
 
 function length(x::AbstractExpr)
-  return prod(x.size)
+    return prod(x.size)
 end
 
 ### User-defined Unions
@@ -107,13 +107,13 @@ convert(::Type{AbstractExpr}, x::Value) = Constant(x)
 convert(::Type{AbstractExpr}, x::AbstractExpr) = x
 
 function size(x::AbstractExpr, dim::Integer)
-  if dim < 1
-    error("dimension out of range")
-  elseif dim > 2
-    return 1
-  else
-    return size(x)[dim]
-  end
+    if dim < 1
+        error("dimension out of range")
+    elseif dim > 2
+        return 1
+    else
+        return size(x)[dim]
+    end
 end
 
 ndims(x::AbstractExpr) = 2

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -145,7 +145,7 @@ function conic_problem(p::Problem)
             for (id, val) in constraint.objs[i]
                 if id == objectid(:constant)
                     for l in 1:sz
-                        b[constr_index + l] = val[1][l]==0 ? val[2][l] : val[1][l]
+                        b[constr_index + l] = val[1][l] == 0 ? val[2][l] : val[1][l]
                     end
                     #b[constr_index + sz + 1 : constr_index + 2*sz] = val[2]
                 else

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -7,41 +7,41 @@ const Float64OrNothing = Union{Float64, Nothing}
 
 # TODO: Cleanup
 mutable struct Solution{T<:Number}
-  primal::Array{T, 1}
-  dual::Array{T, 1}
-  status::Symbol
-  optval::T
-  has_dual::Bool
+    primal::Array{T, 1}
+    dual::Array{T, 1}
+    status::Symbol
+    optval::T
+    has_dual::Bool
 end
 
-Solution(x::Array{T, 1}, status::Symbol, optval::T) where {T} = 
-  Solution(x, T[], status, optval, false)
-Solution(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) where {T} = 
-  Solution(x, y, status, optval, true)
+Solution(x::Array{T, 1}, status::Symbol, optval::T) where {T} =
+    Solution(x, T[], status, optval, false)
+Solution(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) where {T} =
+    Solution(x, y, status, optval, true)
 
 mutable struct Problem
-  head::Symbol
-  objective::AbstractExpr
-  constraints::Array{Constraint}
-  status::Symbol
-  optval::Float64OrNothing
-  model::MathProgBase.AbstractConicModel
-  solution::Solution
+    head::Symbol
+    objective::AbstractExpr
+    constraints::Array{Constraint}
+    status::Symbol
+    optval::Float64OrNothing
+    model::MathProgBase.AbstractConicModel
+    solution::Solution
 
-  function Problem(head::Symbol, objective::AbstractExpr,
-                   model::MathProgBase.AbstractConicModel, constraints::Array=Constraint[])
-    if sign(objective)== Convex.ComplexSign()
-      error("Objective can not be a complex expression")
-    else
-      return new(head, objective, constraints, Symbol("not yet solved"), nothing, model)
+    function Problem(head::Symbol, objective::AbstractExpr,
+                     model::MathProgBase.AbstractConicModel, constraints::Array=Constraint[])
+        if sign(objective)== Convex.ComplexSign()
+            error("Objective can not be a complex expression")
+        else
+            return new(head, objective, constraints, Symbol("not yet solved"), nothing, model)
+        end
     end
-  end
 end
 
 # constructor if model is not specified
 function Problem(head::Symbol, objective::AbstractExpr, constraints::Array=Constraint[],
                  solver::MathProgBase.AbstractMathProgSolver=get_default_solver())
-  Problem(head, objective, MathProgBase.ConicModel(solver), constraints)
+    Problem(head, objective, MathProgBase.ConicModel(solver), constraints)
 end
 
 # If the problem constructed is of the form Ax=b where A is m x n
@@ -51,184 +51,184 @@ end
 # var_to_ranges a dictionary mapping from variable id to (start_index, end_index)
 # where start_index and end_index are the start and end indexes of the variable in A
 function find_variable_ranges(constraints)
-  index = 0
-  constr_size = 0
-  var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
-  for constraint in constraints
-    for i = 1:length(constraint.objs)
-      for (id, val) in constraint.objs[i]
-        if !haskey(var_to_ranges, id) && id != objectid(:constant)
-          var = id_to_variables[id]
-          if var.sign == ComplexSign()
-            var_to_ranges[id] = (index + 1, index + 2*get_vectorized_size(var))
-            index += 2*get_vectorized_size(var)
-          else
-            var_to_ranges[id] = (index + 1, index + get_vectorized_size(var))
-            index += get_vectorized_size(var)
-          end
+    index = 0
+    constr_size = 0
+    var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
+    for constraint in constraints
+        for i = 1:length(constraint.objs)
+            for (id, val) in constraint.objs[i]
+                if !haskey(var_to_ranges, id) && id != objectid(:constant)
+                    var = id_to_variables[id]
+                    if var.sign == ComplexSign()
+                        var_to_ranges[id] = (index + 1, index + 2*get_vectorized_size(var))
+                        index += 2*get_vectorized_size(var)
+                    else
+                        var_to_ranges[id] = (index + 1, index + get_vectorized_size(var))
+                        index += get_vectorized_size(var)
+                    end
+                end
+            end
+            constr_size += constraint.sizes[i]
         end
-      end
-      constr_size += constraint.sizes[i]
     end
-  end
-  return index, constr_size, var_to_ranges
+    return index, constr_size, var_to_ranges
 end
 
 function vexity(p::Problem)
-  bad_vex = [ConcaveVexity, NotDcp]
+    bad_vex = [ConcaveVexity, NotDcp]
 
-  obj_vex = vexity(p.objective)
-  if p.head == :maximize
-    obj_vex = -obj_vex
-  end
-  typeof(obj_vex) in bad_vex && @warn "Problem not DCP compliant: objective is not DCP"
+    obj_vex = vexity(p.objective)
+    if p.head == :maximize
+        obj_vex = -obj_vex
+    end
+    typeof(obj_vex) in bad_vex && @warn "Problem not DCP compliant: objective is not DCP"
 
-  constr_vex = ConstVexity()
-  for i in 1:length(p.constraints)
-    vex = vexity(p.constraints[i])
-    typeof(vex) in bad_vex && @warn "Problem not DCP compliant: constraint $i is not DCP"
-    constr_vex += vex
-  end
-  problem_vex = obj_vex + constr_vex
-  # this check is redundant
-  # typeof(problem_vex) in bad_vex && warn("Problem not DCP compliant")
-  return problem_vex
+    constr_vex = ConstVexity()
+    for i in 1:length(p.constraints)
+        vex = vexity(p.constraints[i])
+        typeof(vex) in bad_vex && @warn "Problem not DCP compliant: constraint $i is not DCP"
+        constr_vex += vex
+    end
+    problem_vex = obj_vex + constr_vex
+    # this check is redundant
+    # typeof(problem_vex) in bad_vex && warn("Problem not DCP compliant")
+    return problem_vex
 end
 
 function conic_form!(p::Problem, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  objective_var = Variable()
-  objective = conic_form!(objective_var, unique_conic_forms)
-  conic_form!(p.objective - objective_var == 0, unique_conic_forms)
-  for constraint in p.constraints
-    conic_form!(constraint, unique_conic_forms)
-  end
-  return objective, objective_var.id_hash
+    objective_var = Variable()
+    objective = conic_form!(objective_var, unique_conic_forms)
+    conic_form!(p.objective - objective_var == 0, unique_conic_forms)
+    for constraint in p.constraints
+        conic_form!(constraint, unique_conic_forms)
+    end
+    return objective, objective_var.id_hash
 end
 
 function conic_problem(p::Problem)
-  if  get_vectorized_size(p.objective) != 1
-    error("Objective must be a scalar")
-  end
+    if get_vectorized_size(p.objective) != 1
+        error("Objective must be a scalar")
+    end
 
-  # conic problems have the form
-  # minimize c'*x
-  # st       b - Ax \in cones
-  # our job is to take the conic forms of the objective and constraints
-  # and convert them into vectors b and c and a matrix A
-  # one chunk of rows in b and in A corresponds to each constraint,
-  # and one chunk of columns in b and A corresponds to each variable,
-  # with the size of the chunk determined by the size of the constraint or of the variable
+    # conic problems have the form
+    # minimize c'*x
+    # st       b - Ax \in cones
+    # our job is to take the conic forms of the objective and constraints
+    # and convert them into vectors b and c and a matrix A
+    # one chunk of rows in b and in A corresponds to each constraint,
+    # and one chunk of columns in b and A corresponds to each variable,
+    # with the size of the chunk determined by the size of the constraint or of the variable
 
-  # A map to hold unique constraints. Each constraint is keyed by a symbol
-  # of which atom generated the constraints, and a integer hash of the child
-  # expressions used by the atom
-  unique_conic_forms = UniqueConicForms()
-  objective, objective_var_id = conic_form!(p, unique_conic_forms)
-  constraints = unique_conic_forms.constr_list
-  # var_to_ranges maps from variable id to the (start_index, stop_index) pairs of the columns of A corresponding to that variable
-  # var_size is the sum of the lengths of all variables in the problem
-  # constr_size is the sum of the lengths of all constraints in the problem
-  var_size, constr_size, var_to_ranges = find_variable_ranges(constraints)
-  c = spzeros(var_size, 1)
-  objective_range = var_to_ranges[objective_var_id]
-  c[objective_range[1]:objective_range[2]] .= 1
+    # A map to hold unique constraints. Each constraint is keyed by a symbol
+    # of which atom generated the constraints, and a integer hash of the child
+    # expressions used by the atom
+    unique_conic_forms = UniqueConicForms()
+    objective, objective_var_id = conic_form!(p, unique_conic_forms)
+    constraints = unique_conic_forms.constr_list
+    # var_to_ranges maps from variable id to the (start_index, stop_index) pairs of the columns of A corresponding to that variable
+    # var_size is the sum of the lengths of all variables in the problem
+    # constr_size is the sum of the lengths of all constraints in the problem
+    var_size, constr_size, var_to_ranges = find_variable_ranges(constraints)
+    c = spzeros(var_size, 1)
+    objective_range = var_to_ranges[objective_var_id]
+    c[objective_range[1]:objective_range[2]] .= 1
 
-  # slot in all of the coefficients in the conic forms into A and b
-  A = spzeros(constr_size, var_size)
-  b = spzeros(constr_size, 1)
-  cones = Tuple{Symbol, UnitRange{Int}}[]
-  constr_index = 0
-  for constraint in constraints
-    total_constraint_size = 0
-    for i = 1:length(constraint.objs)
-      sz = constraint.sizes[i]
-      for (id, val) in constraint.objs[i]
-        if id == objectid(:constant)
-          for l in 1:sz
-            b[constr_index + l] = val[1][l]==0 ? val[2][l] : val[1][l]
-          end
-          #b[constr_index + sz + 1 : constr_index + 2*sz] = val[2]
-        else
-          var_range = var_to_ranges[id]
-          if id_to_variables[id].sign == ComplexSign()
-            A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[1] + get_vectorized_size(id_to_variables[id])-1] = -val[1]
-            A[constr_index + 1 : constr_index + sz, var_range[1] + get_vectorized_size(id_to_variables[id]) : var_range[2]] = -val[2]
-          else
-            A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[2]] = -val[1]
-          end
+    # slot in all of the coefficients in the conic forms into A and b
+    A = spzeros(constr_size, var_size)
+    b = spzeros(constr_size, 1)
+    cones = Tuple{Symbol, UnitRange{Int}}[]
+    constr_index = 0
+    for constraint in constraints
+        total_constraint_size = 0
+        for i = 1:length(constraint.objs)
+            sz = constraint.sizes[i]
+            for (id, val) in constraint.objs[i]
+                if id == objectid(:constant)
+                    for l in 1:sz
+                        b[constr_index + l] = val[1][l]==0 ? val[2][l] : val[1][l]
+                    end
+                    #b[constr_index + sz + 1 : constr_index + 2*sz] = val[2]
+                else
+                    var_range = var_to_ranges[id]
+                    if id_to_variables[id].sign == ComplexSign()
+                        A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[1] + get_vectorized_size(id_to_variables[id])-1] = -val[1]
+                        A[constr_index + 1 : constr_index + sz, var_range[1] + get_vectorized_size(id_to_variables[id]) : var_range[2]] = -val[2]
+                    else
+                        A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[2]] = -val[1]
+                    end
+                end
+            end
+            constr_index += sz
+            total_constraint_size += sz
         end
-      end
-      constr_index += sz
-      total_constraint_size += sz
+        push!(cones, (constraint.cone, constr_index - total_constraint_size + 1 : constr_index))
     end
-    push!(cones, (constraint.cone, constr_index - total_constraint_size + 1 : constr_index))
-  end
 
-  # find integral and boolean variables
-  vartypes = fill(:Cont, length(c))
-  for var_id in keys(var_to_ranges)
-    variable = id_to_variables[var_id]
-    if :Int in variable.sets
-      startidx, endidx = var_to_ranges[var_id]
-      for idx in startidx:endidx
-        vartypes[idx] = :Int
-      end
+    # find integral and boolean variables
+    vartypes = fill(:Cont, length(c))
+    for var_id in keys(var_to_ranges)
+        variable = id_to_variables[var_id]
+        if :Int in variable.sets
+            startidx, endidx = var_to_ranges[var_id]
+            for idx in startidx:endidx
+                vartypes[idx] = :Int
+            end
+        end
+        if :Bin in variable.sets
+            startidx, endidx = var_to_ranges[var_id]
+            for idx in startidx:endidx
+                vartypes[idx] = :Bin
+            end
+        end
     end
-    if :Bin in variable.sets
-      startidx, endidx = var_to_ranges[var_id]
-      for idx in startidx:endidx
-        vartypes[idx] = :Bin
-      end
+
+    if p.head == :maximize
+        c = -c
     end
-  end
 
-  if p.head == :maximize
-    c = -c
-  end
-
-  return c, A, b, cones, var_to_ranges, vartypes, constraints
+    return c, A, b, cones, var_to_ranges, vartypes, constraints
 end
 
 Problem(head::Symbol, objective::AbstractExpr, constraints::Constraint...) =
-  Problem(head, objective, [constraints...])
+    Problem(head, objective, [constraints...])
 
 # Allow users to simply type minimize
 minimize(objective::AbstractExpr, constraints::Constraint...) =
-  Problem(:minimize, objective, collect(constraints))
+    Problem(:minimize, objective, collect(constraints))
 minimize(objective::AbstractExpr, constraints::Array{<:Constraint}=Constraint[]) =
-  Problem(:minimize, objective, constraints)
+    Problem(:minimize, objective, constraints)
 minimize(objective::Value, constraints::Constraint...) =
-  minimize(convert(AbstractExpr, objective), collect(constraints))
+    minimize(convert(AbstractExpr, objective), collect(constraints))
 minimize(objective::Value, constraints::Array{<:Constraint}=Constraint[]) =
-  minimize(convert(AbstractExpr, objective), constraints)
+    minimize(convert(AbstractExpr, objective), constraints)
 
 # Allow users to simply type maximize
 maximize(objective::AbstractExpr, constraints::Constraint...) =
-  Problem(:maximize, objective, collect(constraints))
+    Problem(:maximize, objective, collect(constraints))
 maximize(objective::AbstractExpr, constraints::Array{<:Constraint}=Constraint[]) =
-  Problem(:maximize, objective, constraints)
+    Problem(:maximize, objective, constraints)
 maximize(objective::Value, constraints::Constraint...) =
-  maximize(convert(AbstractExpr, objective), collect(constraints))
+    maximize(convert(AbstractExpr, objective), collect(constraints))
 maximize(objective::Value, constraints::Array{<:Constraint}=Constraint[]) =
-  maximize(convert(AbstractExpr, objective), constraints)
+    maximize(convert(AbstractExpr, objective), constraints)
 
 # Allow users to simply type satisfy (if there is no objective)
 satisfy(constraints::Constraint...) = Problem(:minimize, Constant(0), [constraints...])
 satisfy(constraints::Array{<:Constraint}=Constraint[]) =
-  Problem(:minimize, Constant(0), constraints)
+    Problem(:minimize, Constant(0), constraints)
 satisfy(constraint::Constraint) = satisfy([constraint])
 
 # +(constraints, constraints) is defined in constraints.jl
-add_constraints!(p::Problem, constraints::Array{<:Constraint}) = 
-  +(p.constraints, constraints)
+add_constraints!(p::Problem, constraints::Array{<:Constraint}) =
+    +(p.constraints, constraints)
 add_constraints!(p::Problem, constraint::Constraint) = add_constraints!(p, [constraint])
 add_constraint! = add_constraints!
 
 # caches conic form of x when x is the solution to the optimization problem p
 function cache_conic_form!(conic_forms::UniqueConicForms, x::AbstractExpr, p::Problem)
-  objective = conic_form!(p.objective, conic_forms)
-  for c in p.constraints
-    conic_form!(c, conic_forms)
-  end
-  cache_conic_form!(conic_forms, x, objective)
+    objective = conic_form!(p.objective, conic_forms)
+    for c in p.constraints
+        conic_form!(c, conic_forms)
+    end
+    cache_conic_form!(conic_forms, x, objective)
 end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -36,7 +36,7 @@ function solve!(problem::Problem;
     # populate the status, the primal (and possibly dual) solution
     # and the primal (and possibly dual) variables with values
     populate_solution!(m, problem, var_to_ranges, conic_constraints)
-    if !(problem.status==:Optimal) && verbose
+    if problem.status != :Optimal && verbose
         @warn "Problem status $(problem.status); solution may be inaccurate."
     end
 end
@@ -54,7 +54,7 @@ function set_warmstart!(m::MathProgBase.AbstractConicModel,
                 Warmstart may be ineffective."
          primal = zeros(n)
      end
-     if !(length(primal) == n)
+     if length(primal) != n
          @warn "Unable to use cached solution to warmstart problem.
                 (Perhaps the number of variables or constraints in the problem have changed since you last solved it?)
                 Warmstart may be ineffective."
@@ -81,7 +81,7 @@ function load_problem!(m::MathProgBase.AbstractConicModel, c, A, b, cones, varty
     MathProgBase.loadproblem!(m, vec(Array(c)), A, vec(Array(b)), cones, var_cones)
 
     # add integer and binary constraints on variables
-    if !all(Bool[t==:Cont for t in vartypes])
+    if !all(==(:Cont), vartypes)
         try
             MathProgBase.setvartype!(m, vartypes)
         catch

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -8,9 +8,9 @@ export solve!
 function solve!(problem::Problem,
                 s::MathProgBase.AbstractMathProgSolver;
                 kwargs...)
-  # TODO: warn about wiping out old model if warmstart=true?
-  problem.model = MathProgBase.ConicModel(s)
-  return solve!(problem; kwargs...)
+    # TODO: warn about wiping out old model if warmstart=true?
+    problem.model = MathProgBase.ConicModel(s)
+    return solve!(problem; kwargs...)
 end
 
 function solve!(problem::Problem;
@@ -18,145 +18,144 @@ function solve!(problem::Problem;
                 check_vexity=true,
                 verbose=true)
 
-  if check_vexity
-    vex = vexity(problem)
-  end
+    if check_vexity
+        vex = vexity(problem)
+    end
 
-  c, A, b, cones, var_to_ranges, vartypes, conic_constraints = conic_problem(problem)
+    c, A, b, cones, var_to_ranges, vartypes, conic_constraints = conic_problem(problem)
 
-  # load MPB conic problem
-  m = problem.model
-  load_problem!(m, c, A, b, cones, vartypes)
-  if warmstart
-    set_warmstart!(m, problem, length(c), var_to_ranges)
-  end
-  # optimize MPB conic problem
-  MathProgBase.optimize!(m)
+    # load MPB conic problem
+    m = problem.model
+    load_problem!(m, c, A, b, cones, vartypes)
+    if warmstart
+        set_warmstart!(m, problem, length(c), var_to_ranges)
+    end
+    # optimize MPB conic problem
+    MathProgBase.optimize!(m)
 
-  # populate the status, the primal (and possibly dual) solution
-  # and the primal (and possibly dual) variables with values
-  populate_solution!(m, problem, var_to_ranges, conic_constraints)
-  if !(problem.status==:Optimal) && verbose
-    @warn "Problem status $(problem.status); solution may be inaccurate."
-  end
-
+    # populate the status, the primal (and possibly dual) solution
+    # and the primal (and possibly dual) variables with values
+    populate_solution!(m, problem, var_to_ranges, conic_constraints)
+    if !(problem.status==:Optimal) && verbose
+        @warn "Problem status $(problem.status); solution may be inaccurate."
+    end
 end
 
 function set_warmstart!(m::MathProgBase.AbstractConicModel,
-                       problem::Problem,
-                       n::Int, # length of primal (conic) solution
-                       var_to_ranges)
-    # use previously cached solution, if any,
-    try
-      primal = problem.solution.primal
-    catch
-      @warn "Unable to use cached solution to warmstart problem.
-            (Perhaps this is the first time you're solving this problem?)
-            Warmstart may be ineffective."
-      primal = zeros(n)
-    end
-    if !(length(primal) == n)
-      @warn "Unable to use cached solution to warmstart problem.
-            (Perhaps the number of variables or constraints in the problem have changed since you last solved it?)
-            Warmstart may be ineffective."
-      primal = zeros(n)
-    end
+                        problem::Problem,
+                        n::Int, # length of primal (conic) solution
+                        var_to_ranges)
+     # use previously cached solution, if any,
+     try
+         primal = problem.solution.primal
+     catch
+         @warn "Unable to use cached solution to warmstart problem.
+                (Perhaps this is the first time you're solving this problem?)
+                Warmstart may be ineffective."
+         primal = zeros(n)
+     end
+     if !(length(primal) == n)
+         @warn "Unable to use cached solution to warmstart problem.
+                (Perhaps the number of variables or constraints in the problem have changed since you last solved it?)
+                Warmstart may be ineffective."
+         primal = zeros(n)
+     end
 
-    # grab any variables whose values the user may be trying to set
-    load_primal_solution!(primal, var_to_ranges)
+     # grab any variables whose values the user may be trying to set
+     load_primal_solution!(primal, var_to_ranges)
 
-    # notify the model that we're trying to warmstart
-    try
-      MathProgBase.setwarmstart!(m, primal)
-    catch
-      @warn "Unable to warmstart solution.
-        (Perhaps the solver doesn't support warm starts?)
-        Using a cold start instead."
+     # notify the model that we're trying to warmstart
+     try
+         MathProgBase.setwarmstart!(m, primal)
+     catch
+         @warn "Unable to warmstart solution.
+               (Perhaps the solver doesn't support warm starts?)
+               Using a cold start instead."
+     end
+     m
+end
+
+function load_problem!(m::MathProgBase.AbstractConicModel, c, A, b, cones, vartypes)
+    # no conic constraints on variables
+    var_cones = fill((:Free, 1:size(A, 2)),1)
+    MathProgBase.loadproblem!(m, vec(Array(c)), A, vec(Array(b)), cones, var_cones)
+
+    # add integer and binary constraints on variables
+    if !all(Bool[t==:Cont for t in vartypes])
+        try
+            MathProgBase.setvartype!(m, vartypes)
+        catch
+            error("model $(typeof(m)) does not support variables of some of the following types: $(unique(vartypes))")
+        end
     end
     m
 end
 
-function load_problem!(m::MathProgBase.AbstractConicModel, c, A, b, cones, vartypes)
-  # no conic constraints on variables
-  var_cones = fill((:Free, 1:size(A, 2)),1)
-  MathProgBase.loadproblem!(m, vec(Array(c)), A, vec(Array(b)), cones, var_cones)
-
-  # add integer and binary constraints on variables
-  if !all(Bool[t==:Cont for t in vartypes])
-    try
-      MathProgBase.setvartype!(m, vartypes)
-    catch
-      error("model $(typeof(m)) does not support variables of some of the following types: $(unique(vartypes))")
-    end
-  end
-  m
-end
-
 function populate_solution!(m::MathProgBase.AbstractConicModel,
-                        problem::Problem,
-                        var_to_ranges,
-                        conic_constraints)
-  dual = try
-    MathProgBase.getdual(m)
-  catch
-    fill(NaN, MathProgBase.numconstr(m))
-  end
+                            problem::Problem,
+                            var_to_ranges,
+                            conic_constraints)
+    dual = try
+        MathProgBase.getdual(m)
+    catch
+        fill(NaN, MathProgBase.numconstr(m))
+    end
 
-  solution = try
-    MathProgBase.getsolution(m)
-  catch
-    fill(NaN, MathProgBase.numvar(m))
-  end
+    solution = try
+        MathProgBase.getsolution(m)
+    catch
+        fill(NaN, MathProgBase.numvar(m))
+    end
 
-  objective = try
-    MathProgBase.getobjval(m)
-  catch
-    NaN
-  end
+    objective = try
+        MathProgBase.getobjval(m)
+    catch
+        NaN
+    end
 
-  if any(isnan, dual)
-    problem.solution = Solution(solution, MathProgBase.status(m), objective)
-  else
-    problem.solution = Solution(solution, dual, MathProgBase.status(m), objective)
-  end
+    if any(isnan, dual)
+        problem.solution = Solution(solution, MathProgBase.status(m), objective)
+    else
+        problem.solution = Solution(solution, dual, MathProgBase.status(m), objective)
+    end
 
-  populate_variables!(problem, var_to_ranges)
+    populate_variables!(problem, var_to_ranges)
 
-  if problem.solution.has_dual
-    populate_duals!(conic_constraints, problem.solution.dual)
-  end
+    if problem.solution.has_dual
+        populate_duals!(conic_constraints, problem.solution.dual)
+    end
 
-  # minimize -> maximize
-  if (problem.head == :maximize)
-    problem.solution.optval = -problem.solution.optval
-  end
+    # minimize -> maximize
+    if (problem.head == :maximize)
+        problem.solution.optval = -problem.solution.optval
+    end
 
-  # Populate the problem with the solution
-  problem.optval = problem.solution.optval
-  problem.status = problem.solution.status
+    # Populate the problem with the solution
+    problem.optval = problem.solution.optval
+    problem.status = problem.solution.status
 
-  problem
+    problem
 end
 
 function populate_variables!(problem::Problem, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
-  x = problem.solution.primal
-  for (id, (start_index, end_index)) in var_to_ranges
-    var = id_to_variables[id]
-    sz = var.size
-    if var.sign != ComplexSign()
-      var.value = reshape(x[start_index:end_index], sz[1], sz[2])
-      if sz == (1, 1)
-        var.value = var.value[1]
-      end
-    else
-      real_value = reshape(x[start_index:start_index + div(end_index-start_index+1,2)-1], sz[1], sz[2])
-      imag_value = reshape(x[start_index + div(end_index-start_index+1,2):end_index], sz[1], sz[2])
-      var.value = real_value + im*imag_value
-      if sz == (1, 1)
-        var.value = var.value[1]
-      end
+    x = problem.solution.primal
+    for (id, (start_index, end_index)) in var_to_ranges
+        var = id_to_variables[id]
+        sz = var.size
+        if var.sign != ComplexSign()
+            var.value = reshape(x[start_index:end_index], sz[1], sz[2])
+            if sz == (1, 1)
+                var.value = var.value[1]
+            end
+        else
+            real_value = reshape(x[start_index:start_index + div(end_index-start_index+1,2)-1], sz[1], sz[2])
+            imag_value = reshape(x[start_index + div(end_index-start_index+1,2):end_index], sz[1], sz[2])
+            var.value = real_value + im*imag_value
+            if sz == (1, 1)
+                var.value = var.value[1]
+            end
+        end
     end
-  end
 end
 
 # populates the solution vector from the .value fields of variables
@@ -165,37 +164,37 @@ end
 # get their `expression_to_range`,
 # and populate them too using `evaluate`
 function load_primal_solution!(primal::Array{Float64,1}, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
-  for (id, (start_index, end_index)) in var_to_ranges
-    var = id_to_variables[id]
-    if var.value != nothing
-      sz = size(var.value)
-      if length(sz) <= 1
-        primal[start_index:end_index] = var.value
-      else
-        primal[start_index:end_index] = reshape(var.value, sz[1]*sz[2], 1)
-      end
+    for (id, (start_index, end_index)) in var_to_ranges
+        var = id_to_variables[id]
+        if var.value != nothing
+            sz = size(var.value)
+            if length(sz) <= 1
+                primal[start_index:end_index] = var.value
+            else
+                primal[start_index:end_index] = reshape(var.value, sz[1]*sz[2], 1)
+            end
+        end
     end
-  end
 end
 
 function populate_duals!(constraints::Array{ConicConstr}, dual::Vector)
-  constr_index = 1
-  for constraint in constraints
-    # conic_constr_to_constr only has keys for conic constraints with a single objective
-    # so this will work
-    if haskey(conic_constr_to_constr, constraint)
-      sz = constraint.sizes[1]
-      c = conic_constr_to_constr[constraint]
-      c.dual = reshape(dual[constr_index:constr_index+sz-1], c.size)
-      if c.size == (1, 1)
-        c.dual = c.dual[1]
-      end
-      constr_index += sz
-    else
-      for i = 1:length(constraint.objs)
-        sz = constraint.sizes[i]
-        constr_index += sz
-      end
+    constr_index = 1
+    for constraint in constraints
+        # conic_constr_to_constr only has keys for conic constraints with a single objective
+        # so this will work
+        if haskey(conic_constr_to_constr, constraint)
+            sz = constraint.sizes[1]
+            c = conic_constr_to_constr[constraint]
+            c.dual = reshape(dual[constr_index:constr_index+sz-1], c.size)
+            if c.size == (1, 1)
+                c.dual = c.dual[1]
+            end
+            constr_index += sz
+        else
+            for i = 1:length(constraint.objs)
+                sz = constraint.sizes[i]
+                constr_index += sz
+            end
+        end
     end
-  end
 end

--- a/src/solver_info.jl
+++ b/src/solver_info.jl
@@ -4,24 +4,24 @@ export can_solve_mip, can_solve_socp, can_solve_sdp, can_solve_exp
 export set_default_solver, get_default_solver, isinstalled
 
 function set_default_solver(solver::MathProgBase.AbstractMathProgSolver)
-  global DEFAULT_SOLVER
-  DEFAULT_SOLVER = solver
+    global DEFAULT_SOLVER
+    DEFAULT_SOLVER = solver
 end
 
 function get_default_solver()
-  if DEFAULT_SOLVER == nothing
-    error("The default solver is set to `nothing`
-         You must have at least one solver installed to use Convex.
-         You can install a solver such as SCS by running:
-         Pkg.add(\"SCS\").
-         You will have to restart Julia after that.")
-  end
-  return DEFAULT_SOLVER
+    if DEFAULT_SOLVER == nothing
+        error("The default solver is set to `nothing`
+              You must have at least one solver installed to use Convex.
+              You can install a solver such as SCS by running:
+              Pkg.add(\"SCS\").
+              You will have to restart Julia after that.")
+    end
+    return DEFAULT_SOLVER
 end
 
 # TODO: I have not listed solvers such as CPLEX etc because I have not tested Convex with them
 solvers = [("ECOS", "ECOSSolver"), ("SCS", "SCSSolver"), ("Gurobi", "GurobiSolver"), ("Mosek", "MosekSolver"),
-          ("GLPKMathProgInterface", "GLPKSolverMIP")]
+           ("GLPKMathProgInterface", "GLPKSolverMIP")]
 
 function isinstalled(pkg)
     for path in Base.DEPOT_PATH
@@ -33,61 +33,61 @@ function isinstalled(pkg)
 end
 
 for (dir, solver) in solvers
-  if isinstalled(dir) && DEFAULT_SOLVER == nothing
-    eval(Meta.parse("using $dir"))
-    eval(Meta.parse("set_default_solver($solver())"))
-  end
+    if isinstalled(dir) && DEFAULT_SOLVER == nothing
+        eval(Meta.parse("using $dir"))
+        eval(Meta.parse("set_default_solver($solver())"))
+    end
 end
 
 
 if get_default_solver() == nothing
-  packages = join([dir for (dir, solver) in solvers], " | ")
-  @warn "***********************************************************************************************
-       You don't have any of
-       "*packages*" installed.
-       You must have at least one of these solvers. You can install a solver such as SCS by running:
-       Pkg.add(\"SCS\")
-       You will have to restart Julia after that.
-       ***********************************************************************************************"
+    packages = join([dir for (dir, solver) in solvers], " | ")
+    @warn "***********************************************************************************************
+          You don't have any of
+          "*packages*" installed.
+          You must have at least one of these solvers. You can install a solver such as SCS by running:
+          Pkg.add(\"SCS\")
+          You will have to restart Julia after that.
+          ***********************************************************************************************"
 end
 
 function can_solve_mip(solver)
-  name = typeof(solver).name.name
-  if name == :GurobiSolver || name == :MosekSolver || name == :GLPKSolverMIP || name == :CPLEXSolver || name == :CbcSolver
-    return true
-  else
-    @info "$name cannot solve mixed integer programs. Consider using Gurobi, Mosek, or GLPK."
-    return false
-  end
+    name = typeof(solver).name.name
+    if name == :GurobiSolver || name == :MosekSolver || name == :GLPKSolverMIP || name == :CPLEXSolver || name == :CbcSolver
+        return true
+    else
+        @info "$name cannot solve mixed integer programs. Consider using Gurobi, Mosek, or GLPK."
+        return false
+    end
 end
 
 function can_solve_socp(solver)
-  if :SOC in MathProgBase.supportedcones(solver)
-    return true
-  else
-    name = typeof(solver).name.name
-    @info "$name cannot solve second order cone programs. Consider using SCS, ECOS, Mosek, or Gurobi."
-    return false
-  end
+    if :SOC in MathProgBase.supportedcones(solver)
+        return true
+    else
+        name = typeof(solver).name.name
+        @info "$name cannot solve second order cone programs. Consider using SCS, ECOS, Mosek, or Gurobi."
+        return false
+    end
 end
 
 function can_solve_exp(solver)
-  if :ExpPrimal in MathProgBase.supportedcones(solver)
-    return true
-  else
-    name = typeof(solver).name.name
-    @info "$name cannot solve exponential programs. Consider using SCS or ECOS."
-    return false
-  end
+    if :ExpPrimal in MathProgBase.supportedcones(solver)
+        return true
+    else
+        name = typeof(solver).name.name
+        @info "$name cannot solve exponential programs. Consider using SCS or ECOS."
+        return false
+    end
 end
 
 function can_solve_sdp(solver)
-  if :SDP in MathProgBase.supportedcones(solver)
-    return true
-  else
-    name = typeof(solver).name.name
-    @info "$name cannot solve semidefinite programs. Consider using SCS or Mosek."
-    return false
-  end
+    if :SDP in MathProgBase.supportedcones(solver)
+        return true
+    else
+        name = typeof(solver).name.name
+        @info "$name cannot solve semidefinite programs. Consider using SCS or Mosek."
+        return false
+    end
 end
 

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -4,7 +4,7 @@ export show
 # A Constant is simply a wrapper around a native Julia constant
 # Hence, we simply display its value
 function show(io::IO, x::Constant)
-  print(io, "$(x.value)")
+    print(io, "$(x.value)")
 end
 
 # A variable, for example, Variable(3, 4), will be displayed as:
@@ -13,13 +13,13 @@ end
 # sign: NoSign()
 # vexity: AffineVexity()
 function show(io::IO, x::Variable)
-  print(io, """Variable of
-    size: ($(x.size[1]), $(x.size[2]))
-    sign: $(x.sign)
-    vexity: $(x.vexity)""")
-  if x.value != nothing
-    print(io, "\nvalue: $(x.value)")
-  end
+    print(io, """Variable of
+          size: ($(x.size[1]), $(x.size[2]))
+          sign: $(x.sign)
+          vexity: $(x.vexity)""")
+    if x.value != nothing
+        print(io, "\nvalue: $(x.value)")
+    end
 end
 
 # A constraint, for example, square(x) <= 4 will be displayed as:
@@ -28,11 +28,11 @@ end
 # lhs: ...
 # rhs: ...
 function show(io::IO, c::Constraint)
-  print(io, """Constraint:
-    $(c.head) constraint
-    lhs: $(c.lhs)
-    rhs: $(c.rhs)
-    vexity: $(vexity(c))""")
+    print(io, """Constraint:
+          $(c.head) constraint
+          lhs: $(c.lhs)
+          rhs: $(c.rhs)
+          vexity: $(vexity(c))""")
 end
 
 # SDP constraints are displayed as:
@@ -40,10 +40,10 @@ end
 # sdp constraint
 # expression: ...
 function show(io::IO, c::SDPConstraint)
-  print(io, """Constraint:
-    $(c.head) constraint
-    expression: $(c.child)
-    """)
+    print(io, """Constraint:
+          $(c.head) constraint
+          expression: $(c.child)
+          """)
 end
 
 # An expression, for example, 2 * x, will be displayed as:
@@ -53,34 +53,34 @@ end
 # sign: NoSign()
 # vexity: AffineVexity()
 function show(io::IO, e::AbstractExpr)
-  print(io, """AbstractExpr with
-    head: $(e.head)
-    size: ($(e.size[1]), $(e.size[2]))
-    sign: $(sign(e))
-    vexity: $(vexity(e))
-    """)
+    print(io, """AbstractExpr with
+          head: $(e.head)
+          size: ($(e.size[1]), $(e.size[2]))
+          sign: $(sign(e))
+          vexity: $(vexity(e))
+          """)
 end
 
 # A problem, for example, p = minimize(sum(x) + 3, [x >= 0, x >= 1, x <= 10])
 # will be displayed as follows:
 #
 # Problem: minimize `Expression`
-#    subject to
-#      Constraint: ...
-#      Constraint: ...
-#      Constraint: ...
-#    current status: not yet solved
+#        subject to
+#            Constraint: ...
+#            Constraint: ...
+#            Constraint: ...
+#        current status: not yet solved
 #
 # Once it is solved, the current status would look like:
-#    current status: solved with optimal value of 9.0
+#        current status: solved with optimal value of 9.0
 function show(io::IO, p::Problem)
-  print(io, """Problem:
-    $(p.head) $(p.objective)
-    subject to
-    """)
-  join(io, p.constraints, "\n\t\t")
-  print(io, "\ncurrent status: $(p.status)")
-  if p.status == "solved"
-    print(io, " with optimal value of $(round(p.optval, digits=4))")
-  end
+    print(io, """Problem:
+          $(p.head) $(p.objective)
+          subject to
+          """)
+    join(io, p.constraints, "\n\t\t")
+    print(io, "\ncurrent status: $(p.status)")
+    if p.status == "solved"
+        print(io, " with optimal value of $(round(p.optval, digits=4))")
+    end
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -7,40 +7,37 @@ export Variable, Semidefinite, ComplexVariable, HermitianSemidefinite
 export vexity, evaluate, sign, conic_form!, fix!, free!
 
 mutable struct Variable <: AbstractExpr
-  head::Symbol
-  id_hash::UInt64
-  value::ValueOrNothing
-  size::Tuple{Int, Int}
-  vexity::Vexity
-  sign::Sign
-  sets::Array{Symbol,1}
+    head::Symbol
+    id_hash::UInt64
+    value::ValueOrNothing
+    size::Tuple{Int, Int}
+    vexity::Vexity
+    sign::Sign
+    sets::Array{Symbol,1}
 
 
-  function Variable(size::Tuple{Int, Int}, sign::Sign=NoSign(), sets::Symbol...)
-    this = new(:variable, 0, nothing, size, AffineVexity(), sign, Symbol[sets...])
-    this.id_hash = objectid(this)
-    id_to_variables[this.id_hash] = this
-    return this
-  end
+    function Variable(size::Tuple{Int, Int}, sign::Sign=NoSign(), sets::Symbol...)
+        this = new(:variable, 0, nothing, size, AffineVexity(), sign, Symbol[sets...])
+        this.id_hash = objectid(this)
+        id_to_variables[this.id_hash] = this
+        return this
+    end
 
-  Variable(m::Int, n::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((m,n), sign, sets...)
-  Variable(sign::Sign, sets::Symbol...) = Variable((1, 1), sign, sets...)
-  Variable(sets::Symbol...) = Variable((1, 1), NoSign(), sets...)
-  Variable(size::Tuple{Int, Int}, sets::Symbol...) = Variable(size, NoSign(), sets...)
-  Variable(size::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((size, 1), sign, sets...)
-  Variable(size::Int, sets::Symbol...) = Variable((size, 1), sets...)
-
-
-
+    Variable(m::Int, n::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((m,n), sign, sets...)
+    Variable(sign::Sign, sets::Symbol...) = Variable((1, 1), sign, sets...)
+    Variable(sets::Symbol...) = Variable((1, 1), NoSign(), sets...)
+    Variable(size::Tuple{Int, Int}, sets::Symbol...) = Variable(size, NoSign(), sets...)
+    Variable(size::Int, sign::Sign=NoSign(), sets::Symbol...) = Variable((size, 1), sign, sets...)
+    Variable(size::Int, sets::Symbol...) = Variable((size, 1), sets...)
 end
 
 Semidefinite(m::Integer) = Variable((m,m), :Semidefinite)
 function Semidefinite(m::Integer, n::Integer)
-  if m==n
-    return Variable((m,m), :Semidefinite)
-  else
-    error("Semidefinite matrices must be square")
-  end
+    if m==n
+        return Variable((m,m), :Semidefinite)
+    else
+        error("Semidefinite matrices must be square")
+    end
 end
 
 ComplexVariable(m::Int, n::Int, sets::Symbol...) = Variable((m,n), ComplexSign(), sets...)
@@ -49,11 +46,11 @@ ComplexVariable(size::Tuple{Int, Int}, sets::Symbol...) = Variable(size, Complex
 ComplexVariable(size::Int, sets::Symbol...) = Variable((size, 1), ComplexSign(), sets...)
 HermitianSemidefinite(m::Integer) = ComplexVariable((m,m), :Semidefinite)
 function HermitianSemidefinite(m::Integer, n::Integer)
-  if m==n
-    return ComplexVariable((m,m), :Semidefinite)
-  else
-    error("HermitianSemidefinite matrices must be square")
-  end
+    if m==n
+        return ComplexVariable((m,m), :Semidefinite)
+    else
+        error("HermitianSemidefinite matrices must be square")
+    end
 end
 
 # global map from unique variable ids to variables.
@@ -63,76 +60,76 @@ end
 id_to_variables = Dict{UInt64, Variable}()
 
 function vexity(x::Variable)
-  return x.vexity
+    return x.vexity
 end
 
 function evaluate(x::Variable)
-  return x.value == nothing ? error("Value of the variable is yet to be calculated") : x.value
+    return x.value == nothing ? error("Value of the variable is yet to be calculated") : x.value
 end
 
 function sign(x::Variable)
-  return x.sign
+    return x.sign
 end
 
 
 function real_conic_form(x::Variable)
-  vec_size = get_vectorized_size(x)
-  return sparse(1.0I, vec_size, vec_size)
+    vec_size = get_vectorized_size(x)
+    return sparse(1.0I, vec_size, vec_size)
 end
 
 function imag_conic_form(x::Variable)
-  vec_size = get_vectorized_size(x)
-  if x.sign == ComplexSign()
-    return im*sparse(1.0I, vec_size, vec_size)
-  else
-    return spzeros(vec_size, vec_size)
-  end
+    vec_size = get_vectorized_size(x)
+    if x.sign == ComplexSign()
+        return im*sparse(1.0I, vec_size, vec_size)
+    else
+        return spzeros(vec_size, vec_size)
+    end
 end
 
 function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
-  if !has_conic_form(unique_conic_forms, x)
-    if :fixed in x.sets
-      # do exactly what we would for a constant
-      objective = ConicObj()
-      objective[objectid(:constant)] = (vec([real(x.value);]),vec([imag(x.value);]))
-      cache_conic_form!(unique_conic_forms, x, objective)
-    else
-      objective = ConicObj()
-      vec_size = get_vectorized_size(x)
+    if !has_conic_form(unique_conic_forms, x)
+        if :fixed in x.sets
+            # do exactly what we would for a constant
+            objective = ConicObj()
+            objective[objectid(:constant)] = (vec([real(x.value);]),vec([imag(x.value);]))
+            cache_conic_form!(unique_conic_forms, x, objective)
+        else
+            objective = ConicObj()
+            vec_size = get_vectorized_size(x)
 
-      objective[x.id_hash] = (real_conic_form(x), imag_conic_form(x))
-      objective[objectid(:constant)] = (spzeros(vec_size, 1), spzeros(vec_size, 1))
-      # placeholder values in unique constraints prevent infinite recursion depth
-      cache_conic_form!(unique_conic_forms, x, objective)
-      if !(x.sign == NoSign() || x.sign == ComplexSign())
-        conic_form!(x.sign, x, unique_conic_forms)
-      end
-      for set in x.sets
-        conic_form!(set, x, unique_conic_forms)
-      end
+            objective[x.id_hash] = (real_conic_form(x), imag_conic_form(x))
+            objective[objectid(:constant)] = (spzeros(vec_size, 1), spzeros(vec_size, 1))
+            # placeholder values in unique constraints prevent infinite recursion depth
+            cache_conic_form!(unique_conic_forms, x, objective)
+            if !(x.sign == NoSign() || x.sign == ComplexSign())
+                conic_form!(x.sign, x, unique_conic_forms)
+            end
+            for set in x.sets
+                conic_form!(set, x, unique_conic_forms)
+            end
+        end
     end
-  end
-  return get_conic_form(unique_conic_forms, x)
+    return get_conic_form(unique_conic_forms, x)
 end
 
 # fix variables to hold them at their current value, and free them afterwards
 function fix!(x::Variable)
-  x.value == nothing && error("This variable has no value yet; cannot fix value to nothing!")
-  push!(x.sets, :fixed)
-  x.vexity = ConstVexity()
-  x
+    x.value == nothing && error("This variable has no value yet; cannot fix value to nothing!")
+    push!(x.sets, :fixed)
+    x.vexity = ConstVexity()
+    x
 end
 function fix!(x::Variable, v::AbstractArray)
-  size(x) == size(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-  x.value = Array{Float64}(undef, size(x))
-  x.value[:,:] = v
-  fix!(x)
+    size(x) == size(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
+    x.value = Array{Float64}(undef, size(x))
+    x.value[:,:] = v
+    fix!(x)
 end
 fix!(x::Variable, v::Number) = fix!(x, fill(v, (1, 1)))
 
 function free!(x::Variable)
-  # TODO this won't work if :fixed appears other than at the end of x.sets
-  x.sets[end] == :fixed && pop!(x.sets)
-  x.vexity = AffineVexity()
-  x
+    # TODO this won't work if :fixed appears other than at the end of x.sets
+    x.sets[end] == :fixed && pop!(x.sets)
+    x.vexity = AffineVexity()
+    x
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -31,23 +31,23 @@ mutable struct Variable <: AbstractExpr
     Variable(size::Int, sets::Symbol...) = Variable((size, 1), sets...)
 end
 
-Semidefinite(m::Integer) = Variable((m,m), :Semidefinite)
+Semidefinite(m::Integer) = Variable((m, m), :Semidefinite)
 function Semidefinite(m::Integer, n::Integer)
-    if m==n
-        return Variable((m,m), :Semidefinite)
+    if m == n
+        return Variable((m, m), :Semidefinite)
     else
         error("Semidefinite matrices must be square")
     end
 end
 
-ComplexVariable(m::Int, n::Int, sets::Symbol...) = Variable((m,n), ComplexSign(), sets...)
+ComplexVariable(m::Int, n::Int, sets::Symbol...) = Variable((m, n), ComplexSign(), sets...)
 ComplexVariable(sets::Symbol...) = Variable((1, 1), ComplexSign(), sets...)
 ComplexVariable(size::Tuple{Int, Int}, sets::Symbol...) = Variable(size, ComplexSign(), sets...)
 ComplexVariable(size::Int, sets::Symbol...) = Variable((size, 1), ComplexSign(), sets...)
-HermitianSemidefinite(m::Integer) = ComplexVariable((m,m), :Semidefinite)
+HermitianSemidefinite(m::Integer) = ComplexVariable((m, m), :Semidefinite)
 function HermitianSemidefinite(m::Integer, n::Integer)
-    if m==n
-        return ComplexVariable((m,m), :Semidefinite)
+    if m == n
+        return ComplexVariable((m, m), :Semidefinite)
     else
         error("HermitianSemidefinite matrices must be square")
     end

--- a/test/runtests_single_solver.jl
+++ b/test/runtests_single_solver.jl
@@ -47,10 +47,10 @@ if can_solve_sdp(get_default_solver()) && can_solve_exp(get_default_solver())
 end
 
 if can_solve_mip(get_default_solver())
-	for curtest in tests_int
-    @info " Test: $(curtest)"
-    include(curtest)
-	end
+    for curtest in tests_int
+        @info " Test: $(curtest)"
+        include(curtest)
+    end
 end
 
 if can_solve_sdp(get_default_solver())

--- a/test/test_affine.jl
+++ b/test/test_affine.jl
@@ -8,410 +8,410 @@ eye(n) = Matrix(1.0I, n, n)
 
 @testset "Affine Atoms" begin
 
-  @testset "negate atom" begin
-    x = Variable()
-    p = minimize(-x, [x <= 0])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(-x) ≈ 0 atol=TOL
-  end
+    @testset "negate atom" begin
+        x = Variable()
+        p = minimize(-x, [x <= 0])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(-x) ≈ 0 atol=TOL
+    end
 
-  @testset "multiply atom" begin
-    x = Variable(1)
-    p = minimize(2.0 * x, [x >= 2, x <= 4])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test (evaluate(2.0x))[1] ≈ 4 atol=TOL
+    @testset "multiply atom" begin
+        x = Variable(1)
+        p = minimize(2.0 * x, [x >= 2, x <= 4])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test (evaluate(2.0x))[1] ≈ 4 atol=TOL
 
-    x = Variable(2)
-    A = 1.5 * eye(2)
-    p = minimize([2 2] * x, [A * x >= [1.1; 1.1]])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 2.93333 atol=TOL
-    @test (evaluate([2 2] * x))[1] ≈ 2.93333 atol=TOL
-    @test vec(evaluate(A * x)) ≈ [1.1; 1.1] atol=TOL
+        x = Variable(2)
+        A = 1.5 * eye(2)
+        p = minimize([2 2] * x, [A * x >= [1.1; 1.1]])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 2.93333 atol=TOL
+        @test (evaluate([2 2] * x))[1] ≈ 2.93333 atol=TOL
+        @test vec(evaluate(A * x)) ≈ [1.1; 1.1] atol=TOL
 
-    y = Variable(1)
-    x = Variable(3)
-    z = [1.0, 2.0, 3.0] * y
-    k = -y * [1.0, 2.0, 3.0]
-    c = [y <= 3.0, y >= 0.0, x >= ones(3), k <= x, x <= z]
-    o = 3 * y
-    p = Problem(:minimize, o, c)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
+        y = Variable(1)
+        x = Variable(3)
+        z = [1.0, 2.0, 3.0] * y
+        k = -y * [1.0, 2.0, 3.0]
+        c = [y <= 3.0, y >= 0.0, x >= ones(3), k <= x, x <= z]
+        o = 3 * y
+        p = Problem(:minimize, o, c)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
 
-    p = Problem(:minimize, o, c...)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-  end
+        p = Problem(:minimize, o, c...)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+    end
 
-  @testset "dot atom" begin
-    x = Variable(2)
-    p = minimize(dot([2.0; 2.0], x), x >= [1.1; 1.1])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 4.4 atol=TOL
-    @test (evaluate(dot([2.0; 2.0], x)))[1] ≈ 4.4 atol=TOL
-  end
+    @testset "dot atom" begin
+        x = Variable(2)
+        p = minimize(dot([2.0; 2.0], x), x >= [1.1; 1.1])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 4.4 atol=TOL
+        @test (evaluate(dot([2.0; 2.0], x)))[1] ≈ 4.4 atol=TOL
+    end
 
-  @testset "vecdot atom" begin
-    x = Variable(2,2)
-    p = minimize(vecdot(fill(2.0, (2,2)), x), x >= 1.1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 8.8 atol=TOL
-    @test (evaluate(vecdot(fill(2.0, (2, 2)), x)))[1] ≈ 8.8 atol=TOL
-  end
+    @testset "vecdot atom" begin
+        x = Variable(2,2)
+        p = minimize(vecdot(fill(2.0, (2,2)), x), x >= 1.1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 8.8 atol=TOL
+        @test (evaluate(vecdot(fill(2.0, (2, 2)), x)))[1] ≈ 8.8 atol=TOL
+    end
 
-  @testset "add atom" begin
-    x = Variable(1)
-    y = Variable(1)
-    p = minimize(x + y, [x >= 3, y >= 2])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 5 atol=TOL
-    @test evaluate(x + y) ≈ 5 atol=TOL
+    @testset "add atom" begin
+        x = Variable(1)
+        y = Variable(1)
+        p = minimize(x + y, [x >= 3, y >= 2])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 5 atol=TOL
+        @test evaluate(x + y) ≈ 5 atol=TOL
 
-    x = Variable(1)
-    p = minimize(x, [eye(2) + x >= eye(2)])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(eye(2) + x) ≈ eye(2) atol=TOL
+        x = Variable(1)
+        p = minimize(x, [eye(2) + x >= eye(2)])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(eye(2) + x) ≈ eye(2) atol=TOL
 
-    y = Variable()
-    p = minimize(y - 5, y >= -1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ -6 atol=TOL
-    @test evaluate(y - 5) ≈ -6 atol=TOL
-  end
+        y = Variable()
+        p = minimize(y - 5, y >= -1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ -6 atol=TOL
+        @test evaluate(y - 5) ≈ -6 atol=TOL
+    end
 
-  @testset "transpose atom" begin
-    x = Variable(2)
-    c = ones(2, 1)
-    p = minimize(x' * c, x >= 1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test (evaluate(x' * c))[1] ≈ 2 atol=TOL
+    @testset "transpose atom" begin
+        x = Variable(2)
+        c = ones(2, 1)
+        p = minimize(x' * c, x >= 1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test (evaluate(x' * c))[1] ≈ 2 atol=TOL
 
-    X = Variable(2, 2)
-    c = ones(2, 1)
-    p = minimize(c' * X' * c, [X >= ones(2, 2)])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test (evaluate(c' * X' * c))[1] ≈ 4 atol=TOL
+        X = Variable(2, 2)
+        c = ones(2, 1)
+        p = minimize(c' * X' * c, [X >= ones(2, 2)])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test (evaluate(c' * X' * c))[1] ≈ 4 atol=TOL
 
-    rows = 2
-    cols = 3
-    r = rand(rows, cols)
-    r_2 = rand(cols, rows)
-    x = Variable(rows, cols)
-    c = ones(1, cols)
-    d = ones(rows, 1)
-    p = minimize(c * x' * d + d' * x * c' + (c * x''''' * d)',
-                [x' >= r_2, x >= r, x''' >= r_2, x'' >= r])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    s = sum(max.(r, r_2')) * 3
-    @test p.optval ≈ s atol=TOL
-    @test (evaluate(c * x' * d + d' * x * c' + (c * ((((x')')')')' * d)'))[1] ≈ s atol=TOL
-  end
+        rows = 2
+        cols = 3
+        r = rand(rows, cols)
+        r_2 = rand(cols, rows)
+        x = Variable(rows, cols)
+        c = ones(1, cols)
+        d = ones(rows, 1)
+        p = minimize(c * x' * d + d' * x * c' + (c * x''''' * d)',
+                     [x' >= r_2, x >= r, x''' >= r_2, x'' >= r])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        s = sum(max.(r, r_2')) * 3
+        @test p.optval ≈ s atol=TOL
+        @test (evaluate(c * x' * d + d' * x * c' + (c * ((((x')')')')' * d)'))[1] ≈ s atol=TOL
+    end
 
-  @testset "index atom" begin
-    x = Variable(2)
-    p = minimize(x[1] + x[2], [x >= 1])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test (evaluate(x[1] + x[2]))[1] ≈ 2 atol=TOL
+    @testset "index atom" begin
+        x = Variable(2)
+        p = minimize(x[1] + x[2], [x >= 1])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test (evaluate(x[1] + x[2]))[1] ≈ 2 atol=TOL
 
-    x = Variable(3)
-    I = [true true false]
-    p = minimize(sum(x[I]), [x >= 1])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test (evaluate(sum(x[I])))[1] ≈ 2 atol=TOL
+        x = Variable(3)
+        I = [true true false]
+        p = minimize(sum(x[I]), [x >= 1])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test (evaluate(sum(x[I])))[1] ≈ 2 atol=TOL
 
-    rows = 6
-    cols = 8
-    n = 2
-    X = Variable(rows, cols)
-    A = randn(rows, cols)
-    c = rand(1, n)
-    p = minimize(c * X[1:n, 5:5+n-1]' * c', X >= A)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    s = c * A[1:n, 5:5+n-1]' * c'
-    @test p.optval ≈ s[1] atol=TOL
-    @test evaluate(c * (X[1:n, 5:(5 + n) - 1])' * c') ≈ s atol=TOL
-  end
+        rows = 6
+        cols = 8
+        n = 2
+        X = Variable(rows, cols)
+        A = randn(rows, cols)
+        c = rand(1, n)
+        p = minimize(c * X[1:n, 5:5+n-1]' * c', X >= A)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        s = c * A[1:n, 5:5+n-1]' * c'
+        @test p.optval ≈ s[1] atol=TOL
+        @test evaluate(c * (X[1:n, 5:(5 + n) - 1])' * c') ≈ s atol=TOL
+    end
 
-  @testset "sum atom" begin
-    x = Variable(2,2)
-    p = minimize(sum(x), x>=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test evaluate(sum(x)) ≈ 4 atol=TOL
+    @testset "sum atom" begin
+        x = Variable(2,2)
+        p = minimize(sum(x), x>=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test evaluate(sum(x)) ≈ 4 atol=TOL
 
-    x = Variable(2,2)
-    p = minimize(sum(x) - 2*x[1,1], x>=1, x[1,1]<=2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test (evaluate(sum(x) - 2 * x[1, 1]))[1] ≈ 1 atol=TOL
+        x = Variable(2,2)
+        p = minimize(sum(x) - 2*x[1,1], x>=1, x[1,1]<=2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test (evaluate(sum(x) - 2 * x[1, 1]))[1] ≈ 1 atol=TOL
 
-    x = Variable(10)
-    a = rand(10, 1)
-    p = maximize(sum(x[2:6]), x <= a)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ sum(a[2:6]) atol=TOL
-    @test evaluate(sum(x[2:6])) ≈ sum(a[2:6]) atol=TOL
-  end
+        x = Variable(10)
+        a = rand(10, 1)
+        p = maximize(sum(x[2:6]), x <= a)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ sum(a[2:6]) atol=TOL
+        @test evaluate(sum(x[2:6])) ≈ sum(a[2:6]) atol=TOL
+    end
 
-  @testset "diag atom" begin
-    x = Variable(2,2)
-    p = minimize(sum(diag(x,1)), x >= 1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test evaluate(sum(diag(x, 1))) ≈ 1 atol=TOL
+    @testset "diag atom" begin
+        x = Variable(2,2)
+        p = minimize(sum(diag(x,1)), x >= 1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test evaluate(sum(diag(x, 1))) ≈ 1 atol=TOL
 
-    x = Variable(4, 4)
-    p = minimize(sum(diag(x)), x >= 2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 8 atol=TOL
-    @test evaluate(sum(diag(x))) ≈ 8 atol=TOL
-  end
+        x = Variable(4, 4)
+        p = minimize(sum(diag(x)), x >= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 8 atol=TOL
+        @test evaluate(sum(diag(x))) ≈ 8 atol=TOL
+    end
 
-  @testset "trace atom" begin
-    x = Variable(2,2)
-    p = minimize(tr(x), x >= 1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test evaluate(tr(x)) ≈ 2 atol=TOL
-  end
+    @testset "trace atom" begin
+        x = Variable(2,2)
+        p = minimize(tr(x), x >= 1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test evaluate(tr(x)) ≈ 2 atol=TOL
+    end
 
-  @testset "dot multiply atom" begin
-    x = Variable(3)
-    p = maximize(sum(dot(*)(x,[1,2,3])), x<=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 6 atol=TOL
-    @test evaluate(sum((dot(*))(x, [1, 2, 3]))) ≈ 6 atol=TOL
+    @testset "dot multiply atom" begin
+        x = Variable(3)
+        p = maximize(sum(dot(*)(x,[1,2,3])), x<=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 6 atol=TOL
+        @test evaluate(sum((dot(*))(x, [1, 2, 3]))) ≈ 6 atol=TOL
 
-    x = Variable(3, 3)
-    p = maximize(sum(dot(*)(x,eye(3))), x<=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(sum((dot(*))(x, eye(3)))) ≈ 3 atol=TOL
+        x = Variable(3, 3)
+        p = maximize(sum(dot(*)(x,eye(3))), x<=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(sum((dot(*))(x, eye(3)))) ≈ 3 atol=TOL
 
-    x = Variable(5, 5)
-    p = minimize(x[1, 1], dot(*)(3,x) >= 3)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
+        x = Variable(5, 5)
+        p = minimize(x[1, 1], dot(*)(3,x) >= 3)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
 
-    x = Variable(3,1)
-    p = minimize(sum(dot(*)(ones(3,3), x)), x>=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 9 atol=TOL
-    @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
+        x = Variable(3,1)
+        p = minimize(sum(dot(*)(ones(3,3), x)), x>=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 9 atol=TOL
+        @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
 
-    x = Variable(1,3)
-    p = minimize(sum(dot(*)(ones(3,3), x)), x>=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 9 atol=TOL
-    @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
+        x = Variable(1,3)
+        p = minimize(sum(dot(*)(ones(3,3), x)), x>=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 9 atol=TOL
+        @test (evaluate(x[1, 1]))[1] ≈ 1 atol=TOL
 
-    x = Variable(1, 3, Positive())
-    p = maximize(sum(dot(/)(x,[1 2 3])), x<=1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 11 / 6 atol=TOL
-    @test evaluate(sum((dot(/))(x, [1 2 3]))) ≈ 11 / 6 atol=TOL
+        x = Variable(1, 3, Positive())
+        p = maximize(sum(dot(/)(x,[1 2 3])), x<=1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 11 / 6 atol=TOL
+        @test evaluate(sum((dot(/))(x, [1 2 3]))) ≈ 11 / 6 atol=TOL
 
-    # Broadcast fusion works
-    x = Variable(5, 5)
-    a = 2.0 .* x .* ones(Int, 5)
-    @test a isa DotMultiplyAtom
-  end
+        # Broadcast fusion works
+        x = Variable(5, 5)
+        a = 2.0 .* x .* ones(Int, 5)
+        @test a isa DotMultiplyAtom
+    end
 
-  @testset "reshape atom" begin
-    A = rand(2, 3)
-    X = Variable(3, 2)
-    c = rand()
-    p = minimize(sum(reshape(X, 2, 3) + A), X >= c)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ sum(A .+ c) atol=TOL
-    @test evaluate(sum(reshape(X, 2, 3) + A)) ≈ sum(A .+ c) atol=TOL
+    @testset "reshape atom" begin
+        A = rand(2, 3)
+        X = Variable(3, 2)
+        c = rand()
+        p = minimize(sum(reshape(X, 2, 3) + A), X >= c)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ sum(A .+ c) atol=TOL
+        @test evaluate(sum(reshape(X, 2, 3) + A)) ≈ sum(A .+ c) atol=TOL
 
-    b = rand(6)
-    p = minimize(sum(vec(X) + b), X >= c)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ sum(b .+ c) atol=TOL
-    @test evaluate(sum(vec(X) + b)) ≈ sum(b .+ c) atol=TOL
+        b = rand(6)
+        p = minimize(sum(vec(X) + b), X >= c)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ sum(b .+ c) atol=TOL
+        @test evaluate(sum(vec(X) + b)) ≈ sum(b .+ c) atol=TOL
 
-    x = Variable(4, 4)
-    c = ones(16, 1)
-    reshaped = reshape(x, 16, 1)
-    a = collect(1:16)
-    p = minimize(c' * reshaped, reshaped >= a)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    # TODO: why is accuracy lower here?
-    @test p.optval ≈ 136 atol=10TOL
-    @test (evaluate(c' * reshaped))[1] ≈ 136 atol=10TOL
-  end
+        x = Variable(4, 4)
+        c = ones(16, 1)
+        reshaped = reshape(x, 16, 1)
+        a = collect(1:16)
+        p = minimize(c' * reshaped, reshaped >= a)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        # TODO: why is accuracy lower here?
+        @test p.optval ≈ 136 atol=10TOL
+        @test (evaluate(c' * reshaped))[1] ≈ 136 atol=10TOL
+    end
 
-  @testset "hcat atom" begin
-    x = Variable(4, 4)
-    y = Variable(4, 6)
-    p = maximize(sum(x) + sum([y fill(4.0, 4)]), [x y fill(2.0, (4, 2))] <= 2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 96 atol=TOL
-    @test evaluate(sum(x) + sum([y fill(4.0, 4)])) ≈ 96 atol=TOL
-    @test evaluate([x y fill(2.0, (4, 2))]) ≈ fill(2.0, (4, 12)) atol=TOL
-  end
+    @testset "hcat atom" begin
+        x = Variable(4, 4)
+        y = Variable(4, 6)
+        p = maximize(sum(x) + sum([y fill(4.0, 4)]), [x y fill(2.0, (4, 2))] <= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 96 atol=TOL
+        @test evaluate(sum(x) + sum([y fill(4.0, 4)])) ≈ 96 atol=TOL
+        @test evaluate([x y fill(2.0, (4, 2))]) ≈ fill(2.0, (4, 12)) atol=TOL
+    end
 
-  @testset "vcat atom" begin
-    x = Variable(4, 4)
-    y = Variable(4, 6)
+    @testset "vcat atom" begin
+        x = Variable(4, 4)
+        y = Variable(4, 6)
 
 # TODO: fix dimension mismatch [y 4*eye(4); x -ones(4, 6)]
-    p = maximize(sum(x) + sum([y 4*eye(4); x -ones(4, 6)]), [x;y'] <= 2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    # TODO: why is accuracy lower here?
-    @test p.optval ≈ 104 atol=10TOL
-    @test evaluate(sum(x) + sum([y 4 * eye(4); x -(ones(4, 6))])) ≈ 104 atol=10TOL
-    @test evaluate([x; y']) ≈ 2 * ones(10, 4) atol=TOL
-  end
-
-  @testset "Diagonal atom" begin
-    x = Variable(2, 2)
-    @test_throws ArgumentError Diagonal(x)
-
-    x = Variable(4)
-    p = minimize(sum(Diagonal(x)), x == [1, 2, 3, 4])
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 10 atol=TOL
-    @test all(abs.(evaluate(Diagonal(x)) - Diagonal([1, 2, 3, 4])) .<= TOL)
-
-    x = Variable(3)
-    c = [1; 2; 3]
-    p = minimize(c' * Diagonal(x) * c, x >= 1, sum(x) == 10)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 21 atol=TOL
-
-    x = Variable(3)
-    p = minimize(sum(x), x >= 1, Diagonal(x)[1, 2] == 1)
-    @test solve!(p) === nothing
-    @test p.status != :Optimal
-  end
-
-  @testset "conv atom" begin
-    x = Variable(3)
-    h = [1, -1]
-    p = minimize(sum(conv(h, x)) + sum(x), x >= 1, x <= 2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
-
-    x = Variable(3)
-    h = [1, -1]
-    p = minimize(sum(conv(x, h)) + sum(x), x >= 1, x <= 2)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
-
-  end
-
-  @testset "satisfy problems" begin
-    x = Variable()
-    p = satisfy(x >= 0)
-    add_constraints!(p, x >= 1)
-    add_constraints!(p, [x >= -1, x <= 4])
-    solve!(p)
-    @test p.status == :Optimal
-
-    p = satisfy([x >= 0, x >= 1, x <= 2])
-    solve!(p)
-    @test p.status == :Optimal
-
-    p = maximize(1, [x >= 1, x <= 2])
-    solve!(p)
-    @test p.status == :Optimal
-
-    constr = x >= 0
-    constr += x >= 1
-    constr += x <= 10
-    constr2 = x >= 0
-    constr2 += [x >= 2, x <= 3] + constr
-    p = satisfy(constr)
-    solve!(p)
-    @test p.status == :Optimal
-  end
-
-  @testset "dual" begin
-    x = Variable()
-    p = minimize(x, x >= 0)
-    solve!(p)
-    if p.solution.has_dual
-        println("Solution object has dual value, checking for dual correctness.")
-        @test p.constraints[1].dual ≈ 1 atol=TOL
+        p = maximize(sum(x) + sum([y 4*eye(4); x -ones(4, 6)]), [x;y'] <= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        # TODO: why is accuracy lower here?
+        @test p.optval ≈ 104 atol=10TOL
+        @test evaluate(sum(x) + sum([y 4 * eye(4); x -(ones(4, 6))])) ≈ 104 atol=10TOL
+        @test evaluate([x; y']) ≈ 2 * ones(10, 4) atol=TOL
     end
 
-    x = Variable()
-    p = maximize(x, x <= 0)
-    solve!(p)
-    if p.solution.has_dual
-        println("Solution object has dual value, checking for dual correctness.")
-        @test p.constraints[1].dual ≈ 1 atol=TOL
+    @testset "Diagonal atom" begin
+        x = Variable(2, 2)
+        @test_throws ArgumentError Diagonal(x)
+
+        x = Variable(4)
+        p = minimize(sum(Diagonal(x)), x == [1, 2, 3, 4])
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 10 atol=TOL
+        @test all(abs.(evaluate(Diagonal(x)) - Diagonal([1, 2, 3, 4])) .<= TOL)
+
+        x = Variable(3)
+        c = [1; 2; 3]
+        p = minimize(c' * Diagonal(x) * c, x >= 1, sum(x) == 10)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 21 atol=TOL
+
+        x = Variable(3)
+        p = minimize(sum(x), x >= 1, Diagonal(x)[1, 2] == 1)
+        @test solve!(p) === nothing
+        @test p.status != :Optimal
     end
 
-    x = Variable()
-    p = minimize(x, x >= 0, x == 2)
-    solve!(p)
-    if p.solution.has_dual
-        println("Solution object has dual value, checking for dual correctness.")
-        @test p.constraints[1].dual ≈ 0 atol=TOL
-        @test abs.(p.constraints[2].dual) ≈ 1 atol=TOL
+    @testset "conv atom" begin
+        x = Variable(3)
+        h = [1, -1]
+        p = minimize(sum(conv(h, x)) + sum(x), x >= 1, x <= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
+
+        x = Variable(3)
+        h = [1, -1]
+        p = minimize(sum(conv(x, h)) + sum(x), x >= 1, x <= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
+
     end
 
-    x = Variable(2)
-    A = 1.5 * eye(2)
-    p = minimize(dot([2.0; 2.0], x), [A * x >= [1.1; 1.1]])
-    solve!(p)
-    if p.solution.has_dual
-        println("Solution object has dual value, checking for dual correctness.")
-        dual = [4/3; 4/3]
-        @test all(abs.(p.constraints[1].dual - dual) .<= TOL)
+    @testset "satisfy problems" begin
+        x = Variable()
+        p = satisfy(x >= 0)
+        add_constraints!(p, x >= 1)
+        add_constraints!(p, [x >= -1, x <= 4])
+        solve!(p)
+        @test p.status == :Optimal
+
+        p = satisfy([x >= 0, x >= 1, x <= 2])
+        solve!(p)
+        @test p.status == :Optimal
+
+        p = maximize(1, [x >= 1, x <= 2])
+        solve!(p)
+        @test p.status == :Optimal
+
+        constr = x >= 0
+        constr += x >= 1
+        constr += x <= 10
+        constr2 = x >= 0
+        constr2 += [x >= 2, x <= 3] + constr
+        p = satisfy(constr)
+        solve!(p)
+        @test p.status == :Optimal
     end
-  end
+
+    @testset "dual" begin
+        x = Variable()
+        p = minimize(x, x >= 0)
+        solve!(p)
+        if p.solution.has_dual
+            println("Solution object has dual value, checking for dual correctness.")
+            @test p.constraints[1].dual ≈ 1 atol=TOL
+        end
+
+        x = Variable()
+        p = maximize(x, x <= 0)
+        solve!(p)
+        if p.solution.has_dual
+            println("Solution object has dual value, checking for dual correctness.")
+            @test p.constraints[1].dual ≈ 1 atol=TOL
+        end
+
+        x = Variable()
+        p = minimize(x, x >= 0, x == 2)
+        solve!(p)
+        if p.solution.has_dual
+            println("Solution object has dual value, checking for dual correctness.")
+            @test p.constraints[1].dual ≈ 0 atol=TOL
+            @test abs.(p.constraints[2].dual) ≈ 1 atol=TOL
+        end
+
+        x = Variable(2)
+        A = 1.5 * eye(2)
+        p = minimize(dot([2.0; 2.0], x), [A * x >= [1.1; 1.1]])
+        solve!(p)
+        if p.solution.has_dual
+            println("Solution object has dual value, checking for dual correctness.")
+            dual = [4/3; 4/3]
+            @test all(abs.(p.constraints[1].dual - dual) .<= TOL)
+        end
+    end
 
 end

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -7,108 +7,108 @@ TOL = 1e-3
 @testset "Optimization with complex variables" begin
 
     @testset "Real Variables with complex equality constraints" begin
-    n = 10 # variable dimension (parameter)
-    m = 5 # number of constraints (parameter)
-    xo = rand(n)
-    A = randn(m,n) + im*randn(m,n)
-    b = A * xo
-    x = Variable(n)
-    p1 = minimize(sum(x), A*x == b, x>=0)
-    solve!(p1)
-    x1 = x.value
+        n = 10 # variable dimension (parameter)
+        m = 5 # number of constraints (parameter)
+        xo = rand(n)
+        A = randn(m,n) + im*randn(m,n)
+        b = A * xo
+        x = Variable(n)
+        p1 = minimize(sum(x), A*x == b, x>=0)
+        solve!(p1)
+        x1 = x.value
 
-    p2 = minimize(sum(x), real(A)*x == real(b), imag(A)*x==imag(b), x>=0)
-    solve!(p2)
-    x2 = x.value
-    @test x1 == x2
-  end
+        p2 = minimize(sum(x), real(A)*x == real(b), imag(A)*x==imag(b), x>=0)
+        solve!(p2)
+        x2 = x.value
+        @test x1 == x2
+    end
 
-  @testset "Complex Variable with complex equality constraints" begin
-    n = 10 # variable dimension (parameter)
-    m = 5 # number of constraints (parameter)
-    xo = rand(n)+im*rand(n)
-    A = randn(m,n) + im*randn(m,n)
-    b = A * xo
-    x = ComplexVariable(n)
-    p1 = minimize(real(sum(x)), A*x == b, real(x)>=0, imag(x)>=0)
-    solve!(p1)
-    x1 = x.value
+    @testset "Complex Variable with complex equality constraints" begin
+        n = 10 # variable dimension (parameter)
+        m = 5 # number of constraints (parameter)
+        xo = rand(n)+im*rand(n)
+        A = randn(m,n) + im*randn(m,n)
+        b = A * xo
+        x = ComplexVariable(n)
+        p1 = minimize(real(sum(x)), A*x == b, real(x)>=0, imag(x)>=0)
+        solve!(p1)
+        x1 = x.value
 
-    xr = Variable(n)
-    xi = Variable(n)
-    p2 = minimize(sum(xr), real(A)*xr-imag(A)*xi == real(b), imag(A)*xr+real(A)*xi == imag(b), xr>=0, xi>=0)
-    solve!(p2)
-    #x2 = xr.value + im*xi.value
-    real_diff = real(x1) - xr.value
+        xr = Variable(n)
+        xi = Variable(n)
+        p2 = minimize(sum(xr), real(A)*xr-imag(A)*xi == real(b), imag(A)*xr+real(A)*xi == imag(b), xr>=0, xi>=0)
+        solve!(p2)
+        #x2 = xr.value + im*xi.value
+        real_diff = real(x1) - xr.value
 
-    @test real_diff ≈ zeros(10, 1) atol=TOL
-    imag_diff = imag(x1) - xi.value
-    @test imag_diff ≈ zeros(10, 1) atol=TOL
-    #@fact x1==x2 --> true
-  end
+        @test real_diff ≈ zeros(10, 1) atol=TOL
+        imag_diff = imag(x1) - xi.value
+        @test imag_diff ≈ zeros(10, 1) atol=TOL
+        #@fact x1==x2 --> true
+    end
 
 
-  @testset "norm2 atom" begin
-    a = 2+4im
-    x = ComplexVariable()
-    objective = norm2(a-x)
-    c1 = real(x)>=0
-    p = minimize(objective,c1)
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(objective) ≈ 0 atol=TOL
-    real_diff = real(x.value) - real(a)
-    imag_diff = imag(x.value) - imag(a)
-    @test real_diff ≈ 0 atol=TOL
-    @test imag_diff ≈ 0 atol=TOL
+    @testset "norm2 atom" begin
+        a = 2+4im
+        x = ComplexVariable()
+        objective = norm2(a-x)
+        c1 = real(x)>=0
+        p = minimize(objective,c1)
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(objective) ≈ 0 atol=TOL
+        real_diff = real(x.value) - real(a)
+        imag_diff = imag(x.value) - imag(a)
+        @test real_diff ≈ 0 atol=TOL
+        @test imag_diff ≈ 0 atol=TOL
     end
 
     @testset "sumsquares atom" begin
-    a = [2+4im;4+6im]
-    x = ComplexVariable(2)
-    objective = sumsquares(a-x)
-    c1 = real(x)>=0
-    p = minimize(objective,c1)
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(objective) ≈ zeros(1, 1) atol=TOL
-    real_diff = real.(x.value) - real.(a)
-    imag_diff = imag.(x.value) - imag.(a)
-    @test real_diff ≈ zeros(2, 1) atol=TOL
-    @test imag_diff ≈ zeros(2, 1) atol=TOL
+        a = [2+4im;4+6im]
+        x = ComplexVariable(2)
+        objective = sumsquares(a-x)
+        c1 = real(x)>=0
+        p = minimize(objective,c1)
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(objective) ≈ zeros(1, 1) atol=TOL
+        real_diff = real.(x.value) - real.(a)
+        imag_diff = imag.(x.value) - imag.(a)
+        @test real_diff ≈ zeros(2, 1) atol=TOL
+        @test imag_diff ≈ zeros(2, 1) atol=TOL
     end
 
     @testset "abs atom" begin
-    a = [5-4im]
-    x = ComplexVariable()
-    objective = abs(a-x)
-    c1 = real(x)>=0
-    p = minimize(objective,c1)
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(objective) ≈ zeros(1) atol=TOL
-    real_diff = real(x.value) .- real(a)
-    imag_diff = imag(x.value) .- imag(a)
-    @test real_diff ≈ zeros(1) atol=TOL
-    @test imag_diff ≈ zeros(1) atol=TOL
+        a = [5-4im]
+        x = ComplexVariable()
+        objective = abs(a-x)
+        c1 = real(x)>=0
+        p = minimize(objective,c1)
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(objective) ≈ zeros(1) atol=TOL
+        real_diff = real(x.value) .- real(a)
+        imag_diff = imag(x.value) .- imag(a)
+        @test real_diff ≈ zeros(1) atol=TOL
+        @test imag_diff ≈ zeros(1) atol=TOL
     end
 
     @testset "Complex Semidefinite constraint" begin
-    n = 10
-    A = rand(n,n) + im*rand(n,n)
-    A = A + A' # now A is hermitian
-    x = ComplexVariable(n,n)
-    objective = sumsquares(A - x)
-    c1 = x in :SDP
-    p = minimize(objective, c1)
-    solve!(p)
-    # test that X is approximately equal to posA:
-    l,v = eigen(A)
-    posA = v*Diagonal(max.(l,0))*v'
+        n = 10
+        A = rand(n,n) + im*rand(n,n)
+        A = A + A' # now A is hermitian
+        x = ComplexVariable(n,n)
+        objective = sumsquares(A - x)
+        c1 = x in :SDP
+        p = minimize(objective, c1)
+        solve!(p)
+        # test that X is approximately equal to posA:
+        l,v = eigen(A)
+        posA = v*Diagonal(max.(l,0))*v'
 
-    real_diff = real.(x.value) - real.(posA)
-    imag_diff = imag.(x.value) - imag.(posA)
-    @test real_diff ≈ zeros(n, n) atol=TOL
-    @test imag_diff ≈ zeros(n, n) atol=TOL
+        real_diff = real.(x.value) - real.(posA)
+        imag_diff = imag.(x.value) - imag.(posA)
+        @test real_diff ≈ zeros(n, n) atol=TOL
+        @test imag_diff ≈ zeros(n, n) atol=TOL
     end
 end

--- a/test/test_exp.jl
+++ b/test/test_exp.jl
@@ -5,97 +5,97 @@ TOL = 1e-3
 
 @testset "Exp Atoms" begin
 
-  @testset "exp atom" begin
-    y = Variable()
-    p = minimize(exp(y), y>=0)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test evaluate(exp(y)) ≈ 1 atol=TOL
+    @testset "exp atom" begin
+        y = Variable()
+        p = minimize(exp(y), y>=0)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test evaluate(exp(y)) ≈ 1 atol=TOL
 
-    y = Variable()
-    p = minimize(exp(y), y>=1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ exp(1) atol=TOL
-    @test evaluate(exp(y)) ≈ exp(1) atol=TOL
+        y = Variable()
+        p = minimize(exp(y), y>=1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ exp(1) atol=TOL
+        @test evaluate(exp(y)) ≈ exp(1) atol=TOL
 
-    y = Variable(5)
-    p = minimize(sum(exp(y)), y>=0)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 5 atol=TOL
-    @test evaluate(sum(exp(y))) ≈ 5 atol=TOL
+        y = Variable(5)
+        p = minimize(sum(exp(y)), y>=0)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 5 atol=TOL
+        @test evaluate(sum(exp(y))) ≈ 5 atol=TOL
 
-    y = Variable(5)
-    p = minimize(sum(exp(y)), y>=0)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 5 atol=TOL
-  end
+        y = Variable(5)
+        p = minimize(sum(exp(y)), y>=0)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 5 atol=TOL
+    end
 
-  @testset "log atom" begin
-    y = Variable()
-    p = maximize(log(y), y<=1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
+    @testset "log atom" begin
+        y = Variable()
+        p = maximize(log(y), y<=1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
 
-    y = Variable()
-    p = maximize(log(y), y<=2)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ log(2) atol=TOL
+        y = Variable()
+        p = maximize(log(y), y<=2)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ log(2) atol=TOL
 
-    y = Variable()
-    p = maximize(log(y), [y<=2, exp(y)<=10])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ log(2) atol=TOL
-  end
+        y = Variable()
+        p = maximize(log(y), [y<=2, exp(y)<=10])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ log(2) atol=TOL
+    end
 
-  @testset "log sum exp atom" begin
-    y = Variable(5)
-    p = minimize(logsumexp(y), y>=1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ log(exp(1) * 5) atol=TOL
-  end
+    @testset "log sum exp atom" begin
+        y = Variable(5)
+        p = minimize(logsumexp(y), y>=1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ log(exp(1) * 5) atol=TOL
+    end
 
-  @testset "logistic loss atom" begin
-    y = Variable(5)
-    p = minimize(logisticloss(y), y>=1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ log(exp(1) + 1) * 5 atol=TOL
-  end
+    @testset "logistic loss atom" begin
+        y = Variable(5)
+        p = minimize(logisticloss(y), y>=1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ log(exp(1) + 1) * 5 atol=TOL
+    end
 
-  @testset "entropy atom" begin
-    y = Variable(5, Positive())
-    p = maximize(entropy(y), sum(y)<=1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ -(log(1 / 5)) atol=TOL
-  end
+    @testset "entropy atom" begin
+        y = Variable(5, Positive())
+        p = maximize(entropy(y), sum(y)<=1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ -(log(1 / 5)) atol=TOL
+    end
 
-  @testset "relative entropy atom" begin
-    x = Variable(1)
-    y = Variable(1)
-    # x log (x/y)
-    p = minimize(relative_entropy(x,y), y==1, x >= 2)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 2 * log(2) atol=TOL
-  end
+    @testset "relative entropy atom" begin
+        x = Variable(1)
+        y = Variable(1)
+        # x log (x/y)
+        p = minimize(relative_entropy(x,y), y==1, x >= 2)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 2 * log(2) atol=TOL
+    end
 
-  @testset "log perspective atom" begin
-    x = Variable(1)
-    y = Variable(1)
-    # y log (x/y)
-    p = maximize(log_perspective(x,y), y==5, x <= 10)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 5 * log(2) atol=TOL
-  end
+    @testset "log perspective atom" begin
+        x = Variable(1)
+        y = Variable(1)
+        # y log (x/y)
+        p = maximize(log_perspective(x,y), y==5, x <= 10)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 5 * log(2) atol=TOL
+    end
 
 end

--- a/test/test_exp_and_sdp.jl
+++ b/test/test_exp_and_sdp.jl
@@ -5,13 +5,13 @@ TOL = 1e-2
 
 @testset "SDP and Exp Atoms" begin
 
-  @testset "log det atom" begin
-    x = Variable(2, 2)
-    p = maximize(logdet(x), [x[1, 1] == 1, x[2, 2] == 1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(logdet(x)) ≈ 0 atol=TOL
-  end
+    @testset "log det atom" begin
+        x = Variable(2, 2)
+        p = maximize(logdet(x), [x[1, 1] == 1, x[2, 2] == 1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(logdet(x)) ≈ 0 atol=TOL
+    end
 
 end

--- a/test/test_int.jl
+++ b/test/test_int.jl
@@ -6,79 +6,79 @@ TOL = 1e-2
 LPsolver() = get_default_solver()
 
 if !can_solve_mip(get_default_solver())
-	using GLPKMathProgInterface
-	MIPsolver() = GLPKSolverMIP()
+    using GLPKMathProgInterface
+    MIPsolver() = GLPKSolverMIP()
 else
-	MIPsolver() = get_default_solver()
+    MIPsolver() = get_default_solver()
 end
 
 @testset "Mixed Integer Programs" begin
 
-  @testset "lp fallback interface" begin
-    x = Variable()
-    p = minimize(x, x>=4.3)
-    @test vexity(p) == AffineVexity()
-    solve!(p, LPsolver())
-    @test p.optval ≈ 4.3 atol=TOL
+    @testset "lp fallback interface" begin
+        x = Variable()
+        p = minimize(x, x>=4.3)
+        @test vexity(p) == AffineVexity()
+        solve!(p, LPsolver())
+        @test p.optval ≈ 4.3 atol=TOL
 
-    x = Variable(2)
-    p = minimize(norm(x,1), x[1]>=4.3)
-    @test vexity(p) == ConvexVexity()
-    solve!(p, LPsolver())
-    @test p.optval ≈ 4.3 atol=TOL
-  end
+        x = Variable(2)
+        p = minimize(norm(x,1), x[1]>=4.3)
+        @test vexity(p) == ConvexVexity()
+        solve!(p, LPsolver())
+        @test p.optval ≈ 4.3 atol=TOL
+    end
 
-  @testset "integer variables" begin
-    x = Variable(:Int)
-    p = minimize(x, x>=4.3)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 5 atol=TOL
+    @testset "integer variables" begin
+        x = Variable(:Int)
+        p = minimize(x, x>=4.3)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 5 atol=TOL
 
-    x = Variable(2, :Int)
-    p = minimize(sum(x), x>=4.3)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 10 atol=TOL
+        x = Variable(2, :Int)
+        p = minimize(sum(x), x>=4.3)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 10 atol=TOL
 
-    x = Variable(:Int)
-    y = Variable()
-    p = minimize(sum(x + y), x>=4.3, y>=7)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 12 atol=TOL
+        x = Variable(:Int)
+        y = Variable()
+        p = minimize(sum(x + y), x>=4.3, y>=7)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 12 atol=TOL
 
-    x = Variable(2, :Int)
-    p = minimize(norm(x, 1), x[1]>=4.3)
-    @test vexity(p) == ConvexVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 5 atol=TOL
+        x = Variable(2, :Int)
+        p = minimize(norm(x, 1), x[1]>=4.3)
+        @test vexity(p) == ConvexVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 5 atol=TOL
 
-    x = Variable(2, :Int)
-    p = minimize(sum(x), x[1]>=4.3, x>=0)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 5 atol=TOL
+        x = Variable(2, :Int)
+        p = minimize(sum(x), x[1]>=4.3, x>=0)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 5 atol=TOL
 
-    x = Variable(2, :Int)
-    p = minimize(sum(x), x>=.5)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 2 atol=TOL
-  end
+        x = Variable(2, :Int)
+        p = minimize(sum(x), x>=.5)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 2 atol=TOL
+    end
 
-  @testset "binary variables" begin
-    x = Variable(2, :Bin)
-    p = minimize(sum(x), x>=.5)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 2 atol=TOL
+    @testset "binary variables" begin
+        x = Variable(2, :Bin)
+        p = minimize(sum(x), x>=.5)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 2 atol=TOL
 
-    x = Variable(2, :Bin)
-    p = minimize(sum(x), x[1]>=.5, x>=0)
-    @test vexity(p) == AffineVexity()
-    solve!(p, MIPsolver())
-    @test p.optval ≈ 1 atol=TOL
-  end
+        x = Variable(2, :Bin)
+        p = minimize(sum(x), x[1]>=.5, x>=0)
+        @test vexity(p) == AffineVexity()
+        solve!(p, MIPsolver())
+        @test p.optval ≈ 1 atol=TOL
+    end
 
 end

--- a/test/test_lp.jl
+++ b/test/test_lp.jl
@@ -6,171 +6,171 @@ TOL = 1e-3
 
 @testset "LP Atoms" begin
 
-  @testset "abs atom" begin
-    x = Variable()
-    p = minimize(abs(x), x<=-1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test evaluate(abs(x)) ≈ 1 atol=TOL
+    @testset "abs atom" begin
+        x = Variable()
+        p = minimize(abs(x), x<=-1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test evaluate(abs(x)) ≈ 1 atol=TOL
 
-    x = Variable(2,2)
-    p = minimize(sum(abs(x)), x[2,2]>=1, x[1,1]>=1, x>=0)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test evaluate(sum(abs(x))) ≈ 2 atol=TOL
-  end
+        x = Variable(2,2)
+        p = minimize(sum(abs(x)), x[2,2]>=1, x[1,1]>=1, x>=0)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test evaluate(sum(abs(x))) ≈ 2 atol=TOL
+    end
 
-  @testset "maximum atom" begin
-    x = Variable(10)
-    a = shuffle(collect(0.1:0.1:1.0))
-    p = minimize(maximum(x), x >= a)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ maximum(a) atol=TOL
-    @test evaluate(maximum(x)) ≈ maximum(a) atol=TOL
-  end
+    @testset "maximum atom" begin
+        x = Variable(10)
+        a = shuffle(collect(0.1:0.1:1.0))
+        p = minimize(maximum(x), x >= a)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ maximum(a) atol=TOL
+        @test evaluate(maximum(x)) ≈ maximum(a) atol=TOL
+    end
 
-  @testset "minimum atom" begin
-    x = Variable(1)
-    a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
-    p = maximize(minimum(x), x <= a)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ minimum(a) atol=TOL
-    @test evaluate(minimum(x)) ≈ minimum(a) atol=TOL
+    @testset "minimum atom" begin
+        x = Variable(1)
+        a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
+        p = maximize(minimum(x), x <= a)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ minimum(a) atol=TOL
+        @test evaluate(minimum(x)) ≈ minimum(a) atol=TOL
 
-    x = Variable(4, 4)
-    y = Variable(4, 6)
-    z = Variable(1)
-    c = ones(4, 1)
-    d = fill(2.0, (6, 1))
-    constraints = [[x y] <= 2, z <= 0, z <= x, 2z >= -1]
-    objective = sum(x + z) + minimum(y) + c' * y * d
-    p = maximize(objective, constraints)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 130 atol=TOL
-    @test (evaluate(objective))[1] ≈ 130 atol=TOL
-  end
+        x = Variable(4, 4)
+        y = Variable(4, 6)
+        z = Variable(1)
+        c = ones(4, 1)
+        d = fill(2.0, (6, 1))
+        constraints = [[x y] <= 2, z <= 0, z <= x, 2z >= -1]
+        objective = sum(x + z) + minimum(y) + c' * y * d
+        p = maximize(objective, constraints)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 130 atol=TOL
+        @test (evaluate(objective))[1] ≈ 130 atol=TOL
+    end
 
-  @testset "max atom" begin
-    x = Variable(10, 10)
-    y = Variable(10, 10)
-    a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
-    b = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
-    p = minimize(maximum(max(x, y)), [x >= a, y >= b])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    max_a = maximum(a)
-    max_b = maximum(b)
-    @test p.optval ≈ max(max_a, max_b) atol=10TOL
-    @test evaluate(maximum(max(x, y))) ≈ max(max_a, max_b) atol=10TOL
-  end
+    @testset "max atom" begin
+        x = Variable(10, 10)
+        y = Variable(10, 10)
+        a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
+        b = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
+        p = minimize(maximum(max(x, y)), [x >= a, y >= b])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        max_a = maximum(a)
+        max_b = maximum(b)
+        @test p.optval ≈ max(max_a, max_b) atol=10TOL
+        @test evaluate(maximum(max(x, y))) ≈ max(max_a, max_b) atol=10TOL
+    end
 
-  @testset "min atom" begin
-    x = Variable(10, 10)
-    y = Variable(10, 10)
-    a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
-    b = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
-    p = maximize(minimum(min(x, y)), [x <= a, y <= b])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    min_a = minimum(a)
-    min_b = minimum(b)
-    @test p.optval ≈ min(min_a, min_b) atol=10TOL
-    @test evaluate(minimum(min(x, y))) ≈ min(min_a, min_b) atol=10TOL
-  end
+    @testset "min atom" begin
+        x = Variable(10, 10)
+        y = Variable(10, 10)
+        a = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
+        b = reshape(shuffle(collect(0.01:0.01:1.0)), (10, 10))
+        p = maximize(minimum(min(x, y)), [x <= a, y <= b])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        min_a = minimum(a)
+        min_b = minimum(b)
+        @test p.optval ≈ min(min_a, min_b) atol=10TOL
+        @test evaluate(minimum(min(x, y))) ≈ min(min_a, min_b) atol=10TOL
+    end
 
-  @testset "pos atom" begin
-    x = Variable(3)
-    a = [-2; 1; 2]
-    p = minimize(sum(pos(x)), [x >= a, x <= 2])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(sum(pos(x))) ≈ 3 atol=TOL
-  end
+    @testset "pos atom" begin
+        x = Variable(3)
+        a = [-2; 1; 2]
+        p = minimize(sum(pos(x)), [x >= a, x <= 2])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(sum(pos(x))) ≈ 3 atol=TOL
+    end
 
-  @testset "neg atom" begin
-    x = Variable(3)
-    p = minimize(1, [x >= -2, x <= -2, neg(x) >= -3])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-    @test evaluate(sum(neg(x))) ≈ -6 atol=TOL
-  end
+    @testset "neg atom" begin
+        x = Variable(3)
+        p = minimize(1, [x >= -2, x <= -2, neg(x) >= -3])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+        @test evaluate(sum(neg(x))) ≈ -6 atol=TOL
+    end
 
-  @testset "sumlargest atom" begin
-    x = Variable(2)
-    p = minimize(sumlargest(x, 2), x >= [1; 1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test evaluate(sumlargest(x, 2)) ≈ 2 atol=TOL
+    @testset "sumlargest atom" begin
+        x = Variable(2)
+        p = minimize(sumlargest(x, 2), x >= [1; 1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test evaluate(sumlargest(x, 2)) ≈ 2 atol=TOL
 
-    x = Variable(4, 4)
-    p = minimize(sumlargest(x, 3), x >= eye(4), x[1, 1] >= 1.5, x[2, 3] >= 2.1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 4.6 atol=TOL
-    @test evaluate(sumlargest(x, 2)) ≈ 3.6 atol=TOL
-  end
+        x = Variable(4, 4)
+        p = minimize(sumlargest(x, 3), x >= eye(4), x[1, 1] >= 1.5, x[2, 3] >= 2.1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 4.6 atol=TOL
+        @test evaluate(sumlargest(x, 2)) ≈ 3.6 atol=TOL
+    end
 
-  @testset "sumsmallest atom" begin
-    x = Variable(4, 4)
-    p = minimize(sumlargest(x, 2), sumsmallest(x, 4) >= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.5 atol=TOL
-    @test evaluate(sumsmallest(x, 4)) ≈ 1 atol=TOL
+    @testset "sumsmallest atom" begin
+        x = Variable(4, 4)
+        p = minimize(sumlargest(x, 2), sumsmallest(x, 4) >= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.5 atol=TOL
+        @test evaluate(sumsmallest(x, 4)) ≈ 1 atol=TOL
 
-    x = Variable(3, 2)
-    p = maximize(sumsmallest(x, 3), x >= 2, x <= 5, sumlargest(x, 3) <= 12)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 12 atol=TOL
-    @test evaluate(sumsmallest(x, 3)) ≈ 12 atol=TOL
-  end
+        x = Variable(3, 2)
+        p = maximize(sumsmallest(x, 3), x >= 2, x <= 5, sumlargest(x, 3) <= 12)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 12 atol=TOL
+        @test evaluate(sumsmallest(x, 3)) ≈ 12 atol=TOL
+    end
 
-  @testset "dotsort atom" begin
-    x = Variable(4, 1)
-    p = minimize(dotsort(x, [1, 2, 3, 4]), sum(x) >= 7, x >= 0, x <= 2, x[4] <= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 19 atol=TOL
-    @test vec(x.value) ≈ [2; 2; 2; 1] atol=TOL
-    @test evaluate(dotsort(x, [1, 2, 3, 4])) ≈ 19 atol=TOL
+    @testset "dotsort atom" begin
+        x = Variable(4, 1)
+        p = minimize(dotsort(x, [1, 2, 3, 4]), sum(x) >= 7, x >= 0, x <= 2, x[4] <= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 19 atol=TOL
+        @test vec(x.value) ≈ [2; 2; 2; 1] atol=TOL
+        @test evaluate(dotsort(x, [1, 2, 3, 4])) ≈ 19 atol=TOL
 
-    x = Variable(2, 2)
-    p = minimize(dotsort(x, [1 2; 3 4]), sum(x) >= 7, x >= 0, x <= 2, x[2, 2] <= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 19 atol=TOL
-    @test evaluate(dotsort(x, [1, 2, 3, 4])) ≈ 19 atol=TOL
-  end
+        x = Variable(2, 2)
+        p = minimize(dotsort(x, [1 2; 3 4]), sum(x) >= 7, x >= 0, x <= 2, x[2, 2] <= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 19 atol=TOL
+        @test evaluate(dotsort(x, [1, 2, 3, 4])) ≈ 19 atol=TOL
+    end
 
-  @testset "hinge loss atom" begin
-    # TODO: @davidlizeng. We should finish this someday.
-  end
+    @testset "hinge loss atom" begin
+        # TODO: @davidlizeng. We should finish this someday.
+    end
 
-  @testset "norm inf atom" begin
-    x = Variable(3)
-    p = minimize(norm_inf(x), [-2 <= x, x <= 1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(norm_inf(x)) ≈ 0 atol=TOL
-  end
+    @testset "norm inf atom" begin
+        x = Variable(3)
+        p = minimize(norm_inf(x), [-2 <= x, x <= 1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(norm_inf(x)) ≈ 0 atol=TOL
+    end
 
-  @testset "norm 1 atom" begin
-    x = Variable(3)
-    p = minimize(norm_1(x), [-2 <= x, x <= 1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
-    @test evaluate(norm_1(x)) ≈ 0 atol=TOL
-  end
+    @testset "norm 1 atom" begin
+        x = Variable(3)
+        p = minimize(norm_1(x), [-2 <= x, x <= 1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+        @test evaluate(norm_1(x)) ≈ 0 atol=TOL
+    end
 
 end

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -6,42 +6,42 @@ TOL = 1e-3
 
 @testset "Fixed and freed variables" begin
 
-  @testset "fix and free addition" begin
-	x = Variable()
-	y = Variable()
+    @testset "fix and free addition" begin
+        x = Variable()
+        y = Variable()
 
-	p = minimize(x+y, x>=0, y>=0)
-	solve!(p)
-	@test p.optval ≈ 0 atol=TOL
+        p = minimize(x+y, x>=0, y>=0)
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
 
-	y.value = 4
-	fix!(y)
-	solve!(p)
-	@test p.optval ≈ 4 atol=TOL
+        y.value = 4
+        fix!(y)
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
 
-	free!(y)
-	solve!(p)
-	@test p.optval ≈ 0 atol=TOL
-  end
+        free!(y)
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
+    end
 
-  @testset "fix multiplication" begin
-    a = [1,2,3,2,1]
-    x = Variable(length(a))
-    gamma = Variable(Positive())
-    fix!(gamma, 0.7)
+    @testset "fix multiplication" begin
+        a = [1,2,3,2,1]
+        x = Variable(length(a))
+        gamma = Variable(Positive())
+        fix!(gamma, 0.7)
 
-    p = minimize(norm(x-a) + gamma*norm(x[1:end-1] - x[2:end]))
-    solve!(p)
-    o1 = p.optval
-	# x should be very close to a
-    @test o1 ≈ 0.7 * norm(a[1:end - 1] - a[2:end]) atol=TOL
-	# increase regularization
-    fix!(gamma, 1.0)
-    solve!(p)
-    o2 = p.optval
-	# x should be very close to mean(a)
-    @test o2 ≈ norm(a .- mean(a)) atol=TOL
+        p = minimize(norm(x-a) + gamma*norm(x[1:end-1] - x[2:end]))
+        solve!(p)
+        o1 = p.optval
+        # x should be very close to a
+        @test o1 ≈ 0.7 * norm(a[1:end - 1] - a[2:end]) atol=TOL
+        # increase regularization
+        fix!(gamma, 1.0)
+        solve!(p)
+        o2 = p.optval
+        # x should be very close to mean(a)
+        @test o2 ≈ norm(a .- mean(a)) atol=TOL
 
-    @test o1 <= o2
-  end
+        @test o1 <= o2
+    end
 end

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -9,176 +9,176 @@ eye(n) = Matrix(1.0I, n, n)
 # TODO: uncomment vexity checks once SDP on vars/constraints changes vexity of problem
 
 @testset "SDP Atoms" begin
-  @testset "sdp variables" begin
-    y = Variable((2,2), :Semidefinite)
-    p = minimize(y[1,1])
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
+    @testset "sdp variables" begin
+        y = Variable((2,2), :Semidefinite)
+        p = minimize(y[1,1])
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
 
-    y = Variable((3,3), :Semidefinite)
-    p = minimize(y[1,1], y[2,2]==1)
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0 atol=TOL
+        y = Variable((3,3), :Semidefinite)
+        p = minimize(y[1,1], y[2,2]==1)
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0 atol=TOL
 
-    # Solution is obtained as y[2,2] -> infinity
-    # This test fails on Mosek. See
-    # https://github.com/JuliaOpt/Mosek.jl/issues/29
-    # y = Variable((2, 2), :Semidefinite)
-    # p = minimize(y[1, 1], y[1, 2] == 1)
-    # # @fact vexity(p) --> ConvexVexity()
-    # solve!(p)
-    # @fact p.optval --> roughly(0, TOL)
+        # Solution is obtained as y[2,2] -> infinity
+        # This test fails on Mosek. See
+        # https://github.com/JuliaOpt/Mosek.jl/issues/29
+        # y = Variable((2, 2), :Semidefinite)
+        # p = minimize(y[1, 1], y[1, 2] == 1)
+        # # @fact vexity(p) --> ConvexVexity()
+        # solve!(p)
+        # @fact p.optval --> roughly(0, TOL)
 
-    y = Semidefinite(3)
-    p = minimize(sum(diag(y)), y[1, 1] == 1)
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
+        y = Semidefinite(3)
+        p = minimize(sum(diag(y)), y[1, 1] == 1)
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
 
-    y = Variable((3, 3), :Semidefinite)
-    p = minimize(tr(y), y[2,1]<=4, y[2,2]>=3)
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
+        y = Variable((3, 3), :Semidefinite)
+        p = minimize(tr(y), y[2,1]<=4, y[2,2]>=3)
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
 
-    x = Variable(Positive())
-    y = Semidefinite(3)
-    p = minimize(y[1, 2], y[2, 1] == 1)
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-  end
+        x = Variable(Positive())
+        y = Semidefinite(3)
+        p = minimize(y[1, 2], y[2, 1] == 1)
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+    end
 
-  @testset "sdp constraints" begin
-    # This test fails on Mosek
-    x = Variable(Positive())
-    y = Variable((3, 3))
-    p = minimize(x + y[1, 1], isposdef(y), x >= 1, y[2, 1] == 1)
-    # @fact vexity(p) --> ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 1 atol=TOL
-  end
+    @testset "sdp constraints" begin
+        # This test fails on Mosek
+        x = Variable(Positive())
+        y = Variable((3, 3))
+        p = minimize(x + y[1, 1], isposdef(y), x >= 1, y[2, 1] == 1)
+        # @fact vexity(p) --> ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 1 atol=TOL
+    end
 
-  @testset "nuclear norm atom" begin
-    y = Semidefinite(3)
-    p = minimize(nuclearnorm(y), y[2,1]<=4, y[2,2]>=3, y[3,3]<=2)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(nuclearnorm(y)) ≈ 3 atol=TOL
-  end
+    @testset "nuclear norm atom" begin
+        y = Semidefinite(3)
+        p = minimize(nuclearnorm(y), y[2,1]<=4, y[2,2]>=3, y[3,3]<=2)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(nuclearnorm(y)) ≈ 3 atol=TOL
+    end
 
-  @testset "operator norm atom" begin
-    y = Variable((3,3))
-    p = minimize(opnorm(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test evaluate(opnorm(y)) ≈ 4 atol=TOL
-  end
+    @testset "operator norm atom" begin
+        y = Variable((3,3))
+        p = minimize(opnorm(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test evaluate(opnorm(y)) ≈ 4 atol=TOL
+    end
 
-  @testset "sigma max atom" begin
-    y = Variable((3,3))
-    p = minimize(sigmamax(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test evaluate(sigmamax(y)) ≈ 4 atol=TOL
-  end
+    @testset "sigma max atom" begin
+        y = Variable((3,3))
+        p = minimize(sigmamax(y), y[2,1]<=4, y[2,2]>=3, sum(y)>=12)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test evaluate(sigmamax(y)) ≈ 4 atol=TOL
+    end
 
-  @testset "lambda max atom" begin
-    y = Semidefinite(3)
-    p = minimize(lambdamax(y), y[1,1]>=4)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test evaluate(lambdamax(y)) ≈ 4 atol=TOL
-  end
+    @testset "lambda max atom" begin
+        y = Semidefinite(3)
+        p = minimize(lambdamax(y), y[1,1]>=4)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test evaluate(lambdamax(y)) ≈ 4 atol=TOL
+    end
 
-  @testset "lambda min atom" begin
-    y = Semidefinite(3)
-    p = maximize(lambdamin(y), tr(y)<=6)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test evaluate(lambdamin(y)) ≈ 2 atol=TOL
-  end
+    @testset "lambda min atom" begin
+        y = Semidefinite(3)
+        p = maximize(lambdamin(y), tr(y)<=6)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test evaluate(lambdamin(y)) ≈ 2 atol=TOL
+    end
 
-  @testset "matrix frac atom" begin
-    x = [1, 2, 3]
-    P = Variable(3, 3)
-    p = minimize(matrixfrac(x, P), P <= 2*eye(3), P >= 0.5 * eye(3))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 7 atol=TOL
-    @test (evaluate(matrixfrac(x, P)))[1] ≈ 7 atol=TOL
-  end
+    @testset "matrix frac atom" begin
+        x = [1, 2, 3]
+        P = Variable(3, 3)
+        p = minimize(matrixfrac(x, P), P <= 2*eye(3), P >= 0.5 * eye(3))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 7 atol=TOL
+        @test (evaluate(matrixfrac(x, P)))[1] ≈ 7 atol=TOL
+    end
 
-  @testset "matrix frac atom both arguments variable" begin
-    x = Variable(3)
-    P = Variable(3, 3)
-    p = minimize(matrixfrac(x, P), lambdamax(P) <= 2, x[1] >= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.5 atol=TOL
-    @test (evaluate(matrixfrac(x, P)))[1] ≈ 0.5 atol=TOL
-  end
+    @testset "matrix frac atom both arguments variable" begin
+        x = Variable(3)
+        P = Variable(3, 3)
+        p = minimize(matrixfrac(x, P), lambdamax(P) <= 2, x[1] >= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.5 atol=TOL
+        @test (evaluate(matrixfrac(x, P)))[1] ≈ 0.5 atol=TOL
+    end
 
-  @testset "sum largest eigs" begin
-    x = Semidefinite(3)
-    p = minimize(sumlargesteigs(x, 2), x >= 1)
-    solve!(p)
-    @test p.optval ≈ 3 atol=TOL
-    @test evaluate(x) ≈ ones(3, 3) atol=TOL
+    @testset "sum largest eigs" begin
+        x = Semidefinite(3)
+        p = minimize(sumlargesteigs(x, 2), x >= 1)
+        solve!(p)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(x) ≈ ones(3, 3) atol=TOL
 
-    x = Semidefinite(3)
-    p = minimize(sumlargesteigs(x, 2), [x[i,:] >= i for i=1:3]...)
-    solve!(p)
-    @test p.optval ≈ 8.4853 atol=TOL
+        x = Semidefinite(3)
+        p = minimize(sumlargesteigs(x, 2), [x[i,:] >= i for i=1:3]...)
+        solve!(p)
+        @test p.optval ≈ 8.4853 atol=TOL
 
-    x1 = Semidefinite(3)
-    p1 = minimize(lambdamax(x1), x1[1,1]>=4)
-    solve!(p1)
+        x1 = Semidefinite(3)
+        p1 = minimize(lambdamax(x1), x1[1,1]>=4)
+        solve!(p1)
 
-    x2 = Semidefinite(3)
-    p2 = minimize(sumlargesteigs(x2, 1), x2[1,1]>=4)
-    solve!(p2)
+        x2 = Semidefinite(3)
+        p2 = minimize(sumlargesteigs(x2, 1), x2[1,1]>=4)
+        solve!(p2)
 
-    @test p1.optval ≈ p2.optval atol=TOL
+        @test p1.optval ≈ p2.optval atol=TOL
 
-    x1 = Semidefinite(3)
-    p1 = minimize(lambdamax(x1), [x1[i,:] >= i for i=1:3]...)
-    solve!(p1)
+        x1 = Semidefinite(3)
+        p1 = minimize(lambdamax(x1), [x1[i,:] >= i for i=1:3]...)
+        solve!(p1)
 
-    x2 = Semidefinite(3)
-    p2 = minimize(sumlargesteigs(x2, 1), [x2[i,:] >= i for i=1:3]...)
-    solve!(p2)
+        x2 = Semidefinite(3)
+        p2 = minimize(sumlargesteigs(x2, 1), [x2[i,:] >= i for i=1:3]...)
+        solve!(p2)
 
-    @test p1.optval ≈ p2.optval atol=TOL
+        @test p1.optval ≈ p2.optval atol=TOL
 
-    println(p1.optval)
-  end
+        println(p1.optval)
+    end
 
-  @testset "kron atom" begin
-    id = eye(4)
-    X = Semidefinite(4)
-    W = kron(id, X)
-    p = maximize(tr(W), tr(X) ≤ 1)
-    @test vexity(p) == AffineVexity()
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-  end
+    @testset "kron atom" begin
+        id = eye(4)
+        X = Semidefinite(4)
+        W = kron(id, X)
+        p = maximize(tr(W), tr(X) ≤ 1)
+        @test vexity(p) == AffineVexity()
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+    end
 
-  @testset "Partial trace" begin
-    A = Semidefinite(2)
-    B = [1 0; 0 0]
-    ρ = kron(B, A)
-    constraints = [partialtrace(ρ, 1, [2; 2]) == [0.09942819 0.29923607; 0.29923607 0.90057181], ρ in :SDP]
-    p = satisfy(constraints)
-    solve!(p)
-    @test evaluate(ρ) ≈ [0.09942819 0.29923607 0 0; 0.299237 0.900572 0 0; 0 0 0 0; 0 0 0 0] atol=TOL
-    @test evaluate(partialtrace(ρ, 1, [2; 2])) ≈ [1.0 0; 0 0] atol=TOL
-  end
+    @testset "Partial trace" begin
+        A = Semidefinite(2)
+        B = [1 0; 0 0]
+        ρ = kron(B, A)
+        constraints = [partialtrace(ρ, 1, [2; 2]) == [0.09942819 0.29923607; 0.29923607 0.90057181], ρ in :SDP]
+        p = satisfy(constraints)
+        solve!(p)
+        @test evaluate(ρ) ≈ [0.09942819 0.29923607 0 0; 0.299237 0.900572 0 0; 0 0 0 0; 0 0 0 0] atol=TOL
+        @test evaluate(partialtrace(ρ, 1, [2; 2])) ≈ [1.0 0; 0 0] atol=TOL
+    end
 end

--- a/test/test_socp.jl
+++ b/test/test_socp.jl
@@ -6,242 +6,242 @@ TOL = 1e-3
 
 @testset "SOCP Atoms" begin
 
-  @testset "norm 2 atom" begin
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    p = minimize(norm2(A * x + b))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.64888 atol=TOL
-    @test evaluate(norm2(A * x + b)) ≈ 0.64888 atol=TOL
+    @testset "norm 2 atom" begin
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        p = minimize(norm2(A * x + b))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.64888 atol=TOL
+        @test evaluate(norm2(A * x + b)) ≈ 0.64888 atol=TOL
 
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    lambda = 1
-    p = minimize(norm2(A * x + b) + lambda * norm2(x), x >= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 14.9049 atol=TOL
-    @test evaluate(norm2(A * x + b) + lambda * norm2(x)) ≈ 14.9049 atol=TOL
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        lambda = 1
+        p = minimize(norm2(A * x + b) + lambda * norm2(x), x >= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 14.9049 atol=TOL
+        @test evaluate(norm2(A * x + b) + lambda * norm2(x)) ≈ 14.9049 atol=TOL
 
-    x = Variable(2)
+        x = Variable(2)
 
-    p = minimize(norm2([x[1] + 2x[2] + 2; 2x[1] + x[2] + 3; 3x[1]+4x[2] + 4]) + lambda * norm2(x), x >= 1)
-    @test vexity(p) == ConvexVexity()
+        p = minimize(norm2([x[1] + 2x[2] + 2; 2x[1] + x[2] + 3; 3x[1]+4x[2] + 4]) + lambda * norm2(x), x >= 1)
+        @test vexity(p) == ConvexVexity()
 
-    solve!(p)
-    @test p.optval ≈ 14.9049 atol=TOL
-    @test evaluate(norm2(A * x + b) + lambda * norm2(x)) ≈ 14.9049 atol=TOL
+        solve!(p)
+        @test p.optval ≈ 14.9049 atol=TOL
+        @test evaluate(norm2(A * x + b) + lambda * norm2(x)) ≈ 14.9049 atol=TOL
 
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    lambda = 1
-    p = minimize(norm2(A * x + b) + lambda * norm_1(x), x >= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 15.4907 atol=TOL
-    @test evaluate(norm2(A * x + b) + lambda * norm_1(x)) ≈ 15.4907 atol=TOL
-  end
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        lambda = 1
+        p = minimize(norm2(A * x + b) + lambda * norm_1(x), x >= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 15.4907 atol=TOL
+        @test evaluate(norm2(A * x + b) + lambda * norm_1(x)) ≈ 15.4907 atol=TOL
+    end
 
-  @testset "frobenius norm atom" begin
-    m = Variable(4, 5)
-    c = [m[3, 3] == 4, m >= 1]
-    p = minimize(norm(vec(m), 2), c)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ sqrt(35) atol=TOL
-    @test evaluate(norm(vec(m), 2)) ≈ sqrt(35) atol=TOL
-  end
+    @testset "frobenius norm atom" begin
+        m = Variable(4, 5)
+        c = [m[3, 3] == 4, m >= 1]
+        p = minimize(norm(vec(m), 2), c)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ sqrt(35) atol=TOL
+        @test evaluate(norm(vec(m), 2)) ≈ sqrt(35) atol=TOL
+    end
 
-  @testset "quad over lin atom" begin
-    x = Variable(3, 1)
-    A = [2 -3 5; -2 9 -3; 5 -8 3]
-    b = [-3; 9; 5]
-    c = [3 2 4]
-    d = -3
-    p = minimize(quadoverlin(A*x + b, c*x + d))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 17.7831 atol=TOL
-    @test (evaluate(quadoverlin(A * x + b, c * x + d)))[1] ≈ 17.7831 atol=TOL
-  end
+    @testset "quad over lin atom" begin
+        x = Variable(3, 1)
+        A = [2 -3 5; -2 9 -3; 5 -8 3]
+        b = [-3; 9; 5]
+        c = [3 2 4]
+        d = -3
+        p = minimize(quadoverlin(A*x + b, c*x + d))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 17.7831 atol=TOL
+        @test (evaluate(quadoverlin(A * x + b, c * x + d)))[1] ≈ 17.7831 atol=TOL
+    end
 
-  @testset "sum squares atom" begin
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    p = minimize(sumsquares(A*x + b))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.42105 atol=TOL
-    @test (evaluate(sumsquares(A * x + b)))[1] ≈ 0.42105 atol=TOL
-  end
+    @testset "sum squares atom" begin
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        p = minimize(sumsquares(A*x + b))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.42105 atol=TOL
+        @test (evaluate(sumsquares(A * x + b)))[1] ≈ 0.42105 atol=TOL
+    end
 
-  @testset "square atom" begin
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    p = minimize(sum(square(A*x + b)))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.42105 atol=TOL
-    @test evaluate(sum(square(A * x + b))) ≈ 0.42105 atol=TOL
+    @testset "square atom" begin
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        p = minimize(sum(square(A*x + b)))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.42105 atol=TOL
+        @test evaluate(sum(square(A * x + b))) ≈ 0.42105 atol=TOL
 
-    x = Variable(2, 1)
-    A = [1 2; 2 1; 3 4]
-    b = [2; 3; 4]
-    expr = A * x + b
-    p = minimize(sum(dot(^)(expr,2))) # elementwise ^
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.42105 atol=TOL
-    @test evaluate(sum(broadcast(^, expr, 2))) ≈ 0.42105 atol=TOL
+        x = Variable(2, 1)
+        A = [1 2; 2 1; 3 4]
+        b = [2; 3; 4]
+        expr = A * x + b
+        p = minimize(sum(dot(^)(expr,2))) # elementwise ^
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.42105 atol=TOL
+        @test evaluate(sum(broadcast(^, expr, 2))) ≈ 0.42105 atol=TOL
 
-    p = minimize(sum(dot(*)(expr, expr))) # elementwise *
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 0.42105 atol=TOL
-    @test evaluate(sum((dot(*))(expr, expr))) ≈ 0.42105 atol=TOL
-  end
+        p = minimize(sum(dot(*)(expr, expr))) # elementwise *
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 0.42105 atol=TOL
+        @test evaluate(sum((dot(*))(expr, expr))) ≈ 0.42105 atol=TOL
+    end
 
-  @testset "inv pos atom" begin
-    x = Variable(4)
-    p = minimize(sum(invpos(x)), invpos(x) < 2, x > 1, x == 2, 2 == x)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 2 atol=TOL
-    @test evaluate(sum(invpos(x))) ≈ 2 atol=TOL
+    @testset "inv pos atom" begin
+        x = Variable(4)
+        p = minimize(sum(invpos(x)), invpos(x) < 2, x > 1, x == 2, 2 == x)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 2 atol=TOL
+        @test evaluate(sum(invpos(x))) ≈ 2 atol=TOL
 
-    x = Variable(3)
-    p = minimize(sum(dot(/)([3,6,9], x)), x<=3)
-    solve!(p)
-    @test x.value ≈ fill(3.0, (3, 1)) atol=TOL
-    @test p.optval ≈ 6 atol=TOL
-    @test evaluate(sum((dot(/))([3, 6, 9], x))) ≈ 6 atol=TOL
+        x = Variable(3)
+        p = minimize(sum(dot(/)([3,6,9], x)), x<=3)
+        solve!(p)
+        @test x.value ≈ fill(3.0, (3, 1)) atol=TOL
+        @test p.optval ≈ 6 atol=TOL
+        @test evaluate(sum((dot(/))([3, 6, 9], x))) ≈ 6 atol=TOL
 
-    x = Variable()
-    p = minimize(sum([3,6,9]/x), x<=3)
-    solve!(p)
-    @test x.value ≈ 3 atol=TOL
-    @test p.optval ≈ 6 atol=TOL
-    @test evaluate(sum([3, 6, 9] / x)) ≈ 6 atol=TOL
-  end
+        x = Variable()
+        p = minimize(sum([3,6,9]/x), x<=3)
+        solve!(p)
+        @test x.value ≈ 3 atol=TOL
+        @test p.optval ≈ 6 atol=TOL
+        @test evaluate(sum([3, 6, 9] / x)) ≈ 6 atol=TOL
+    end
 
-  @testset "geo mean atom" begin
-    x = Variable(2)
-    y = Variable(2)
-    p = minimize(geomean(x, y), x >= 1, y >= 2)
-    # not DCP compliant
-    @test vexity(p) == ConcaveVexity()
-    p = maximize(geomean(x, y), 1 < x, x < 2, y < 2)
-    # Just gave it a vector as an objective, not okay
-    @test_throws Exception solve!(p)
+    @testset "geo mean atom" begin
+        x = Variable(2)
+        y = Variable(2)
+        p = minimize(geomean(x, y), x >= 1, y >= 2)
+        # not DCP compliant
+        @test vexity(p) == ConcaveVexity()
+        p = maximize(geomean(x, y), 1 < x, x < 2, y < 2)
+        # Just gave it a vector as an objective, not okay
+        @test_throws Exception solve!(p)
 
-    p = maximize(sum(geomean(x, y)), 1 < x, x < 2, y < 2)
-    solve!(p)
-    @test p.optval ≈ 4 atol=TOL
-    @test evaluate(sum(geomean(x, y))) ≈ 4 atol=TOL
-  end
+        p = maximize(sum(geomean(x, y)), 1 < x, x < 2, y < 2)
+        solve!(p)
+        @test p.optval ≈ 4 atol=TOL
+        @test evaluate(sum(geomean(x, y))) ≈ 4 atol=TOL
+    end
 
-  @testset "sqrt atom" begin
-    x = Variable()
-    p = maximize(sqrt(x), 1 >= x)
-  end
+    @testset "sqrt atom" begin
+        x = Variable()
+        p = maximize(sqrt(x), 1 >= x)
+    end
 
-  @testset "quad form atom" begin
-    x = Variable(3, 1)
-    A = [0.8608 0.3131 0.5458; 0.3131 0.8584 0.5836; 0.5458 0.5836 1.5422]
-    p = minimize(quadform(x, A), [x >= 1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 6.1464 atol=TOL
-    @test (evaluate(quadform(x, A)))[1] ≈ 6.1464 atol=TOL
+    @testset "quad form atom" begin
+        x = Variable(3, 1)
+        A = [0.8608 0.3131 0.5458; 0.3131 0.8584 0.5836; 0.5458 0.5836 1.5422]
+        p = minimize(quadform(x, A), [x >= 1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 6.1464 atol=TOL
+        @test (evaluate(quadform(x, A)))[1] ≈ 6.1464 atol=TOL
 
-    x = Variable(3, 1)
-    A = -1.0*[0.8608 0.3131 0.5458; 0.3131 0.8584 0.5836; 0.5458 0.5836 1.5422]
-    c = [3 2 4]
-    p = maximize(c*x , [quadform(x, A) >= -1])
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 3.7713 atol=TOL
-    @test (evaluate(quadform(x, A)))[1] ≈ -1 atol=TOL
-  end
+        x = Variable(3, 1)
+        A = -1.0*[0.8608 0.3131 0.5458; 0.3131 0.8584 0.5836; 0.5458 0.5836 1.5422]
+        c = [3 2 4]
+        p = maximize(c*x , [quadform(x, A) >= -1])
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 3.7713 atol=TOL
+        @test (evaluate(quadform(x, A)))[1] ≈ -1 atol=TOL
+    end
 
-  @testset "huber atom" begin
-    x = Variable(3)
-    p = minimize(sum(huber(x, 1)), x >= 2)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    @test p.optval ≈ 9 atol=TOL
-    @test evaluate(sum(huber(x, 1))) ≈ 9 atol=TOL
-  end
+    @testset "huber atom" begin
+        x = Variable(3)
+        p = minimize(sum(huber(x, 1)), x >= 2)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        @test p.optval ≈ 9 atol=TOL
+        @test evaluate(sum(huber(x, 1))) ≈ 9 atol=TOL
+    end
 
-  @testset "rational norm atom" begin
-    A = [1 2 3; -1 2 3]
-    b = A * ones(3)
-    x = Variable(3)
-    p = minimize(norm(x, 4.5), [A * x == b])
-    @test vexity(p) == ConvexVexity()
-    # Solution is approximately x = [1, .93138, 1.04575]
-    solve!(p)
-    @test p.optval ≈ 1.2717 atol=TOL
-    @test evaluate(norm(x, 4.5)) ≈ 1.2717 atol=TOL
-  end
+    @testset "rational norm atom" begin
+        A = [1 2 3; -1 2 3]
+        b = A * ones(3)
+        x = Variable(3)
+        p = minimize(norm(x, 4.5), [A * x == b])
+        @test vexity(p) == ConvexVexity()
+        # Solution is approximately x = [1, .93138, 1.04575]
+        solve!(p)
+        @test p.optval ≈ 1.2717 atol=TOL
+        @test evaluate(norm(x, 4.5)) ≈ 1.2717 atol=TOL
+    end
 
-  @testset "rational norm dual norm" begin
-    v = [0.463339, 0.0216084, -2.07914, 0.99581, 0.889391]
-    x = Variable(5)
-    q = 1.379;  # q norm constraint that generates many inequalities
-    qs = q / (q - 1);  # Conjugate to q
-    p = minimize(x' * v)
-    p.constraints += (norm(x, q) <= 1)
-    @test vexity(p) == ConvexVexity()
-    solve!(p)  # Solution is -norm(v, q / (q - 1))
-    @test p.optval ≈ -2.144087 atol=TOL
-    @test sum(evaluate(x' * v)) ≈ -2.144087 atol=TOL
-    @test evaluate(norm(x, q)) ≈ 1 atol=TOL
-    @test sum(evaluate(x' * v)) ≈ -(sum(abs.(v) .^ qs) ^ (1 / qs)) atol=TOL
-  end
+    @testset "rational norm dual norm" begin
+        v = [0.463339, 0.0216084, -2.07914, 0.99581, 0.889391]
+        x = Variable(5)
+        q = 1.379;  # q norm constraint that generates many inequalities
+        qs = q / (q - 1);  # Conjugate to q
+        p = minimize(x' * v)
+        p.constraints += (norm(x, q) <= 1)
+        @test vexity(p) == ConvexVexity()
+        solve!(p)  # Solution is -norm(v, q / (q - 1))
+        @test p.optval ≈ -2.144087 atol=TOL
+        @test sum(evaluate(x' * v)) ≈ -2.144087 atol=TOL
+        @test evaluate(norm(x, q)) ≈ 1 atol=TOL
+        @test sum(evaluate(x' * v)) ≈ -(sum(abs.(v) .^ qs) ^ (1 / qs)) atol=TOL
+    end
 
-  @testset "rational norm atom sum" begin
-    A = [-0.719255  -0.229089
-         -1.33632   -1.37121
-         0.703447  -1.4482]
-    b = [-1.82041, -1.67516, -0.866884]
-    q = 1.5
-    xvar = Variable(2)
-    p = minimize(.5 * sumsquares(xvar) + norm(A * xvar - b, q))
-    @test vexity(p) == ConvexVexity()
-    solve!(p)
-    # Compute gradient, check it is zero(ish)
-    x_opt = xvar.value
-    margins = A * x_opt - b
-    qs = q / (q - 1);  # Conjugate
-    denom = sum(abs.(margins).^q)^(1/qs)
-    g = x_opt + A' * (abs.(margins).^(q-1) .* sign.(margins)) / denom
-    @test p.optval ≈ 1.7227 atol=TOL
-    @test norm(g, 2) ^ 2 ≈ 0 atol=TOL
-  end
+    @testset "rational norm atom sum" begin
+        A = [-0.719255  -0.229089
+             -1.33632   -1.37121
+              0.703447  -1.4482]
+        b = [-1.82041, -1.67516, -0.866884]
+        q = 1.5
+        xvar = Variable(2)
+        p = minimize(.5 * sumsquares(xvar) + norm(A * xvar - b, q))
+        @test vexity(p) == ConvexVexity()
+        solve!(p)
+        # Compute gradient, check it is zero(ish)
+        x_opt = xvar.value
+        margins = A * x_opt - b
+        qs = q / (q - 1);  # Conjugate
+        denom = sum(abs.(margins).^q)^(1/qs)
+        g = x_opt + A' * (abs.(margins).^(q-1) .* sign.(margins)) / denom
+        @test p.optval ≈ 1.7227 atol=TOL
+        @test norm(g, 2) ^ 2 ≈ 0 atol=TOL
+    end
 
-  @testset "norm consistent with Base for matrix variables" begin
-    A = randn(4, 4)
-    x = Variable(4, 4)
-    x.value = A
-    # Matrix norm
-    @test evaluate(opnorm(x)) ≈ opnorm(A) atol=TOL
-    @test evaluate(opnorm(x, 1)) ≈ opnorm(A, 1) atol=TOL
-    @test evaluate(opnorm(x, 2)) ≈ opnorm(A, 2) atol=TOL
-    @test evaluate(opnorm(x, Inf)) ≈ opnorm(A, Inf) atol=TOL
-    # Vector norm
-    # TODO: Once the deprecation for norm on matrices is removed, remove the `vec` calls
-    @test evaluate(norm(vec(x), 1)) ≈ norm(vec(A), 1) atol=TOL
-    @test evaluate(norm(vec(x), 2)) ≈ norm(vec(A), 2) atol=TOL
-    @test evaluate(norm(vec(x), 7)) ≈ norm(vec(A), 7) atol=TOL
-    @test evaluate(norm(vec(x), Inf)) ≈ norm(vec(A), Inf) atol=TOL
-  end
+    @testset "norm consistent with Base for matrix variables" begin
+        A = randn(4, 4)
+        x = Variable(4, 4)
+        x.value = A
+        # Matrix norm
+        @test evaluate(opnorm(x)) ≈ opnorm(A) atol=TOL
+        @test evaluate(opnorm(x, 1)) ≈ opnorm(A, 1) atol=TOL
+        @test evaluate(opnorm(x, 2)) ≈ opnorm(A, 2) atol=TOL
+        @test evaluate(opnorm(x, Inf)) ≈ opnorm(A, Inf) atol=TOL
+        # Vector norm
+        # TODO: Once the deprecation for norm on matrices is removed, remove the `vec` calls
+        @test evaluate(norm(vec(x), 1)) ≈ norm(vec(A), 1) atol=TOL
+        @test evaluate(norm(vec(x), 2)) ≈ norm(vec(A), 2) atol=TOL
+        @test evaluate(norm(vec(x), 7)) ≈ norm(vec(A), 7) atol=TOL
+        @test evaluate(norm(vec(x), Inf)) ≈ norm(vec(A), Inf) atol=TOL
+    end
 
 
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -3,28 +3,28 @@ using Test
 
 @testset "Utilities" begin
 
-  @testset "length and size" begin
-    x = Variable(2,3)
-    @test length(x) == 6
-    @test size(x) == (2, 3)
-    @test size(x, 1) == 2
-    @test size(x, 2) == 3
+    @testset "length and size" begin
+        x = Variable(2,3)
+        @test length(x) == 6
+        @test size(x) == (2, 3)
+        @test size(x, 1) == 2
+        @test size(x, 2) == 3
 
-    x = Variable(3)
-    @test length(x) == 3
-    @test size(x) == (3, 1)
+        x = Variable(3)
+        @test length(x) == 3
+        @test size(x) == (3, 1)
 
-    x = Variable()
-    @test length(x) == 1
-    @test size(x) == (1, 1)
-  end
+        x = Variable()
+        @test length(x) == 1
+        @test size(x) == (1, 1)
+    end
 
-  # returns [21]; not sure why
-  # context("iteration") do
-  #   x = Variable(2,3)
-  #   s = sum([xi for xi in x])
-  #   x.value = [1 2 3; 4 5 6]
-  #   @fact evaluate(s) --> 21
-  # end
+    # returns [21]; not sure why
+    # context("iteration") do
+    #     x = Variable(2,3)
+    #     s = sum([xi for xi in x])
+    #     x.value = [1 2 3; 4 5 6]
+    #     @fact evaluate(s) --> 21
+    # end
 
 end


### PR DESCRIPTION
The package currently uses a mixture of indentation, including 2- and 4-space indents, as well as tab characters. This normalizes everything to 4-space indents only, which is the standard Julia style, and is what's recommended in the JuMP style guide.

Fixes #240.

Note that the diff here is _brutal_. I recommend viewing it with whitespace changes ignored: https://github.com/JuliaOpt/Convex.jl/pull/243/files?w=1

I've also included one very minor corrective change: `gc` now lives in the Base.GC module.