### PR TITLE
Parametrize `Problem` with a numeric type `T`

### DIFF
--- a/src/atoms/affine/conv.jl
+++ b/src/atoms/affine/conv.jl
@@ -11,7 +11,7 @@ function conv(x::Value, y::AbstractExpr)
     end
     m = length(x)
     n = y.size[1]
-    X = spzeros(m+n - 1, n)
+    X = spzeros(eltype(x), m + n - 1, n)
     for i = 1:n
         X[i:m+i-1, i] = x
     end

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -19,18 +19,18 @@ Solution(x::Array{T, 1}, status::Symbol, optval::T) where {T} =
 Solution(x::Array{T, 1}, y::Array{T, 1}, status::Symbol, optval::T) where {T} =
     Solution(x, y, status, optval, true)
 
-mutable struct Problem{T<:Number}
+mutable struct Problem{T<:Real}
     head::Symbol
     objective::AbstractExpr
     constraints::Array{Constraint}
     status::Symbol
-    optval::Union{Number,Nothing}
+    optval::Union{Real,Nothing}
     model::Union{MathProgBase.AbstractConicModel, Nothing}
     solution::Solution
 
     function Problem{T}(head::Symbol, objective::AbstractExpr,
                      model::Union{MathProgBase.AbstractConicModel, Nothing},
-                     constraints::Array=Constraint[]) where {T}
+                     constraints::Array=Constraint[]) where {T <: Real}
         if sign(objective)== Convex.ComplexSign()
             error("Objective can not be a complex expression")
         else
@@ -41,7 +41,7 @@ end
 
 # constructor if model is not specified
 function Problem{T}(head::Symbol, objective::AbstractExpr, constraints::Array=Constraint[],
-                 solver::Union{MathProgBase.AbstractMathProgSolver, Nothing}=nothing) where {T<:Number}
+                 solver::Union{MathProgBase.AbstractMathProgSolver, Nothing}=nothing) where {T<:Real}
     model = solver !== nothing ? MathProgBase.ConicModel(solver) : solver
     Problem{T}(head, objective, model, constraints)
 end
@@ -193,7 +193,7 @@ function conic_problem(p::Problem{T}) where {T}
     return c, A, b, cones, var_to_ranges, vartypes, constraints
 end
 
-Problem{T}(head::Symbol, objective::AbstractExpr, constraints::Constraint...) where {T<:Number} =
+Problem{T}(head::Symbol, objective::AbstractExpr, constraints::Constraint...) where {T<:Real} =
     Problem{T}(head, objective, [constraints...])
 
 # Allow users to simply type minimize

--- a/test/test_affine.jl
+++ b/test/test_affine.jl
@@ -353,6 +353,21 @@
         @test p.optval ≈ 3 atol=TOL
         @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
 
+
+        # test #288
+        x = rand(5) + im*rand(5);
+        y = Constant(rand(5));
+        @test conv(x,y) isa AbstractExpr
+
+        x =  Variable(3)
+        y = im * x
+        h = [1, -1]
+        p = minimize(imag(sum(conv(y, h)) + sum(y)), x >= 1, x <= 2)
+        @test vexity(p) == AffineVexity()
+        solve!(p, solver)
+        @test p.optval ≈ 3 atol=TOL
+        @test evaluate(sum(conv(h, x))) ≈ 0 atol=TOL
+
     end
 
     @testset "satisfy problems" begin

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -18,7 +18,7 @@
     end
 
     using SparseArrays
-    @testset "Parametrically typed problems" for T = [Float32, Float64, BigFloat]
+    @testset "Parametrically typed problems with type $T" for T = [Float32, Float64, BigFloat]
         x = Variable()
         p = Problem{T}(:minimize, -x, [x <= 0])
         c, A, b, cones, var_to_ranges, vartypes, constraints = Convex.conic_problem(p)
@@ -39,7 +39,7 @@
         end
     end
 
-    @testset "ConicObj" for T = [UInt32, UInt64]
+    @testset "ConicObj with type $T" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)
         @test !haskey(c, z)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -25,6 +25,18 @@
         @test c isa SparseMatrixCSC{T,Int64}
         @test A isa SparseMatrixCSC{T,Int64}
         @test b isa SparseMatrixCSC{T,Int64}
+
+        Y = Variable(5,5)
+        X = rand(T, 5, 5)
+        p = Problem{T}(:minimize, tr(Y), [ diag(Y)[2:5] == diag(X)[2:5], Y[1,1] == big(0.0) ])
+        c, A, b, cones, var_to_ranges, vartypes, constraints = Convex.conic_problem(p)
+        @test c isa SparseMatrixCSC{T,Int64}
+        @test A isa SparseMatrixCSC{T,Int64}
+        @test b isa SparseMatrixCSC{T,Int64}
+        @test diag(X)[2:5] ≈ -1 * b[2:5]
+        if T == BigFloat
+            @test diag(X)[2:5] + 1e-30*rand(4) ≉ -1 * b[2:5]
+        end
     end
 
     @testset "ConicObj" for T = [UInt32, UInt64]

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -17,6 +17,16 @@
         @test isempty(Convex.conic_constr_to_constr)
     end
 
+    using SparseArrays
+    @testset "Parametrically typed problems" for T = [Float32, Float64, BigFloat]
+        x = Variable()
+        p = Problem{T}(:minimize, -x, [x <= 0])
+        c, A, b, cones, var_to_ranges, vartypes, constraints = Convex.conic_problem(p)
+        @test c isa SparseMatrixCSC{T,Int64}
+        @test A isa SparseMatrixCSC{T,Int64}
+        @test b isa SparseMatrixCSC{T,Int64}
+    end
+
     @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)


### PR DESCRIPTION
Right now, Convex is pretty good about not converting user supplied data to Float64. The only explicit numeric types I can find in Convex are the Float64 sparse arrays made by commands like `spzeros`. Most of the time, these are multiplied against user input, so e.g. if the user passes in `BigFloat`s, the resulting type will still be a `BigFloat`. 

This isn't the case in `conv`, which is essentially a bug, since it rules out complex inputs without much reason (#288), but I think in the other atoms it is the case, and I fixed `conv` here.

At the last step, Convex assembles the objective function and constraints into a standard form to pass to MathProgBase, and it is at this step that Convex builds a sparse matrix `A` to hold all the numbers associated to the linear part of the constraints, a sparse vector `b` to hold the affine part, and a sparse vector `c` to hold the objective function. Right now, all three of these are constructed via `spzeros(size...)` and hence have type `Float64`.

Instead, I propose we parametrize `Problem` with a type `T`, and construct `A`, `b`, and `c` via `spzeros(T, size...)`, and add a default constructor to allow `Problem()` to construct a `Problem{Float64}()` (which has the same behavior as the current `Problem` struct). I chose `T <: Real` to avoid confusion: `T` should be real even if there are complex variables in the problem, since they are transformed to a real form during the problem assembly. I.e. `T` governs the `eltype`s of `A`, `b`, and `c` in the standard form.

This has no affect on anyone using the current API, but it allows one to use `Problem{BigFloat}(:minimize, ...)` to construct problems with more precision that can then be passed to the solvers (none of which currently support high precision, but I'm hoping we can change that this summer). I added some tests to demonstrate that we can pass `BigFloat`s all the way through the problem construction and get them out from `conic_problem`.

We could also try to deduce the type from the numeric types of the problem data itself, but that seemed like a more complicated change with more possibilities for bugs.

One other relevant thing is that if we do switch to MathOptInterface, we will likely want to use the `MathOptInterface.Utilities.@model` macro to construct a concrete MathOptInterface model, i.e. a struct `MOIModel{T}` (analogous to the `MathProgBase.conic_model` we use now). These models also have a single type parameter governing the model, and all the constraint functions and objective functions have this type. By parametrizing `Problem` with a type `T`, when we want to construct an associated MOI model we can use `T` to construct the appropriate kind of MOI model (i.e., a `MOIModel{T}`).

To be clear, the change I propose here doesn't really help or hurt our adoption of MOI-- we could adopt MOI independently of the kind of change I propose here, and simply take `T=Float64` (since that is the type of our `A`, `b`, and `c` that we would use to construct the MOI objective and constraints). But since MOI already parametrizes their models (at least the ones constructed via `@model`, which seems like the simplest way to go), it makes sense to me to first parametrize our `Problem`s too.

I also loosened the type restriction on `optval`. It should be `nothing` or else whatever the solver passes back, which should be a number but might not be a `Float64`. I don't think this should affect any current code.