### PR TITLE
Deprecate get_vectorized_size in favor of length

### DIFF
--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -108,7 +108,7 @@ function conic_form!(x::AdditionAtom, unique_conic_forms::UniqueConicForms=Uniqu
         for child in x.children
             child_objective = conic_form!(child, unique_conic_forms)
             if x.size != child.size
-                child_objective = promote_size(child_objective, get_vectorized_size(x))
+                child_objective = promote_size(child_objective, length(x))
             end
             objective += child_objective
         end

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -83,7 +83,7 @@ function conic_form!(x::DiagAtom, unique_conic_forms::UniqueConicForms=UniqueCon
             sz_diag = Base.min(num_rows + k, num_cols)
         end
 
-        select_diag = spzeros(sz_diag, get_vectorized_size(x.children[1]))
+        select_diag = spzeros(sz_diag, length(x.children[1]))
         for i in 1:sz_diag
             select_diag[i, start_index] = 1
             start_index += num_rows + 1

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -49,8 +49,8 @@ end
 
 function conic_form!(x::IndexAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, x)
-        m = get_vectorized_size(x)
-        n = get_vectorized_size(x.children[1])
+        m = length(x)
+        n = length(x.children[1])
 
         if x.inds == nothing
             sz = length(x.cols) * length(x.rows)

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -74,7 +74,7 @@ function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms=Uniqu
             if const_child.size == (1, 1)
                 const_multiplier = evaluate(const_child)[1]
             else
-                const_multiplier = reshape(evaluate(const_child), get_vectorized_size(const_child), 1)
+                const_multiplier = reshape(evaluate(const_child), length(const_child), 1)
             end
 
             objective = const_multiplier * objective

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -10,7 +10,7 @@ struct ReshapeAtom <: AbstractExpr
     size::Tuple{Int, Int}
 
     function ReshapeAtom(x::AbstractExpr, m::Int, n::Int)
-        if m * n != get_vectorized_size(x)
+        if m * n != length(x)
             error("Cannot reshape expression of size $(x.size) to ($(m), $(n))")
         end
         return new(:reshape, objectid(x), (x,), (m, n))
@@ -39,4 +39,4 @@ end
 
 
 reshape(x::AbstractExpr, m::Int, n::Int) = ReshapeAtom(x, m, n)
-vec(x::AbstractExpr) = reshape(x, get_vectorized_size(x), 1)
+vec(x::AbstractExpr) = reshape(x, length(x), 1)

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -54,7 +54,7 @@ function conic_form!(x::HcatAtom, unique_conic_forms::UniqueConicForms=UniqueCon
                     if id == objectid(:constant)
                         variable_to_sizes[id] = 1
                     else
-                        variable_to_sizes[id] = get_vectorized_size(id_to_variables[id])
+                        variable_to_sizes[id] = length(id_to_variables[id])
                     end
                 end
             end
@@ -91,7 +91,7 @@ function conic_form!(x::HcatAtom, unique_conic_forms::UniqueConicForms=UniqueCon
             x2_value_list = Value[]
 
             for i in 1:length(objectives)
-                row_size = get_vectorized_size(x.children[i])
+                row_size = length(x.children[i])
                 if haskey(objectives[i], id)
                     push!(x1_value_list, objectives[i][id][1])
                     push!(x2_value_list, objectives[i][id][2])

--- a/src/atoms/affine/transpose.jl
+++ b/src/atoms/affine/transpose.jl
@@ -43,7 +43,7 @@ function conic_form!(x::TransposeAtom, unique_conic_forms::UniqueConicForms=Uniq
     if !has_conic_form(unique_conic_forms, x)
         objective = conic_form!(x.children[1], unique_conic_forms)
 
-        sz = get_vectorized_size(x)
+        sz = length(x)
 
         num_rows = x.size[1]
         num_cols = x.size[2]
@@ -106,7 +106,7 @@ function conic_form!(x::AdjointAtom, unique_conic_forms::UniqueConicForms=Unique
     if !has_conic_form(unique_conic_forms, x)
         objective = conic_form!(x.children[1], unique_conic_forms)
 
-        sz = get_vectorized_size(x)
+        sz = length(x)
 
         num_rows = x.size[1]
         num_cols = x.size[2]

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -21,11 +21,11 @@ struct DotSortAtom <: AbstractExpr
         if sign(x) == ComplexSign()
             error("Argument should be real instead it is $(sign(x))")
         else
-            if !(length(w) == get_vectorized_size(x))
+            if !(length(w) == length(x))
                 error("x and w must be the same size")
             end
             children = (x,)
-            vecw = reshape(w, get_vectorized_size(x))
+            vecw = reshape(w, length(x))
             return new(:dotsort, hash((children, vecw)), children, (1,1), vecw)
         end
     end

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -22,7 +22,7 @@ struct SumLargestAtom <: AbstractExpr
             if k <= 0
                 error("sumlargest and sumsmallest only support positive values of k")
             end
-            if k > get_vectorized_size(x)
+            if k > length(x)
                 error("k cannot be larger than the number of entries in x")
             end
             children = (x,)

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -54,7 +54,9 @@ function imag_conic_form(x::Constant)
     return im*vec([imag(x.value);])
 end
 
-
+# We can more efficiently get the length of a constant by asking for the length of its
+# value, which Julia can get via Core.arraylen for arrays and knows is 1 for scalars
+length(x::Constant) = length(x.value)
 
 function conic_form!(x::Constant, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, x)

--- a/src/constraints/soc_constraints.jl
+++ b/src/constraints/soc_constraints.jl
@@ -22,7 +22,7 @@ function conic_form!(c::SOCConstraint, unique_conic_forms::UniqueConicForms=Uniq
         for iobj=1:length(c.children)
             objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
         end
-        cache_conic_form!(unique_conic_forms, c, ConicConstr(objectives, :SOC, [get_vectorized_size(x) for x in c.children]))
+        cache_conic_form!(unique_conic_forms, c, ConicConstr(objectives, :SOC, [length(x) for x in c.children]))
     end
     return get_conic_form(unique_conic_forms, c)
 end
@@ -45,7 +45,7 @@ end
 
 function conic_form!(c::SOCElemConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, c)
-        num_constrs = get_vectorized_size(c.children[1])
+        num_constrs = length(c.children[1])
         num_children = length(c.children)
         conic_constrs = Array{ConicConstr}(undef, num_constrs)
         objectives = Array{ConicObj}(undef, num_children)

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -34,7 +34,6 @@ export vexity, sign, size, evaluate, monotonicity, curvature, length, convert
 export conic_form!
 export lastindex, ndims
 export Value, ValueOrNothing
-export get_vectorized_size
 
 ### Abstract types
 abstract type AbstractExpr end
@@ -117,9 +116,10 @@ function size(x::AbstractExpr, dim::Integer)
 end
 
 ndims(x::AbstractExpr) = 2
-get_vectorized_size(x::AbstractExpr) = reduce(*, size(x))
-lastindex(x::AbstractExpr) = get_vectorized_size(x)
+lastindex(x::AbstractExpr) = length(x)
 
 axes(x::AbstractExpr) = (Base.OneTo(size(x, 1)), Base.OneTo(size(x, 2)))
 axes(x::AbstractExpr, n::Integer) = axes(x)[n]
 lastindex(x::AbstractExpr, n::Integer) = last(axes(x, n))
+
+@deprecate get_vectorized_size(x::AbstractExpr) length(x)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -62,11 +62,11 @@ function find_variable_ranges(constraints)
                 if !haskey(var_to_ranges, id) && id != objectid(:constant)
                     var = id_to_variables[id]
                     if var.sign == ComplexSign()
-                        var_to_ranges[id] = (index + 1, index + 2*get_vectorized_size(var))
-                        index += 2*get_vectorized_size(var)
+                        var_to_ranges[id] = (index + 1, index + 2*length(var))
+                        index += 2*length(var)
                     else
-                        var_to_ranges[id] = (index + 1, index + get_vectorized_size(var))
-                        index += get_vectorized_size(var)
+                        var_to_ranges[id] = (index + 1, index + length(var))
+                        index += length(var)
                     end
                 end
             end
@@ -108,7 +108,7 @@ function conic_form!(p::Problem, unique_conic_forms::UniqueConicForms=UniqueConi
 end
 
 function conic_problem(p::Problem)
-    if get_vectorized_size(p.objective) != 1
+    if length(p.objective) != 1
         error("Objective must be a scalar")
     end
 
@@ -153,8 +153,8 @@ function conic_problem(p::Problem)
                 else
                     var_range = var_to_ranges[id]
                     if id_to_variables[id].sign == ComplexSign()
-                        A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[1] + get_vectorized_size(id_to_variables[id])-1] = -val[1]
-                        A[constr_index + 1 : constr_index + sz, var_range[1] + get_vectorized_size(id_to_variables[id]) : var_range[2]] = -val[2]
+                        A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[1] + length(id_to_variables[id])-1] = -val[1]
+                        A[constr_index + 1 : constr_index + sz, var_range[1] + length(id_to_variables[id]) : var_range[2]] = -val[2]
                     else
                         A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[2]] = -val[1]
                     end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -73,12 +73,12 @@ end
 
 
 function real_conic_form(x::Variable)
-    vec_size = get_vectorized_size(x)
+    vec_size = length(x)
     return sparse(1.0I, vec_size, vec_size)
 end
 
 function imag_conic_form(x::Variable)
-    vec_size = get_vectorized_size(x)
+    vec_size = length(x)
     if x.sign == ComplexSign()
         return im*sparse(1.0I, vec_size, vec_size)
     else
@@ -95,7 +95,7 @@ function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueCon
             cache_conic_form!(unique_conic_forms, x, objective)
         else
             objective = ConicObj()
-            vec_size = get_vectorized_size(x)
+            vec_size = length(x)
 
             objective[x.id_hash] = (real_conic_form(x), imag_conic_form(x))
             objective[objectid(:constant)] = (spzeros(vec_size, 1), spzeros(vec_size, 1))


### PR DESCRIPTION
They're defined to be the same thing but the implementation of the former is 2x slower than the latter. Rather than improving the code we can just combine them.

Further, we can simplify the implementation of `length` by calling `length` directly on the underlying value for `Constant`s.