### PR TITLE
Deprecated default solvers

### DIFF
--- a/docs/solvers.rst
+++ b/docs/solvers.rst
@@ -30,14 +30,6 @@ To use a specific solver, you can use the following syntax
 	using GLPKMathProgInterface
 	solve!(p, GLPKSolverMIP())
 
-You can set or see the current default solver by
-::
-
-	get_default_solver()
-	using Gurobi
-	set_default_solver(GurobiSolver()) # or set_default_solver(SCSSolver(verbose=0))
-	# Now Gurobi will be used by default as a solver
-
 Many of the solvers also allow options to be passed in. More details can be found in each solver's documentation.
 
 For example, if we wish to turn off printing for the SCS solver (ie, run in quiet mode), we can do so by

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -40,7 +40,7 @@ end
 
 # constructor if model is not specified
 function Problem(head::Symbol, objective::AbstractExpr, constraints::Array=Constraint[],
-                 solver::MathProgBase.AbstractMathProgSolver=get_default_solver())
+                 solver::MathProgBase.AbstractMathProgSolver=DEFAULT_SOLVER)
     Problem(head, objective, MathProgBase.ConicModel(solver), constraints)
 end
 

--- a/src/solver_info.jl
+++ b/src/solver_info.jl
@@ -4,16 +4,28 @@ export can_solve_mip, can_solve_socp, can_solve_sdp, can_solve_exp
 export set_default_solver, get_default_solver, isinstalled
 
 function set_default_solver(solver::MathProgBase.AbstractMathProgSolver)
-    Base.depwarn("Default solvers are deprecated and will not be provided in a future " *
-                 "release.\nLoad any necessary solvers manually.", :set_default_solver)
+    Base.depwarn(
+        "Default solvers are deprecated and will not be provided in a future release.
+        You can still manually load and use solvers such as ECOS by running:
+        using ECOS
+        p = minimize(...);
+        solve!(p, ECOSSolver())",
+        :set_default_solver
+    )
 
     global DEFAULT_SOLVER
     DEFAULT_SOLVER = solver
 end
 
 function get_default_solver()
-    Base.depwarn("Default solvers are deprecated and will not be provided in a future " *
-                 "release.\nLoad any necessary solvers manually.", :get_default_solver)
+    Base.depwarn(
+        "Default solvers are deprecated and will not be provided in a future release.
+        You can still manually load and use installed solvers such as ECOS by running:
+        using ECOS
+        p = minimize(...);
+        solve!(p, ECOSSolver())",
+        :get_default_solver
+    )
 
     if DEFAULT_SOLVER == nothing
         error("The default solver is set to `nothing`

--- a/src/solver_info.jl
+++ b/src/solver_info.jl
@@ -4,11 +4,17 @@ export can_solve_mip, can_solve_socp, can_solve_sdp, can_solve_exp
 export set_default_solver, get_default_solver, isinstalled
 
 function set_default_solver(solver::MathProgBase.AbstractMathProgSolver)
+    Base.depwarn("Default solvers are deprecated and will not be provided in a future " *
+                 "release.\nLoad any necessary solvers manually.", :set_default_solver)
+
     global DEFAULT_SOLVER
     DEFAULT_SOLVER = solver
 end
 
 function get_default_solver()
+    Base.depwarn("Default solvers are deprecated and will not be provided in a future " *
+                 "release.\nLoad any necessary solvers manually.", :get_default_solver)
+
     if DEFAULT_SOLVER == nothing
         error("The default solver is set to `nothing`
               You must have at least one solver installed to use Convex.
@@ -16,6 +22,7 @@ function get_default_solver()
               Pkg.add(\"SCS\").
               You will have to restart Julia after that.")
     end
+
     return DEFAULT_SOLVER
 end
 
@@ -29,6 +36,7 @@ function isinstalled(pkg)
             return true
         end
     end
+
     return false
 end
 
@@ -90,4 +98,3 @@ function can_solve_sdp(solver)
         return false
     end
 end
-


### PR DESCRIPTION
This seems like the first step to dropping the `DEFAULT_SOLVER` behaviour and getting rid of the following warning:

```
┌ Warning: Package Convex does not have ECOS in its dependencies:
│ - If you have Convex checked out for development and have
│   added ECOS as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Convex
```

which causes precompilation to fail on 1.0. Related to #244 