### PR TITLE
Fix `fix!` for scalar parameters with multiplication

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -123,7 +123,12 @@ function fix!(x::Variable, v::AbstractArray)
     x.value = convert(Array{Float64}, v)
     fix!(x)
 end
-fix!(x::Variable, v::Number) = fix!(x, fill(v, (1, 1)))
+
+function fix!(x::Variable, v::Number)
+    size(x) == (1,1) || throw(DimensionMismatch("Variable and value sizes do not match!"))
+    x.value = Float64(v)
+    fix!(x)
+end
 
 function free!(x::Variable)
     x.vexity = AffineVexity()

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -47,7 +47,16 @@
         fix!(y, 1.0)
         solve!(prob, solver)
         @test prob.optval ≈ 0.5 atol = TOL
+    end
 
+    @testset "fix! and multiply" begin
+        p = Variable()
+        fix!(p, 1.0)
+        x = Variable(2,2)
+        prob = minimize( tr(p*x), [ x >= 1 ])
+        solve!(prob, solver)
+        @test prob.optval ≈ 2.0 atol = TOL
+        @test evaluate( tr(p*x) ) ≈ 2.0 atol = TOL
     end
 
 


### PR DESCRIPTION
Convex only has 2-dimensional objects but it works hard to promote and demote user types from scalars and vectors to 2-dimensional objects and back. This pull request is to help maintain that illusion when calling `fix!` on a "scalar" variable (i.e., "size(x)==(1,1)"). 

A problem similar to the test I added is what motivates the change. This test fails on master; specifically, the second test with `evaluate` throws the following:

```julia
Test threw exception
  Expression: ≈(evaluate(tr(p * x)), 2.0, atol=TOL)
  DimensionMismatch("A has dimensions (1,1) but B has dimensions (2,2)")
  Stacktrace:
   [1] gemm_wrapper!(::Array{Float64,2}, ::Char, ::Char, ::Array{Float64,2}, ::Array{Float64,2}) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/matmul.jl:439
   [2] mul! at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/matmul.jl:144 [inlined]
   [3] *(::Array{Float64,2}, ::Array{Float64,2}) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/matmul.jl:142
   [4] evaluate(::Convex.MultiplyAtom) at /Users/ephhome/.julia/dev/Convex/src/atoms/affine/multiply_divide.jl:54
   [5] evaluate(::Convex.DiagAtom) at /Users/ephhome/.julia/dev/Convex/src/atoms/affine/diag.jl:54
   [6] evaluate(::Convex.SumAtom) at /Users/ephhome/.julia/dev/Convex/src/atoms/affine/sum.jl:40
   [7] top-level scope at REPL[22]:8
   [8] top-level scope at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.1/Test/src/Test.jl:1083
   [9] top-level scope at REPL[22]:2
```

Note, currently you can work around this by doing

```julia
p = Variable()
p.value = 1.0
fix!(p)
```

instead of `fix!(p, 1.0)`. 