### PR TITLE
Fix some issues with `fix!`

### DIFF
--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -80,13 +80,13 @@ function conic_form!(x::MultiplyAtom, unique_conic_forms::UniqueConicForms=Uniqu
             objective = const_multiplier * objective
 
         # left matrix multiplication
-        elseif x.children[1].head == :constant
+        elseif vexity(x.children[1]) == ConstVexity()
             objective = conic_form!(x.children[2], unique_conic_forms)
-            objective = kron(sparse(1.0I, x.size[2], x.size[2]), x.children[1].value) * objective
+            objective = kron(sparse(1.0I, x.size[2], x.size[2]), evaluate(x.children[1])) * objective
         # right matrix multiplication
         else
             objective = conic_form!(x.children[1], unique_conic_forms)
-            objective = kron(transpose(x.children[2].value), sparse(1.0I, x.size[1], x.size[1])) * objective
+            objective = kron(transpose(evaluate(x.children[2])), sparse(1.0I, x.size[1], x.size[1])) * objective
         end
         cache_conic_form!(unique_conic_forms, x, objective)
     end
@@ -158,7 +158,7 @@ function conic_form!(x::DotMultiplyAtom, unique_conic_forms::UniqueConicForms=Un
         # promote the size of the coefficient matrix, so eg
         # 3 .* x
         # works regardless of the size of x
-        coeff = x.children[1].value .* ones(size(x.children[2]))
+        coeff = evaluate(x.children[1]) .* ones(size(x.children[2]))
         # promote the size of the variable
         # we've previously ensured neither x nor y is 1x1
         # and that the sizes are compatible,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ push!(solvers, SCSSolver(verbose=0, eps=1e-6))
 
 @testset "Convex" begin
     include("test_utilities.jl")
+    include("test_const.jl")
     include("test_affine.jl")
     include("test_lp.jl")
     include("test_socp.jl")

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -1,0 +1,35 @@
+@testset "Constant variables: $solver" for solver in solvers
+
+    @testset "Issue #166" begin
+        # Issue #166
+        α = Variable(5)
+        fix!(α, ones(5,1))
+
+        # has const vexity, but not at the head
+        c = (rand(5,5) * α) * ones(1,5) 
+
+        β = Variable(5)
+        β.value = ones(5)
+
+        problem = minimize(sum(c * β), [β >= 0])
+        solve!(problem, solver)
+        @test problem.optval ≈ evaluate(sum(c * β)) atol=TOL
+        @test problem.optval ≈ 0.0 atol=TOL
+        @test β.value ≈ zeros(5) atol=TOL
+    end
+
+    @testset "Issue #228" begin
+        x = Variable(2)
+        y = Variable(2)
+        fix!(x, [1 1]')
+        prob = minimize(y'*(x+[2 2]'), [y>=0])
+        solve!(prob, solver)
+        @test prob.optval ≈ 0.0 atol = TOL
+
+        prob = minimize(x'*y, [y>=0])
+        solve!(prob, solver)
+        @test prob.optval ≈ 0.0 atol = TOL
+    end
+
+
+end

--- a/test/test_socp.jl
+++ b/test/test_socp.jl
@@ -276,7 +276,6 @@
 
                 @test o1 <= o2
             end
-
         end
     end
 end

--- a/test/test_socp.jl
+++ b/test/test_socp.jl
@@ -276,6 +276,25 @@
 
                 @test o1 <= o2
             end
+
+            @testset "Issue #166" begin
+                # Issue #166
+                α = Variable(5)
+                fix!(α, ones(5,1))
+
+                # has const vexity, but not at the head
+                c = (rand(5,5) * α) * ones(1,5) 
+
+                β = Variable(5)
+                β.value = ones(5)
+
+                problem = minimize(norm(c * β), [β >= 0])
+                solve!(problem, solver)
+                @test problem.optval ≈ evaluate(norm(c * β)) atol=TOL
+                @test problem.optval ≈ 0.0 atol=TOL
+                @test β.value ≈ zeros(5) atol=TOL
+             end
+
         end
     end
 end

--- a/test/test_socp.jl
+++ b/test/test_socp.jl
@@ -277,24 +277,6 @@
                 @test o1 <= o2
             end
 
-            @testset "Issue #166" begin
-                # Issue #166
-                α = Variable(5)
-                fix!(α, ones(5,1))
-
-                # has const vexity, but not at the head
-                c = (rand(5,5) * α) * ones(1,5) 
-
-                β = Variable(5)
-                β.value = ones(5)
-
-                problem = minimize(norm(c * β), [β >= 0])
-                solve!(problem, solver)
-                @test problem.optval ≈ evaluate(norm(c * β)) atol=TOL
-                @test problem.optval ≈ 0.0 atol=TOL
-                @test β.value ≈ zeros(5) atol=TOL
-             end
-
         end
     end
 end


### PR DESCRIPTION
Fixes #166, fixes  #228, resolves #139 

`x.children[1].head == :constant` was incorrectly used to check if `x.children[1]` is constant, which doesn’t happen when `x.children[1]` is a function of a constant; instead, `ConstVexity()` should be used instead, like it is in the rest of the file. This was causing the second branch to be taken when creating the conic form for multiplication, i.e. the code would assume that `x.children[2]` must be the constant variable when in fact it could be the non-constant variable, which was then sometimes giving incorrect results when using `fix!`, as shown in #166. 

Another issue is that `x.value` was used to access the value of a constant expression. When `x` was not simply a constant variable (instead say a `fix!`’d variable that was multiplied by a constant matrix), it wouldn’t have a value field. Instead, `evaluate` should be used to recurse through the tree and get out the actual constant value. I believe this to be the cause of #139, and was also causing some of the problems in the other two issues.

It looks like these problems were identified in https://github.com/JuliaOpt/Convex.jl/issues/228#issuecomment-466483994 as well.