### PR TITLE
Bug in sign detection of complex constants

### DIFF
--- a/src/constant.jl
+++ b/src/constant.jl
@@ -22,9 +22,9 @@ struct Constant <: AbstractExpr
         if check_sign
             if !isreal(x)
                 return Constant(x, ComplexSign())
-            elseif all(xi >= 0 for xi in x)
+            elseif all(real(xi) >= 0 for xi in x)
                 return Constant(x, Positive())
-            elseif all(xi <= 0 for xi in x)
+            elseif all(real(xi) <= 0 for xi in x)
                 return Constant(x, Negative())
             end
         end


### PR DESCRIPTION
The following snippet
```
z = ComplexVariable(2,2)
[1.0 0.0*im; 0.0 1.0]*z
```

will fail with 
```
MethodError: no method matching isless(::Int64, ::Complex{Float64})
Closest candidates are:
  isless(!Matched::Missing, ::Any) at missing.jl:66
  isless(::Real, !Matched::AbstractFloat) at operators.jl:149
  isless(::Real, !Matched::Real) at operators.jl:338
  ...
```

Quick fix is to force the type to actually be real, but I have no idea if this will or will not 
impact any code down the line. 