### PR TITLE
Allow `fix!`ing complex variables to complex numbers

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -120,13 +120,13 @@ function fix!(x::Variable)
 end
 function fix!(x::Variable, v::AbstractArray)
     size(x) == size(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = convert(Array{Float64}, v)
+    x.value = sign(x) == ComplexSign() ? convert(Array{ComplexF64}, v) : convert(Array{Float64}, v)
     fix!(x)
 end
 
 function fix!(x::Variable, v::Number)
     size(x) == (1,1) || throw(DimensionMismatch("Variable and value sizes do not match!"))
-    x.value = Float64(v)
+    x.value = sign(x) == ComplexSign() ? convert(ComplexF64, v) : convert(Float64, v)
     fix!(x)
 end
 

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -59,5 +59,23 @@
         @test evaluate( tr(p*x) ) ≈ 2.0 atol = TOL
     end
 
+    @testset "fix! with complex numbers" begin
+        x = ComplexVariable()
+        fix!(x, 1.0 + im*1.0)
+        y = Variable()
+        prob = minimize( real(x*y), [ y >= .5, real(x) >= .5, imag(x) >= 0])
+        solve!(prob, solver)
+        @test prob.optval ≈ .5 atol=TOL
+        @test evaluate(real(x*y)) ≈ .5 atol=TOL
+        @test evaluate(y) ≈ 0.5 atol=TOL
+
+        free!(x)
+        fix!(y)
+        solve!(prob, solver)
+        @test prob.optval ≈ 0.25 atol=TOL
+        @test evaluate(real(x*y)) ≈ 0.25 atol=TOL
+        @test real(evaluate(x)) ≈ 0.5 atol=TOL
+        @test evaluate(y) ≈ 0.5 atol=TOL
+    end
 
 end


### PR DESCRIPTION
The `Array{Float64}` conversion seems to have been in Convex since the start (before the introduction of complex numbers), so I think it is just overdue for an update. I introduced the scalar `Float64` conversion in https://github.com/JuliaOpt/Convex.jl/pull/303, following the array case, which got me thinking about this conversion and realizing it would fail in the complex case. (Also, I think I should have used `convert` instead of the constructor for consistency.)

I think these conversions are just so that if someone does `fix!(x, 1)` everything works ok.