### PR TITLE
Allow indexing into ConicObj with any Integer

### DIFF
--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -16,9 +16,9 @@ end
 ConicObj() = ConicObj(OrderedDict{UInt64,Tuple{Value,Value}}())
 Base.iterate(c::ConicObj, s...) = iterate(c.mapping, s...)
 Base.keys(c::ConicObj) = keys(c.mapping)
-Base.haskey(c::ConicObj, var::UInt64) = haskey(c.mapping, var)
-Base.getindex(c::ConicObj, var::UInt64) = c.mapping[var]
-Base.setindex!(c::ConicObj, val, var::UInt64) = setindex!(c.mapping, val, var)
+Base.haskey(c::ConicObj, var::Integer) = haskey(c.mapping, UInt64(var))
+Base.getindex(c::ConicObj, var::Integer) = c.mapping[UInt64(var)]
+Base.setindex!(c::ConicObj, val, var::Integer) = setindex!(c.mapping, val, UInt64(var))
 Base.copy(c::ConicObj) = ConicObj(copy(c.mapping))
 
 # helper function to negate conic objectives

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,12 +1,12 @@
 @testset "Utilities" begin
 
-    @testset "ConicObj" begin
+    @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
-        z = UInt64(0)
+        z = zero(T)
         @test !haskey(c, z)
         c[z] = (1, 1)
         @test c[z] == (1, 1)
-        x = UInt64[]
+        x = T[]
         for (k, v) in c
             push!(x, k)
         end


### PR DESCRIPTION
We're using the value of `objectid` to store values in `ConicObj`, but `objectid` returns `UInt32` on 32-bit systems. Currently `ConicObj` only accepts indexing operations with `UInt64` keys, which causes a method error on 32-bit systems. This was an oversight when introducing `ConicObj` as its own type.

Fixes #272