### PR TITLE
Fix `kron` dimension bug, add simple test

### DIFF
--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -23,7 +23,11 @@ function kron(a::AbstractExpr, b::Value)
     for i in 1:size(a)[1]
         row = AbstractExpr[]
         for j in 1:size(a)[2]
-            push!(row, a[i, j] .* b)
+            if isreal(b)
+                push!(row, a[i, j] * real(b))
+            else
+                push!(row, a[i, j] * b)
+            end
         end
         push!(rows, foldl(hcat, row))
     end

--- a/test/test_affine.jl
+++ b/test/test_affine.jl
@@ -8,6 +8,13 @@
         @test evaluate(-x) ≈ 0 atol=TOL
     end
 
+    @testset "kron atom" begin
+        x = ComplexVariable(3, 3)
+        y = [1.0 2.0; 3.0 4.0]
+        @test size(kron(x, y)) == (6, 6)
+        @test size(kron(y, x)) == (6, 6)
+    end
+
     @testset "multiply atom" begin
         x = Variable(1)
         p = minimize(2.0 * x, [x >= 2, x <= 4])


### PR DESCRIPTION
Fixes #267, #209. The dimensions of `kron(A,B)` should be the same as the dimensions of `kron(B,A)`. I just copied the working method to fix the broken one, and put the `isreal` check on the value again. That check is mentioned in <https://github.com/JuliaOpt/Convex.jl/issues/204#issuecomment-315590295>, seems to be working around the strange behavior `Convex.jl` has with complex-typed but `isreal`-true values.