### PR TITLE
Make ConicObj its own type

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.7
 MathProgBase 0.7 0.8
-DataStructures
+OrderedCollections

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module Convex
-import DataStructures
+using OrderedCollections: OrderedDict
 using LinearAlgebra
 using SparseArrays
 

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -41,16 +41,16 @@ function conic_form!(c::ExpConstraint, unique_conic_forms::UniqueConicForms=Uniq
     if !has_conic_form(unique_conic_forms, c)
         conic_constrs = ConicConstr[]
         if c.size == (1, 1)
-            objectives = Array{ConicObj}(undef, 3)
-            for iobj=1:3
+            objectives = Vector{ConicObj}(undef, 3)
+            @inbounds for iobj = 1:3
                 objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
             end
             push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))
         else
-            for i=1:c.size[1]
-                for j=1:c.size[2]
-                    objectives = Array{ConicObj}(undef, 3)
-                    for iobj=1:3
+            for i = 1:c.size[1]
+                for j = 1:c.size[2]
+                    objectives = Vector{ConicObj}(undef, 3)
+                    @inbounds for iobj = 1:3
                         objectives[iobj] = conic_form!(c.children[iobj][i,j], unique_conic_forms)
                     end
                     push!(conic_constrs, ConicConstr(objectives, :ExpPrimal, [1, 1, 1]))

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -50,13 +50,13 @@ function conic_form!(c::SDPConstraint, unique_conic_forms::UniqueConicForms=Uniq
         rescale = sqrt(2)*tril(ones(n,n))
         rescale[diagind(n, n)] .= 1.0
         diagandlowerpart = findall(!iszero, vec(rescale))
-        lowerpart = Array{Int}(undef, div(n*(n-1),2))
-        upperpart = Array{Int}(undef, div(n*(n-1),2))
+        lowerpart = Vector{Int}(undef, div(n*(n-1),2))
+        upperpart = Vector{Int}(undef, div(n*(n-1),2))
         klower = 0
         # diagandlowerpart in column-major order:
         # ie the (1,1), (2,1), ..., (n,1), (2,2), (3,2), ...
         # consider using  and find(triu(ones(3,3)))
-        for j = 1:n
+        @inbounds for j = 1:n
             for i = j+1:n
                 klower += 1
                 upperpart[klower] = n*(i-1) + j # (j,i)th element

--- a/src/constraints/soc_constraints.jl
+++ b/src/constraints/soc_constraints.jl
@@ -18,8 +18,8 @@ end
 
 function conic_form!(c::SOCConstraint, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, c)
-        objectives = Array{ConicObj}(undef, length(c.children))
-        for iobj=1:length(c.children)
+        objectives = Vector{ConicObj}(undef, length(c.children))
+        @inbounds for iobj = 1:length(c.children)
             objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
         end
         cache_conic_form!(unique_conic_forms, c, ConicConstr(objectives, :SOC, [length(x) for x in c.children]))
@@ -47,12 +47,12 @@ function conic_form!(c::SOCElemConstraint, unique_conic_forms::UniqueConicForms=
     if !has_conic_form(unique_conic_forms, c)
         num_constrs = length(c.children[1])
         num_children = length(c.children)
-        conic_constrs = Array{ConicConstr}(undef, num_constrs)
-        objectives = Array{ConicObj}(undef, num_children)
-        for iobj = 1:num_children
+        conic_constrs = Vector{ConicConstr}(undef, num_constrs)
+        objectives = Vector{ConicObj}(undef, num_children)
+        @inbounds for iobj = 1:num_children
             objectives[iobj] = conic_form!(c.children[iobj], unique_conic_forms)
         end
-        for row = 1:num_constrs
+        @inbounds for row = 1:num_constrs
             objectives_by_row = [get_row(obj, row) for obj in objectives]
             conic_constrs[row] = ConicConstr(objectives_by_row, :SOC, [1, 1, 1])
         end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -121,8 +121,7 @@ function fix!(x::Variable)
 end
 function fix!(x::Variable, v::AbstractArray)
     size(x) == size(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = Array{Float64}(undef, size(x))
-    x.value[:,:] = v
+    x.value = convert(Array{Float64}, v)
     fix!(x)
 end
 fix!(x::Variable, v::Number) = fix!(x, fill(v, (1, 1)))

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,5 +1,20 @@
 @testset "Utilities" begin
 
+    @testset "ConicObj" begin
+        c = ConicObj()
+        z = UInt64(0)
+        @test !haskey(c, z)
+        c[z] = (1, 1)
+        @test c[z] == (1, 1)
+        x = UInt64[]
+        for (k, v) in c
+            push!(x, k)
+        end
+        @test x == collect(keys(c))
+        d = copy(c)
+        @test d !== c
+    end
+
     @testset "length and size" begin
         x = Variable(2,3)
         @test length(x) == 6


### PR DESCRIPTION
* Make ConicObj its own type. This reduces the amount of type piracy in the package. Currently the package defines multiplication of a sparse matrix and an ordered dictionary, as one example.

* Replace the dependency on DataStructures, which is quite large, with one on OrderedCollections. This is a lighter weight package and we're only using one piece of it anyway.

* Change some `Array` definitions to `Vector` as appropriate (the compiler likes it better) and add `@inbounds` annotations to a few loops that fill the arrays.