### PR TITLE
Remove Base.vect override

### DIFF
--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -131,9 +131,3 @@ function hvcat(rows::Tuple{Vararg{Int}}, args::AbstractExprOrValue...)
     end
     return vcat(rs...)
 end
-
-Base.vect(args::AbstractExpr...) = transpose(HcatAtom(map(transpose, args)...))
-Base.vect(args::AbstractExprOrValue...) = transpose(HcatAtom(map(arg -> transpose(convert(AbstractExpr, arg)), args)...))
-
-# XXX: Reimplementation of the Base method
-Base.vect(args::Value...) = copyto!(Vector{Base.promote_typeof(args...)}(undef, length(args)), args)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -88,6 +88,11 @@
         @test Convex.imag_conic_form(Constant([1.0, 2.0])) == [0.0, 0.0]
     end
 
+    @testset "Base.vect" begin
+    # Issue #223: ensure we can make vectors of variables
+    @test size([Variable(2), Variable(3,4)]) == (2,)
+    end
+
     @testset "Iteration" begin
         x = Variable(2,3)
         s = sum([xi for xi in x])


### PR DESCRIPTION
Fixes https://github.com/JuliaOpt/Convex.jl/issues/223.

I'm not sure if this change is OK or not. On the one hand, the tests pass. On the other hand, it must be here for a reason; maybe this change will break some obscure edge case. In the latter case though, it would be nice if we had a test to show we need this override (or even better, find a different resolution to such an edge case without overriding `Base.vect`).

I thought I'd make the pull request to open a discussion at least.

P.S. sorry for the barrage of pull requests; no rush to address these, I'm just trying to work through the issue backlog a bit.