### PR TITLE
Update README to reflect that you need to pass a solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pkg.add("SCS")
 Now let's solve a least-squares problem with inequality constraints.
 ```julia
 # Let us first make the Convex.jl module available
-using Convex
+using Convex, SCS
 
 # Generate random problem data
 m = 4;  n = 5
@@ -39,7 +39,7 @@ x = Variable(n)
 problem = minimize(sumsquares(A * x - b), [x >= 0])
 
 # Solve the problem by calling solve!
-solve!(problem)
+solve!(problem, SCSSolver())
 
 # Check the status of the problem
 problem.status # :Optimal, :Infeasible, :Unbounded etc.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 To run this example, first install Convex and at least one solver, such as SCS:
 ```julia
+using Pkg
 Pkg.add("Convex")
 Pkg.add("SCS")
 ```

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -21,8 +21,11 @@ function solve!(problem::Problem;
     if problem.model === nothing
         throw(ArgumentError(
             "The provided problem hasn't been initialized with a conic model.
-            You can resolve this by passing in `AbstractMathProgSolver` such as:
-            solve!(problem, ECOSSolver())"
+            You can resolve this by passing in a `AbstractMathProgSolver`. For example,
+            ```
+            using ECOS
+            solve!(problem, ECOSSolver())
+            ```"
         ))
     end
 


### PR DESCRIPTION
Looks like I forgot to update the README in https://github.com/JuliaOpt/Convex.jl/pull/271. I also went ahead and added a `using ECOS` to the error message for `solve!(problem)`, since it looks like that being missing caused some confusion in #300. Maybe we should switch it to SCS though? Or switch all the SCS stuff in the docs to ECOS. I had simply chosen SCS in #271 because it was an open source solver I had been using, but that choice was pretty arbitrary, and I don't mind switching it all to ECOS. Or maybe it's nice that the docs and error message use two different solvers to show more of the possibilities :).

Fixes https://github.com/JuliaOpt/Convex.jl/issues/300