### PR TITLE
Allow calling `fix!` twice in a row

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -88,7 +88,7 @@ end
 
 function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, x)
-        if x.vexity == ConstVexity()
+        if vexity(x) == ConstVexity()
             # do exactly what we would for a constant
             objective = ConicObj()
             objective[objectid(:constant)] = (vec([real(x.value);]),vec([imag(x.value);]))

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -127,8 +127,7 @@ end
 fix!(x::Variable, v::Number) = fix!(x, fill(v, (1, 1)))
 
 function free!(x::Variable)
-    # TODO this won't work if :fixed appears other than at the end of x.sets
-    x.sets[end] == :fixed && pop!(x.sets)
+    deleteat!(x.sets, findall(==(:fixed), x.sets))
     x.vexity = AffineVexity()
     x
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -88,7 +88,7 @@ end
 
 function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, x)
-        if :fixed in x.sets
+        if x.vexity == ConstVexity()
             # do exactly what we would for a constant
             objective = ConicObj()
             objective[objectid(:constant)] = (vec([real(x.value);]),vec([imag(x.value);]))
@@ -115,7 +115,6 @@ end
 # fix variables to hold them at their current value, and free them afterwards
 function fix!(x::Variable)
     x.value === nothing && error("This variable has no value yet; cannot fix value to nothing!")
-    push!(x.sets, :fixed)
     x.vexity = ConstVexity()
     x
 end
@@ -127,7 +126,6 @@ end
 fix!(x::Variable, v::Number) = fix!(x, fill(v, (1, 1)))
 
 function free!(x::Variable)
-    deleteat!(x.sets, findall(==(:fixed), x.sets))
     x.vexity = AffineVexity()
     x
 end

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -31,5 +31,24 @@
         @test prob.optval ≈ 0.0 atol = TOL
     end
 
+    @testset "Test double `fix!`" begin
+        x = Variable()
+        y = Variable()
+        fix!(x, 1.0)
+        prob = minimize(y*x, [y >= x, x >= 0.5])
+        solve!(prob, solver)
+        @test prob.optval ≈ 1.0 atol = TOL
+
+        fix!(x, 2.0)
+        solve!(prob, solver)
+        @test prob.optval ≈ 4.0 atol = TOL
+
+        free!(x)
+        fix!(y, 1.0)
+        solve!(prob, solver)
+        @test prob.optval ≈ 0.5 atol = TOL
+
+    end
+
 
 end


### PR DESCRIPTION
Currently, if you `fix!` twice and then `free!`, you end up with a variable with `AffineVexity` but `:fixed`, because `free!` only removes the last `:fixed` and still changes the convexity. 

On release and on master with ECOS, the test I added segfaults (which seems strange), and on release and master with SCS, the third test simply fails (the solver returns `NaN`).