### PR TITLE
Fix right-multiply bug, add simple test

### DIFF
--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -86,7 +86,7 @@ function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms=Uniqu
         # right matrix multiplication
         else
             objective = conic_form!(x.children[1], unique_conic_forms)
-            objective = kron(x.children[2].value', sparse(1.0I, x.size[1], x.size[1])) * objective
+            objective = kron(transpose(x.children[2].value), sparse(1.0I, x.size[1], x.size[1])) * objective
         end
         cache_conic_form!(unique_conic_forms, x, objective)
     end

--- a/test/test_affine.jl
+++ b/test/test_affine.jl
@@ -47,6 +47,12 @@
         @test vexity(p) == AffineVexity()
         solve!(p, solver)
         @test p.optval ≈ 3 atol=TOL
+
+        # Check #274
+        x = ComplexVariable(2,2)
+        p = minimize( real( [1.0im, 0.0]' * x * [1.0im, 0.0] ), [ x == [1.0 0.0; 0.0 1.0] ])
+        solve!(p, solver)
+        @test p.optval ≈ 1.0
     end
 
     @testset "dot atom" begin


### PR DESCRIPTION
Fixes #274 and #266.

I saw a suspicious adjoint and changed it to a transpose, and suddenly #274 worked (and the tests pass). 

I have to say, I don't entirely understand how this works. I think what's going on is that matrices are stored as long vectors, which I think corresponds to the map in (1.127) of [TQI], and then matrix multiplication can be represented on the vectorized space by the formula 1.132 of [TQI], which indeed uses the transpose, not the adjoint.

    [TQI]: https://cs.uwaterloo.ca/~watrous/TQI/TQI.1.pdf

But I'd appreciate a more appropriate reference!