### PR TITLE
Add a Project file, remove vestigial Pkg uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.DS_Store
 *.cov
 .ipynb_checkpoints/
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "Convex"
+uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+MathProgBase = "0.7"
+OrderedCollections = ">=1.0.0"
+julia = "0.7, 1.0"
+
+[extras]
+ECOS = "e2685f51-7e38-5353-a97d-a921fd2c8199"
+GLPKMathProgInterface = "3c7084bd-78ad-589a-b5bb-dbd673274bea"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ECOS", "GLPKMathProgInterface", "LinearAlgebra", "Random", "SCS", "Statistics", "Test"]

--- a/src/solver_info.jl
+++ b/src/solver_info.jl
@@ -1,22 +1,13 @@
-using Pkg
 import MathProgBase
 export can_solve_mip, can_solve_socp, can_solve_sdp, can_solve_exp
-export isinstalled
 
-function isinstalled(pkg)
-    for path in Base.DEPOT_PATH
-        if isdir(joinpath(path, pkg)) || isdir(joinpath(path, "packages", pkg))
-            return true
-        end
-    end
-
-    return false
-end
-
-# TODO: I have not listed solvers such as CPLEX etc because I have not tested Convex with them
-solvers = [("ECOS", "ECOSSolver"), ("SCS", "SCSSolver"), ("Gurobi", "GurobiSolver"), ("Mosek", "MosekSolver"),
-           ("GLPKMathProgInterface", "GLPKSolverMIP")]
-
+# NOTE: Convex has been tested with the following solvers:
+#   ECOS:   ECOSSolver
+#   SCS:    SCSSolver
+#   Gurobi: GurobiSolver
+#   Mosek:  MosekSolver
+#   GLPKMathProgInterface: GLPKSolverMIP
+# It has not been tested with other solvers such a CPLEX.
 
 function can_solve_mip(solver)
     name = typeof(solver).name.name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,15 +24,13 @@ push!(solvers, ECOSSolver(verbose=0))
 push!(solvers, GLPKSolverMIP())
 push!(solvers, SCSSolver(verbose=0, eps=1e-6))
 
-if isinstalled("Gurobi")
-    using Gurobi
-    push!(solvers, GurobiSolver(OutputFlag=0))
-end
+# If Gurobi is installed, uncomment to test with it:
+#using Gurobi
+#push!(solvers, GurobiSolver(OutputFlag=0))
 
-if isinstalled("Mosek")
-    using Mosek
-    push!(solvers, MosekSolver(LOG=0))
-end
+# If Mosek is installed, uncomment to test with it:
+#using Mosek
+#push!(solvers, MosekSolver(LOG=0))
 
 @testset "Convex" begin
     include("test_utilities.jl")


### PR DESCRIPTION
This adds a Project.toml file which records dependencies and compatibility information and it removes the vestigial uses of Pkg for hacking optional dependencies.