### PR TITLE
Fixing bug for complex semidefinite cases

### DIFF
--- a/src/atoms/affine/real_imag.jl
+++ b/src/atoms/affine/real_imag.jl
@@ -47,7 +47,6 @@ function conic_form!(x::RealAtom, unique_conic_forms::UniqueConicForms=UniqueCon
         new_objective = ConicObj()
         objective = conic_form!(x.children[1], unique_conic_forms)
 
-
         for var in keys(objective)
             re = real.(objective[var][1])
             im = real.(objective[var][2])

--- a/src/constraints/signs_and_sets.jl
+++ b/src/constraints/signs_and_sets.jl
@@ -5,7 +5,7 @@ conic_form!(s::Negative, x::Variable, unique_conic_forms) = conic_form!(x<=0, un
 
 function conic_form!(set::Symbol, x::Variable, unique_conic_forms)
     if set==:Semidefinite
-        if sign(x) == ComplexVariable()
+        if sign(x) == ComplexSign()
             conic_form!(SDPConstraint([real(x) -imag(x);imag(x) real(x)]), unique_conic_forms)
         else
             conic_form!(SDPConstraint(x), unique_conic_forms)

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -250,6 +250,7 @@
                 solve!(p, SCSSolver())
                 @test p.status == :Optimal
                 @test p.solution.primal ≈ [0.; 1.; 0.; 0.; 1.; zeros(4)] atol=TOL
+                @test p.optval ≈ 0 atol=TOL
             end
 
             @testset "norm2 atom" begin

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -243,7 +243,7 @@
                 #@fact x1==x2 --> true
             end
 
-            @testset "" begin
+            @testset "Issue #198" begin
                 ρ = HermitianSemidefinite(2)
                 constraints = [ρ == [ 1. 0.; 0.  1.]]
                 p = satisfy(constraints)

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -243,6 +243,15 @@
                 #@fact x1==x2 --> true
             end
 
+            @testset "" begin
+                ρ = HermitianSemidefinite(2)
+                constraints = [ρ == [ 1. 0.; 0.  1.]]
+                p = satisfy(constraints)
+                solve!(p, SCSSolver())
+                @test p.status == :Optimal
+                @test p.solution.primal ≈ [0.; 1.; 0.; 0.; 1.; zeros(4)] atol=TOL
+            end
+
             @testset "norm2 atom" begin
                 a = 2+4im
                 x = ComplexVariable()


### PR DESCRIPTION
Addressing #198. I believe this check is incorrectly checking for `ComplexVariable()` rather than `ComplexSign()` which results in some complex values in the constraints list.

Besides this small fix, I have added the bugged case from #198 in the tests. Please let me know if you want me to change or add something.