### PR TITLE
Fixed iterate over Variable

### DIFF
--- a/src/utilities/iteration.jl
+++ b/src/utilities/iteration.jl
@@ -1,6 +1,6 @@
 import Base.iterate
 export iterate
 
-function iterate(x::Variable, (el, s)=(x[1], 0))
-    return s >= length(x) ? nothing : (el, (x[s+1], s+1))
+function iterate(x::Variable, s=0)
+    return s >= length(x) ? nothing : (x[s+1], s+1)
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -71,6 +71,22 @@
         @test Convex.imag_conic_form(Constant([1.0, 2.0])) == [0.0, 0.0]
     end
 
+    @testset "Iteration" begin
+        x = Variable(2,3)
+        s = sum([xi for xi in x])
+        x.value = [1 2 3; 4 5 6]
+        # evaluate(s) == [21] (which might be wrong? expected 21)
+        # but [21][1] === 21[1] === 21
+        # so this should pass even after "fixing" that
+        @test evaluate(s)[1] == 21
+
+        x = Variable(4)
+        @test [xi.inds for xi in x] == [1:1, 2:2, 3:3, 4:4]
+
+        x = Variable(0)
+        @test [xi for xi in x] == []
+        @test iterate(x) == nothing
+    end
     # returns [21]; not sure why
     # context("iteration") do
     #     x = Variable(2,3)


### PR DESCRIPTION
Fixed iteration (and thus broadcast over variables). Previous behavior was
```julia
x = Variable(4)
[xi.inds for xi in x] == [1:1, 1:1, 2:2, 3:3]
```
which for example resulted in wrong results in the following cases
```julia
constraints = x .>= [1,2,3,4] #[x[1] >=1, x[1] >=2, x[2]>=3, x[3]>=4]
sum([xi for xi in x]) # x[1]+x[1]+x[2]+x[3]
```

Also made sure that `iterate` does not depend on indexing the variable out of range.
It previously accessed `x[1]` even when `length(x)=0`.

I also removed the elements of `x` from the state, I see no reason for passing them around.

There is still the (existing) unexpected behavior of `evaluate(sum([xi for xi in x]))` being a vector.
I didn't fix this but made sure the test will pass if it is fixed.

As a side note (I can add an issue if it is not expected behavior), there are no bounds checks on indexing of `IndexAtom`. The following expression returns fine `x[-1]`, although it can not be evaluated. 
I tried to add bounds checks, but it seems like Convex.jl routinely relies on indexing outside the range `[1,length(x)]`.