### PR TITLE
Fix method overwrite warning when loading the package

### DIFF
--- a/src/problems.jl
+++ b/src/problems.jl
@@ -29,7 +29,7 @@ mutable struct Problem
     solution::Solution
 
     function Problem(head::Symbol, objective::AbstractExpr,
-                     model::Union{MathProgBase.AbstractConicModel, Nothing}=nothing,
+                     model::Union{MathProgBase.AbstractConicModel, Nothing},
                      constraints::Array=Constraint[])
         if sign(objective)== Convex.ComplexSign()
             error("Objective can not be a complex expression")


### PR DESCRIPTION
```
julia> using Convex
WARNING: Method definition (::Type{Convex.Problem})(Symbol, Convex.AbstractExpr) in module Convex at /home/alex/.julia/packages/Convex/MLj0c/src/problems.jl:34 overwritten at /home/alex/.julia/packages/Convex/MLj0c/src/problems.jl:45.
```
This was caused by providing a default value of `nothing` for the `model` argument in the `Problem` constructor, which ends up creating a two-argument method that is also created further down by virtue of using default values.

By simply removing the default value for `model`, we remain at feature parity with the methods prior to the change and we don't overwrite anything.