### PR TITLE
Parameterize Constant on the type of its value

### DIFF
--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -42,6 +42,35 @@
         @test size(y) == (2, 1)
     end
 
+    @testset "Parametric constants" begin
+        z = Constant([1.0 0.0im; 0.0 1.0])
+        @test z isa Constant{Matrix{Complex{Float64}}}
+
+        # Helper functions
+        @test Convex.ispos(1)
+        @test Convex.ispos(0)
+        @test !Convex.ispos(-1)
+        @test Convex.ispos([0,1,0])
+        @test !Convex.ispos([0,-1,0])
+        @test Convex.isneg(-1)
+        @test Convex.isneg(0)
+        @test !Convex.isneg(1)
+        @test Convex.isneg([0,-1,0])
+        @test !Convex.isneg([0,1,0])
+        @test Convex._size(3) == (1, 1)
+        @test Convex._sign(3) == Positive()
+        @test Convex._size([-1,1,1]) == (3, 1)
+        @test Convex._sign([-1,1,1]) == NoSign()
+        @test Convex._sign([-1,-1,-1]) == Negative()
+        @test Convex._size([0 0; 0 0]) == (2, 2)
+        @test Convex._sign([0 0; 0 0]) == Positive()
+        @test Convex._size(0+1im) == (1, 1)
+        @test Convex._sign(0+1im) == ComplexSign()
+
+        @test Convex.imag_conic_form(Constant(1.0)) == [0.0]
+        @test Convex.imag_conic_form(Constant([1.0, 2.0])) == [0.0, 0.0]
+    end
+
     # returns [21]; not sure why
     # context("iteration") do
     #     x = Variable(2,3)


### PR DESCRIPTION
This allows for more expressive condition checking using dispatch, as complex numbers, real numbers, or arrays thereof can be handled as separate methods.

~~This also limits the types that can be accepted as constant values to scalars, vectors, and matrices. Previously this was assumed but not actually checked.~~

Fixes #264.