### PR TITLE
Make global variables constant

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -84,9 +84,10 @@ include("utilities/broadcast.jl")
 
 #Temporary workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
-    global id_to_variables = Dict{UInt64, Variable}()
-    global var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
-    global conic_constr_to_constr = Dict{ConicConstr, Constraint}()
+    global id_to_variables
+    empty!(id_to_variables)
+    global conic_constr_to_constr 
+    empty!(conic_constr_to_constr)
     GC.gc()
 end
 

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -2,7 +2,7 @@ import Base.==, Base.<=, Base.>=, Base.<, Base.>
 export EqConstraint, LtConstraint, GtConstraint
 export ==, <=, >=
 
-conic_constr_to_constr = Dict{ConicConstr, Constraint}()
+const conic_constr_to_constr = Dict{ConicConstr, Constraint}()
 
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -57,7 +57,7 @@ end
 # the expression tree will only utilize variable ids during construction
 # full information of the variables will be needed during stuffing
 # and after solving to populate the variables with values
-id_to_variables = Dict{UInt64, Variable}()
+const id_to_variables = Dict{UInt64, Variable}()
 
 function vexity(x::Variable)
     return x.vexity

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,5 +1,22 @@
 @testset "Utilities" begin
 
+    @testset "clearmemory" begin
+        # solve a problem to populate globals
+        x = Variable()
+        p = minimize(-x, [x <= 0])
+        @test vexity(p) == AffineVexity()
+        solve!(p, solvers[1])
+
+        @test !isempty(Convex.id_to_variables)
+        @test !isempty(Convex.conic_constr_to_constr)
+
+        Convex.clearmemory()
+
+        # check they are cleared
+        @test isempty(Convex.id_to_variables)
+        @test isempty(Convex.conic_constr_to_constr)
+    end
+
     @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)


### PR DESCRIPTION
I saw there were some  global variables which I thought should be declared `const`. I wasn't sure how to check for improvement, so I ran `@time include("test/runtests.jl");` three times on master and with these changes, each on a fresh Julia session (after running it once to compile).

With these changes:
1.   2.271733 seconds (1.45 M allocations: 95.721 MiB, 8.59% gc time)
2.   2.238526 seconds (1.45 M allocations: 96.115 MiB, 2.97% gc time)
3.   2.084262 seconds (1.45 M allocations: 95.699 MiB, 3.14% gc time)

On master:
1.   2.532733 seconds (1.45 M allocations: 95.759 MiB, 2.42% gc time)
2.   3.026007 seconds (1.45 M allocations: 96.404 MiB, 7.01% gc time)
3.   2.388227 seconds (1.45 M allocations: 95.752 MiB, 2.65% gc time)

There's a lot of variance, but it does seem faster. I think it should be a fairly safe change; I checked each usage of the two globals and saw they are only accessed by indexing (not rebinding), so I don't think the `const` declaration rules out anything the code was doing, except in the `clearmemory()` function, which I changed to use `empty!` instead. I just removed `var_to_ranges` from `clearmemory()` since it is never actually used as a global, as was noted in https://github.com/JuliaOpt/Convex.jl/issues/83#issuecomment-182632107.