### PR TITLE
(WIP) Allow variables to carry constraints, custom variable types

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -107,6 +107,16 @@ constraint = ([x y; y' z] in :SDP)
 constraint = ([x y; y' z] ⪰ 0)
 ```
 
+Constraints can also be added to variables after their construction, to automatically apply constraints
+to any problem which uses the variable. For example,
+
+```julia
+x = Variable(3)
+add_constraint!(x, sum(x) == 1)
+```
+
+Now, in any problem in which `x` is used, the constraint `sum(x) == 1` will be added.
+
 Objective
 ---------
 

--- a/src/constraints/signs_and_sets.jl
+++ b/src/constraints/signs_and_sets.jl
@@ -3,12 +3,12 @@ export conic_form!
 conic_form!(s::Positive, x::Variable, unique_conic_forms) = conic_form!(x>=0, unique_conic_forms)
 conic_form!(s::Negative, x::Variable, unique_conic_forms) = conic_form!(x<=0, unique_conic_forms)
 
-function conic_form!(set::Symbol, x::Variable, unique_conic_forms)
-    if set==:Semidefinite
-        if sign(x) == ComplexSign()
-            conic_form!(SDPConstraint([real(x) -imag(x);imag(x) real(x)]), unique_conic_forms)
-        else
-            conic_form!(SDPConstraint(x), unique_conic_forms)
-        end
-    end
-end
+# function conic_form!(set::Symbol, x::Variable, unique_conic_forms)
+#     if set==:Semidefinite
+#         if sign(x) == ComplexVariable()
+#             conic_form!(SDPConstraint([real(x) -imag(x);imag(x) real(x)]), unique_conic_forms)
+#         else
+#             conic_form!(SDPConstraint(x), unique_conic_forms)
+#         end
+#     end
+# end

--- a/src/constraints/signs_and_sets.jl
+++ b/src/constraints/signs_and_sets.jl
@@ -1,14 +1,4 @@
 export conic_form!
 
-conic_form!(s::Positive, x::Variable, unique_conic_forms) = conic_form!(x>=0, unique_conic_forms)
-conic_form!(s::Negative, x::Variable, unique_conic_forms) = conic_form!(x<=0, unique_conic_forms)
-
-# function conic_form!(set::Symbol, x::Variable, unique_conic_forms)
-#     if set==:Semidefinite
-#         if sign(x) == ComplexVariable()
-#             conic_form!(SDPConstraint([real(x) -imag(x);imag(x) real(x)]), unique_conic_forms)
-#         else
-#             conic_form!(SDPConstraint(x), unique_conic_forms)
-#         end
-#     end
-# end
+conic_form!(s::Positive, x::AbstractVariable, unique_conic_forms) = conic_form!(x>=0, unique_conic_forms)
+conic_form!(s::Negative, x::AbstractVariable, unique_conic_forms) = conic_form!(x<=0, unique_conic_forms)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -224,7 +224,8 @@ satisfy(constraint::Constraint) = satisfy([constraint])
 add_constraints!(p::Problem, constraints::Array{<:Constraint}) =
     +(p.constraints, constraints)
 add_constraints!(p::Problem, constraint::Constraint) = add_constraints!(p, [constraint])
-add_constraint! = add_constraints!
+add_constraint!(p::Problem, constraint::Constraint) = add_constraints!(p::Problem, constraint::Constraint)
+add_constraint!(p::Problem, constraints::Array{<:Constraint}) = add_constraints!(p::Problem, constraints::Array{<:Constraint})
 
 # caches conic form of x when x is the solution to the optimization problem p
 function cache_conic_form!(conic_forms::UniqueConicForms, x::AbstractExpr, p::Problem)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -170,13 +170,13 @@ function conic_problem(p::Problem)
     vartypes = fill(:Cont, length(c))
     for var_id in keys(var_to_ranges)
         variable = id_to_variables[var_id]
-        if IntVar == variable.vartype
+        if get_vartype(variable) == IntVar
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Int
             end
         end
-        if BinVar == variable.vartype
+        if get_vartype(variable) == BinVar
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Bin

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -61,7 +61,7 @@ function find_variable_ranges(constraints)
             for (id, val) in constraint.objs[i]
                 if !haskey(var_to_ranges, id) && id != objectid(:constant)
                     var = id_to_variables[id]
-                    if var.sign == ComplexSign()
+                    if sign(var) == ComplexSign()
                         var_to_ranges[id] = (index + 1, index + 2*length(var))
                         index += 2*length(var)
                     else
@@ -152,7 +152,7 @@ function conic_problem(p::Problem)
                     #b[constr_index + sz + 1 : constr_index + 2*sz] = val[2]
                 else
                     var_range = var_to_ranges[id]
-                    if id_to_variables[id].sign == ComplexSign()
+                    if sign(id_to_variables[id]) == ComplexSign()
                         A[constr_index + 1 : constr_index + sz, var_range[1] : var_range[1] + length(id_to_variables[id])-1] = -val[1]
                         A[constr_index + 1 : constr_index + sz, var_range[1] + length(id_to_variables[id]) : var_range[2]] = -val[2]
                     else
@@ -170,13 +170,13 @@ function conic_problem(p::Problem)
     vartypes = fill(:Cont, length(c))
     for var_id in keys(var_to_ranges)
         variable = id_to_variables[var_id]
-        if get_vartype(variable) == IntVar
+        if vartype(variable) == IntVar
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Int
             end
         end
-        if get_vartype(variable) == BinVar
+        if vartype(variable) == BinVar
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Bin

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -170,13 +170,13 @@ function conic_problem(p::Problem)
     vartypes = fill(:Cont, length(c))
     for var_id in keys(var_to_ranges)
         variable = id_to_variables[var_id]
-        if :Int in variable.sets
+        if IntVar == variable.vartype
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Int
             end
         end
-        if :Bin in variable.sets
+        if BinVar == variable.vartype
             startidx, endidx = var_to_ranges[var_id]
             for idx in startidx:endidx
                 vartypes[idx] = :Bin

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -152,19 +152,18 @@ function populate_variables!(problem::Problem, var_to_ranges::Dict{UInt64, Tuple
     x = problem.solution.primal
     for (id, (start_index, end_index)) in var_to_ranges
         var = id_to_variables[id]
-        sz = var.size
-        if var.sign != ComplexSign()
-            var.value = reshape(x[start_index:end_index], sz[1], sz[2])
-            if sz == (1, 1)
-                var.value = var.value[1]
-            end
+        sz = size(var)
+        if sign(var) != ComplexSign()
+            val = reshape(x[start_index:end_index], sz[1], sz[2])
         else
             real_value = reshape(x[start_index:start_index + div(end_index-start_index+1,2)-1], sz[1], sz[2])
             imag_value = reshape(x[start_index + div(end_index-start_index+1,2):end_index], sz[1], sz[2])
-            var.value = real_value + im*imag_value
-            if sz == (1, 1)
-                var.value = var.value[1]
-            end
+            val =  real_value + im*imag_value
+        end
+        if sz == (1, 1)
+            value!(var, val[])
+        else
+            value!(var, val)
         end
     end
 end
@@ -177,12 +176,12 @@ end
 function load_primal_solution!(primal::Array{Float64,1}, var_to_ranges::Dict{UInt64, Tuple{Int, Int}})
     for (id, (start_index, end_index)) in var_to_ranges
         var = id_to_variables[id]
-        if var.value !== nothing
-            sz = size(var.value)
+        if value(var) !== nothing
+            sz = size(value(var))
             if length(sz) <= 1
-                primal[start_index:end_index] = var.value
+                primal[start_index:end_index] = value(var)
             else
-                primal[start_index:end_index] = reshape(var.value, sz[1]*sz[2], 1)
+                primal[start_index:end_index] = reshape(value(var), sz[1]*sz[2], 1)
             end
         end
     end

--- a/src/utilities/broadcast.jl
+++ b/src/utilities/broadcast.jl
@@ -20,8 +20,8 @@ applyDotExpAtom(x, y) = broadcast(^, x, y)
 
 # alternative syntax
 
-# dot(::typeof(*), x::Variable, y::Variable) = broadcast(*, x, y)
-# dot(::typeof(/), x::Variable, y::Variable) = broadcast(/, x, y)
-# dot(::typeof(+), x::Variable, y::Variable) = broadcast(+, x, y)
-# dot(::typeof(-), x::Variable, y::Variable) = broadcast(-, x, y)
-# dot(::typeof(^), x::Variable, y::Variable) = broadcast(^, x, y)
+# dot(::typeof(*), x::AbstractVariable, y::AbstractVariable) = broadcast(*, x, y)
+# dot(::typeof(/), x::AbstractVariable, y::AbstractVariable) = broadcast(/, x, y)
+# dot(::typeof(+), x::AbstractVariable, y::AbstractVariable) = broadcast(+, x, y)
+# dot(::typeof(-), x::AbstractVariable, y::AbstractVariable) = broadcast(-, x, y)
+# dot(::typeof(^), x::AbstractVariable, y::AbstractVariable) = broadcast(^, x, y)

--- a/src/utilities/iteration.jl
+++ b/src/utilities/iteration.jl
@@ -1,6 +1,6 @@
 import Base.iterate
 export iterate
 
-function iterate(x::Variable, s=0)
+function iterate(x::AbstractVariable, s=0)
     return s >= length(x) ? nothing : (x[s+1], s+1)
 end

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -12,7 +12,7 @@ end
 # size: (3, 4)
 # sign: NoSign()
 # vexity: AffineVexity()
-function show(io::IO, x::Variable)
+function show(io::IO, x::AbstractVariable)
     print(io, """Variable of
           size: ($(x.size[1]), $(x.size[2]))
           sign: $(x.sign)

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -14,11 +14,11 @@ end
 # vexity: AffineVexity()
 function show(io::IO, x::AbstractVariable)
     print(io, """Variable of
-          size: ($(x.size[1]), $(x.size[2]))
-          sign: $(x.sign)
-          vexity: $(x.vexity)""")
-    if x.value !== nothing
-        print(io, "\nvalue: $(x.value)")
+          size: ($(size(x)[1]), $(size(x)[2]))
+          sign: $(sign(x))
+          vexity: $(vexity(x))""")
+    if value(x) !== nothing
+        print(io, "\nvalue: $(value(x))")
     end
 end
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -6,7 +6,7 @@
 export Variable, Semidefinite, ComplexVariable, HermitianSemidefinite
 export vexity, evaluate, sign, conic_form!, fix!, free!
 
-export BinVar, IntVar, ContVar
+export BinVar, IntVar, ContVar, get_vartype, set_vartype
 
 """
     VarType
@@ -31,7 +31,6 @@ mutable struct Variable <: AbstractVariable
     constraints::Vector{Constraint}
     vartype::VarType
     function Variable(size::Tuple{Int, Int}, sign::Sign=NoSign(), constraint_fns...)
-        this = new(:variable, 0, nothing, size, AffineVexity(), sign, Constraint[], vartype)
 
         # compatability with old `sets` model
         if :Bin in constraint_fns
@@ -41,6 +40,8 @@ mutable struct Variable <: AbstractVariable
         else
             vartype = ContVar
         end
+
+        this = new(:variable, 0, nothing, size, AffineVexity(), sign, Constraint[], vartype)
 
         fns = Any[s for s in constraint_fns if !(s isa Symbol)]
         if :Semidefinite in constraint_fns

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -74,7 +74,7 @@ function value!(x::AbstractVariable, v::AbstractArray)
     x.value = convert(Array{eltype(x)}, v)
 end
 
-function value!(x::Variable, v::AbstractVector)
+function value!(x::AbstractVariable, v::AbstractVector)
     size(x, 2) == 1 || throw(DimensionMismatch("Cannot set value of a variable of size $(size(x)) to a vector"))
     size(x, 1) == length(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
     x.value = convert(Array{eltype(x)}, v)
@@ -84,7 +84,10 @@ function value!(x::AbstractVariable, v::Number)
     size(x) == (1,1) || throw(DimensionMismatch("Variable and value sizes do not match!"))
     x.value = convert(eltype(x), v)
 end
+# End of `AbstractVariable` interface
 
+
+# Some helpers for the constructors for `Variable`
 iscomplex(::Type{T}) where {T <: Number} = T != real(T)
 iscomplex(sign::Sign) = sign == ComplexSign()
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -28,7 +28,7 @@ to conform to the `AbstractExpr` interface, and implement methods (or use the fi
 
 * `value`, `value!`: get or set the numeric value of the variable. `value` should return `nothing` when no numeric value is set.
 * `vexity`, `vexity!`: get or set the `vexity` of the variable. The `vexity` should be `AffineVexity()` unless the variable has been `fix!`'d, in which case it is `ConstVexity()`.
-* `sign`, `vartype`, `eltype`, and `constraints`: get the `Sign`, `VarType`, numeric type, and a (possibly empty) vector of constraints which are to be applied to any problem in which the variable is used.
+* `sign`, `vartype`, and `constraints`: get the `Sign`, `VarType`, numeric type, and a (possibly empty) vector of constraints which are to be applied to any problem in which the variable is used.
 
 Optionally, also implement `sign!`, `vartype!`, and `add_constraint!` to allow users to modify those values or add a constraint. Moreover, when an `AbstractVariable` `x` is constructed, it should populate `Convex.id_to_variables` via, e.g.
 ```
@@ -120,7 +120,7 @@ mutable struct Variable{T <: Number} <: AbstractVariable{T}
     The `VarType` of the variable (binary, integer, or continuous).
     """
     vartype::VarType
-    function Variable{T}(size::Tuple{Int, Int}, sign::Sign, constraint_fns...; vartype = ContVar) where {T <: Number}
+    function Variable{T}(size::Tuple{Int, Int}, sign::Sign, vartype::VarType) where {T <: Number}
         if iscomplex(T) != iscomplex(sign)
             throw(ArgumentError("type parameter and sign must agree (both complex or both real). Got T=$T, sign = $sign"))
         end
@@ -129,105 +129,121 @@ mutable struct Variable{T <: Number} <: AbstractVariable{T}
         end
         this = new{T}(:variable, 0, nothing, size, AffineVexity(), sign, Constraint[], vartype)
 
-        # now that we have access to the variable (`this`), we can apply constraints to it.
-        for f in constraint_fns
-            push!(this.constraints, f(this))
-        end
-
         this.id_hash = objectid(this)
         id_to_variables[this.id_hash] = this
         return this
     end
-    Variable{T}(size::Tuple{Int, Int}, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}(size, defaultsign(T), constraint_fns...; vartype = vartype)
-    Variable(size::Tuple{Int, Int}, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{defaulttype()}(size, defaultsign(), constraint_fns...; vartype = vartype)
-
-    Variable{T}(m::Int, n::Int, sign::Sign, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((m,n), sign, constraint_fns...; vartype = vartype)
-    Variable(m::Int, n::Int, sign::Sign, constraint_fns...; vartype = ContVar) = Variable{defaulttype(sign)}((m,n), sign, constraint_fns...; vartype = vartype)
-    Variable{T}(m::Int, n::Int, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((m,n), defaultsign(T), constraint_fns...; vartype = vartype)
-    Variable(m::Int, n::Int, constraint_fns...; vartype = ContVar) = Variable{defaulttype()}((m,n), defaultsign(), constraint_fns...; vartype = vartype)
-
-    Variable{T}(size::Int, sign::Sign, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((size, 1), sign, constraint_fns...; vartype = vartype)
-    Variable(size::Int, sign::Sign, constraint_fns...; vartype = ContVar) = Variable{defaultsign(T)}((size, 1), sign, constraint_fns...; vartype = vartype)
-    Variable{T}(size::Int, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((size, 1), defaultsign(T), constraint_fns...; vartype = vartype)
-    Variable(size::Int, constraint_fns...; vartype = ContVar) = Variable{defaulttype()}((size, 1), defaultsign(), constraint_fns...; vartype = vartype)
-
-    Variable{T}(sign::Sign, constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((1, 1), sign, constraint_fns...; vartype = vartype)
-    Variable(sign::Sign, constraint_fns...; vartype = ContVar) = Variable{defaultsign(T)}((1, 1), sign, constraint_fns...; vartype = vartype)
-    Variable{T}(constraint_fns...; vartype = ContVar) where {T <: Number} = Variable{T}((1, 1), defaultsign(T), constraint_fns...; vartype = vartype)
-    Variable(constraint_fns...; vartype = ContVar) = Variable{defaulttype()}((1, 1), defaultsign(), constraint_fns...; vartype = vartype)
 end
+Variable{T}(size::Tuple{Int, Int}, sign::Sign) where {T <: Number} = Variable{T}(size, sign, ContVar)
+Variable{T}(size::Tuple{Int, Int}, vartype::VarType) where {T <: Number} = Variable{T}(size, defaultsign(T), vartype)
+Variable{T}(size::Tuple{Int, Int}) where {T <: Number} = Variable{T}(size, defaultsign(T), ContVar)
 
+Variable(size::Tuple{Int, Int}, sign::Sign, vartype::VarType) = Variable{defaulttype(sign)}(size, sign, vartype)
+Variable(size::Tuple{Int, Int}, sign::Sign) = Variable{defaulttype(sign)}(size, sign, ContVar)
+Variable(size::Tuple{Int, Int}, vartype::VarType) = Variable{defaulttype()}(size, defaultsign(), vartype)
+Variable(size::Tuple{Int, Int}) = Variable{defaulttype()}(size, defaultsign(), ContVar)
+
+Variable{T}(m::Int, n::Int, sign::Sign, vartype::VarType) where {T <: Number} = Variable{T}((m,n), sign, vartype)
+Variable{T}(m::Int, n::Int, sign::Sign) where {T <: Number} = Variable{T}((m,n), sign, ContVar)
+Variable{T}(m::Int, n::Int, vartype::VarType) where {T <: Number} = Variable{T}((m,n), defaultsign(T), vartype)
+Variable{T}(m::Int, n::Int) where {T <: Number} = Variable{T}((m,n), defaultsign(T), ContVar)
+
+Variable(m::Int, n::Int, sign::Sign, vartype::VarType) = Variable{defaulttype(sign)}((m,n), sign, vartype)
+Variable(m::Int, n::Int, sign::Sign) = Variable{defaulttype(sign)}((m,n), sign, ContVar)
+Variable(m::Int, n::Int, vartype::VarType) = Variable{defaulttype()}((m,n), defaultsign(), vartype)
+Variable(m::Int, n::Int) = Variable{defaulttype()}((m,n), defaultsign(), ContVar)
+
+Variable{T}(m::Int, sign::Sign, vartype::VarType) where {T <: Number} = Variable{T}((m,1), sign, vartype)
+Variable{T}(m::Int, sign::Sign) where {T <: Number} = Variable{T}((m,1), sign, ContVar)
+Variable{T}(m::Int, vartype::VarType) where {T <: Number} = Variable{T}((m,1), defaultsign(T), vartype)
+Variable{T}(m::Int) where {T <: Number} = Variable{T}((m,1), defaultsign(T), ContVar)
+
+Variable(m::Int, sign::Sign, vartype::VarType) = Variable{defaulttype(sign)}((m,1), sign, vartype)
+Variable(m::Int, sign::Sign) = Variable{defaulttype(sign)}((m,1), sign, ContVar)
+Variable(m::Int, vartype::VarType) = Variable{defaulttype()}((m,1), defaultsign(), vartype)
+Variable(m::Int) = Variable{defaulttype()}((m,1), defaultsign(), ContVar)
+
+Variable{T}(sign::Sign, vartype::VarType) where {T <: Number} = Variable{T}((1,1), sign, vartype)
+Variable{T}(sign::Sign) where {T <: Number} = Variable{T}((1,1), sign, ContVar)
+Variable{T}(vartype::VarType) where {T <: Number} = Variable{T}((1,1), defaultsign(T), vartype)
+Variable{T}() where {T <: Number} = Variable{T}((1,1), defaultsign(T), ContVar)
+
+Variable(sign::Sign, vartype::VarType) = Variable{defaulttype(sign)}((1,1), sign, vartype)
+Variable(sign::Sign) = Variable{defaulttype(sign)}((1,1), sign, ContVar)
+Variable(vartype::VarType) = Variable{defaulttype()}((1,1), defaultsign(), vartype)
+Variable() = Variable{defaulttype()}((1,1), defaultsign(), ContVar)
+
+
+###
 # Compatability with old `sets` model
-# Only dispatch to these methods when at least one set is given
-# Otherwise dispatch to the inner constructors
-function Variable{T}(size::Tuple{Int, Int}, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar)  where {T <: Number}
+# Only dispatch to these methods when at least one set is given;
+# otherwise dispatch to the inner constructors.
+# There are choices of sign or no sign, type parameter or no type parameter, and various
+# ways to enter the size for each. We will start with:
+# Case 1: with sign, with type parameter.
+function Variable{T}(size::Tuple{Int, Int}, sign::Sign, first_set::Symbol, more_sets::Symbol...)  where {T <: Number}
     sets = [first_set]
     append!(sets, more_sets)
     if :Bin in sets
         vartype = BinVar
     elseif :Int in sets
         vartype = IntVar
-    end
-    if :Semidefinite in sets
-        fns = [ x -> x ⪰ 0 ]
     else
-        fns = []
+        vartype = ContVar
     end
-    Variable{T}(size, sign, fns...; vartype = vartype)
+    x = Variable{T}(size, sign, vartype)
+    if :Semidefinite in sets
+        add_constraint!(x, x ⪰ 0)
+    end
+    return x
 end
-Variable(size::Tuple{Int, Int}, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) = Variable{defaulttype(sign)}(size, sign, first_set, more_sets...; vartype = vartype)
+Variable{T}(m::Int, n::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...)  where {T <: Number} = Variable{T}((m,n), sign, first_set, more_sets...)
+Variable{T}(m::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...)  where {T <: Number} = Variable{T}((m,1), sign, first_set, more_sets...)
+Variable{T}(sign::Sign, first_set::Symbol, more_sets::Symbol...)  where {T <: Number} = Variable{T}((1,1), sign, first_set, more_sets...)
 
-Variable{T}(m::Int, n::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((m,n), sign, first_set, more_sets...; vartype = vartype)
-Variable(m::Int, n::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) = Variable{defaulttype(sign)}((m,n), sign, first_set, more_sets...; vartype = vartype)
+# Case 2: with sign, no type parameter.
+Variable(size::Tuple{Int, Int}, sign::Sign, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype(sign)}(size, sign, first_set, more_sets...)
+Variable(m::Int, n::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype(sign)}((m,n), sign, first_set, more_sets...)
+Variable(m::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype(sign)}((m,1), sign, first_set, more_sets...)
+Variable(sign::Sign, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype(sign)}((1,1), sign, first_set, more_sets...)
 
-Variable{T}(m::Int, n::Int, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((m,n), defaultsign(T), first_set, more_sets...; vartype = vartype)
-Variable(m::Int, n::Int, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) = Variable{defaulttype()}((m,n), defaultsign(), first_set, more_sets...; vartype = vartype)
+# Case 3: no sign, type parameter
+Variable{T}(size::Tuple{Int, Int}, first_set::Symbol, more_sets::Symbol...) where {T <: Number} = Variable{T}(size, defaultsign(T), first_set, more_sets...)
+Variable{T}(m::Int, n::Int, first_set::Symbol, more_sets::Symbol...) where {T <: Number} = Variable{T}((m,n), defaultsign(T), first_set, more_sets...)
+Variable{T}(m::Int, first_set::Symbol, more_sets::Symbol...) where {T <: Number} = Variable{T}((m,1), defaultsign(T), first_set, more_sets...)
+Variable{T}(first_set::Symbol, more_sets::Symbol...) where {T <: Number} = Variable{T}((1,1), defaultsign(T), first_set, more_sets...)
 
-Variable{T}(sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((1, 1), sign, first_set, more_sets...; vartype = vartype)
-Variable(sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{defaulttype(sign)}((1, 1), sign, first_set, more_sets...; vartype = vartype)
-Variable{T}(first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((1, 1), NoSign(), first_set, more_sets...; vartype = vartype)
-Variable(first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{defaulttype()}((1, 1), defaultsign(), first_set, more_sets...; vartype = vartype)
-Variable{T}(size::Tuple{Int, Int},first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}(size, NoSign(), first_set, more_sets...; vartype = vartype)
-Variable(size::Tuple{Int, Int},first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{defaulttype()}(size, defaultsign(), first_set, more_sets...; vartype = vartype)
-Variable{T}(size::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((size, 1), sign, first_set, more_sets...; vartype = vartype)
-Variable(size::Int, sign::Sign, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{defaulttype(sign)}((size, 1), sign, first_set, more_sets...; vartype = vartype)
-Variable{T}(size::Int, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{T}((size, 1), NoSign(), first_set, more_sets...; vartype = vartype)
-Variable(size::Int, first_set::Symbol, more_sets::Symbol...; vartype = ContVar) where {T <: Number} = Variable{defaulttype()}((size, 1), defaultsign(), first_set, more_sets...; vartype = vartype)
+# Case 4: no sign, no type parameter
+Variable(size::Tuple{Int, Int}, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype()}(size, defaultsign(), first_set, more_sets...)
+Variable(m::Int, n::Int, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype()}((m,n), defaultsign(), first_set, more_sets...)
+Variable(m::Int, first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype()}((m,1), defaultsign(), first_set, more_sets...)
+Variable(first_set::Symbol, more_sets::Symbol...) = Variable{defaulttype()}((1,1), defaultsign(), first_set, more_sets...)
 
 
-Semidefinite(m::Integer; eltype=Float64, vartype = ContVar) = Variable{eltype}((m, m), x -> x ⪰ 0; vartype = vartype)
+Semidefinite(m::Integer, vartype::VarType = ContVar; eltype::Type{T} = Float64) where {T <: Number} = Semidefinite(m, m, vartype; eltype=eltype)
 
-function Semidefinite(m::Integer, n::Integer; eltype=Float64, vartype = ContVar)
+function Semidefinite(m::Integer, n::Integer, vartype::VarType = ContVar; eltype::Type{T} = Float64) where {T <: Number}
     if m == n
-        return Variable{eltype}((m, m), x -> x ⪰ 0; vartype = vartype)
+        x = Variable{eltype}((m, m), NoSign(), vartype)
+        add_constraint!(x, x ⪰ 0)
+        return x
     else
         error("Semidefinite matrices must be square")
     end
 end
 
-
-ComplexVariable(m::Int, n::Int, constraint_fns...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((m, n), ComplexSign(), constraint_fns...; vartype = vartype)
-ComplexVariable(m::Int, n::Int, first_set::Symbol, more_sets::Symbol...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((m, n), ComplexSign(), first_set, more_sets...; vartype = vartype)
-
-ComplexVariable(constraint_fns...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((1, 1), ComplexSign(), constraint_fns...; vartype = vartype)
-ComplexVariable(first_set::Symbol, more_sets::Symbol...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((1, 1), ComplexSign(), first_set, more_sets...; vartype = vartype)
-
-ComplexVariable(size::Tuple{Int, Int}, constraint_fns...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}(size, ComplexSign(), constraint_fns...; vartype = vartype)
-ComplexVariable(size::Tuple{Int, Int}, first_set::Symbol, more_sets::Symbol...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}(size, ComplexSign(), first_set, more_sets...; vartype = vartype)
-
-ComplexVariable(size::Int, constraint_fns...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((size, 1), ComplexSign(), constraint_fns...; vartype = vartype)
-ComplexVariable(size::Int, first_set::Symbol, more_sets::Symbol...; eltype=ComplexF64, vartype = ContVar) = Variable{eltype}((size, 1), ComplexSign(), first_set, more_sets...; vartype = vartype)
+# The `defaultsign(T)` calls in the constructors will take care of setting the `sign`
+ComplexVariable(args...; eltype::Type{T}=ComplexF64) where {T <: Complex{<:Real}} = Variable{eltype}(args...)
  
-function HermitianSemidefinite(m::Integer, constraint_fns...; eltype=ComplexF64, vartype = ContVar)
-    fns = [ x -> x ⪰ 0 ]
-    append!(fns, constraint_fns)
-    ComplexVariable((m, m), fns; vartype = vartype)
+function HermitianSemidefinite(m::Integer, vartype::VarType = ContVar; eltype::Type{T}=ComplexF64) where {T <: Complex{<:Real}}
+    return HermitianSemidefinite(m,m, vartype; eltype = eltype)
 end
-function HermitianSemidefinite(m::Integer, n::Integer, constraint_fns...; eltype=ComplexF64, vartype = ContVar)
+
+function HermitianSemidefinite(m::Integer, n::Integer, vartype::VarType = ContVar; eltype::Type{T}=ComplexF64) where {T <: Complex{<:Real}}
     if m == n
-        fns = [ x -> x ⪰ 0 ]
-        append!(fns, constraint_fns)
-        return ComplexVariable((m, m), fns; vartype = vartype)
+        x = Variable{eltype}((m, n), ComplexSign(), vartype)
+        add_constraint!(x, x ⪰ 0)
+        return x
     else
         error("`HermitianSemidefinite` matrices must be square")
     end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -53,7 +53,7 @@ vexity!(x::AbstractVariable, v::Vexity) = x.vexity = v
 sign(x::AbstractVariable) = x.sign
 sign!(x::AbstractVariable, s::Sign) = x.sign = s
 
-Base.eltype(x::AbstractVariable{T}) where {T} = T
+Base.eltype(::Type{<:AbstractVariable{T}}) where {T} = T
 
 value(x::AbstractVariable) = x.value
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -23,16 +23,13 @@ Describe the type of a `Variable`: either continuous (`ContVar`), integer-valued
     abstract type AbstractVariable <: AbstractExpr end
 
 An `AbstractVariable` should have `head` field, an `id_hash` field and a `size` field
-to conform to the `AbstractExpr` interface, and implement methods for
+to conform to the `AbstractExpr` interface, and implement methods (or use the field-access fallbacks) for
 
 * `value`, `value!`: get or set the numeric value of the variable. `value` should return `nothing` when no numeric value is set.
 * `vexity`, `vexity!`: get or set the `vexity` of the variable. The `vexity` should be `AffineVexity()` unless the variable has been `fix!`'d, in which case it is `ConstVexity()`.
-* `sign`, `sign!`: get or set the `Sign` of the variable
-* `vartype`, `vartype!`: get or set the `VarType` of the variable
-* `constraints`, `constraints!`: get or set a `Vector` of constraints which are to be applied to any problem in which the variable is used
-* `eltype`: return a numeric type for the variable
+* `sign`, `vartype`, `eltype`, and `constraints`: get the `Sign`, `VarType`, numeric type, and a (possibly empty) vector of constraints which are to be applied to any problem in which the variable is used.
 
-Moreover, when an `AbstractVariable` `x` is constructed, it should populate `Convex.id_to_variables` via, e.g.
+Optionally, also implement `sign!`, `vartype!`, and `constraints!` to allow users to modify those values. Moreover, when an `AbstractVariable` `x` is constructed, it should populate `Convex.id_to_variables` via, e.g.
 ```
 Convex.id_to_variables(x.id_hash) = x
 ```

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -12,7 +12,8 @@ export constraints, add_constraint!
 """
     VarType
 
-Describe the type of a `Variable`: either continuous (`ContVar`), integer-valued (`IntVar`), or binary (`BinVar`).
+Describe the type of a `Variable`: either continuous (`ContVar`),
+integer-valued (`IntVar`), or binary (`BinVar`).
 """
 @enum VarType BinVar IntVar ContVar
 
@@ -23,19 +24,30 @@ Describe the type of a `Variable`: either continuous (`ContVar`), integer-valued
 """
     abstract type AbstractVariable{T <: Number} <: AbstractExpr end
 
-An `AbstractVariable` should have `head` field, an `id_hash` field and a `size` field
-to conform to the `AbstractExpr` interface, and implement methods (or use the field-access fallbacks) for
+An `AbstractVariable` should have `head` field, an `id_hash` field
+and a `size` field to conform to the `AbstractExpr` interface, and
+implement methods (or use the field-access fallbacks) for
 
-* `value`, `value!`: get or set the numeric value of the variable. `value` should return `nothing` when no numeric value is set.
-* `vexity`, `vexity!`: get or set the `vexity` of the variable. The `vexity` should be `AffineVexity()` unless the variable has been `fix!`'d, in which case it is `ConstVexity()`.
-* `sign`, `vartype`, and `constraints`: get the `Sign`, `VarType`, numeric type, and a (possibly empty) vector of constraints which are to be applied to any problem in which the variable is used.
+* `value`, `value!`: get or set the numeric value of the variable.
+    `value` should return `nothing` when no numeric value is set.
+* `vexity`, `vexity!`: get or set the `vexity` of the variable. The
+    `vexity` should be `AffineVexity()` unless the variable has been
+    `fix!`'d, in which case it is `ConstVexity()`.
+* `sign`, `vartype`, and `constraints`: get the `Sign`, `VarType`,
+    numeric type, and a (possibly empty) vector of constraints which are
+    to be applied to any problem in which the variable is used.
 
-Optionally, also implement `sign!`, `vartype!`, and `add_constraint!` to allow users to modify those values or add a constraint. Moreover, when an `AbstractVariable` `x` is constructed, it should populate `Convex.id_to_variables` via, e.g.
+Optionally, also implement `sign!`, `vartype!`, and `add_constraint!`
+to allow users to modify those values or add a constraint. Moreover,
+when an `AbstractVariable` `x` is constructed, it should populate
+`Convex.id_to_variables` via, e.g.
 ```
 Convex.id_to_variables(x.id_hash) = x
 ```
 
-The parameter `T` indicates the numeric type (e.g. `Float64`). If the variable is a complex variable, `T` should be complex (e.g. `Complex{Float64}`).
+The parameter `T` indicates the numeric type (e.g. `Float64`). If
+the variable is a complex variable, `T` should be complex
+(e.g. `Complex{Float64}`).
 
 """
 abstract type AbstractVariable{T <: Number} <: AbstractExpr end
@@ -92,28 +104,32 @@ mutable struct Variable{T <: Number} <: AbstractVariable{T}
     """
     id_hash::UInt64
     """
-    The current value of the variable. Defaults to `nothing` until the variable has been
-    [`fix!`](@ref)'d to a particular value, or the variable has been used in a problem which
-    has been solved, at which point the optimal value is populated into this field.
+    The current value of the variable. Defaults to `nothing` until the
+    variable has been [`fix!`](@ref)'d to a particular value, or the
+    variable has been used in a problem which has been solved, at which
+    point the optimal value is populated into this field.
     """
     value::ValueOrNothing
     """
-    The size of the variable. Scalar variables have size `(1,1)`; `d`-dimensional vectors have
-    size `(d, 1)`, and `n` by `m` matrices have size `(n,m)`.
+    The size of the variable. Scalar variables have size `(1,1)`;
+    `d`-dimensional vectors have size `(d, 1)`, and `n` by `m` matrices
+    have size `(n,m)`.
     """
     size::Tuple{Int, Int}
     """
-    `AffineVexity()` unless the variable is `fix!`'d, in which case it is `ConstVexity()`.
-    Accessed by `vexity(v::Variable)`. To check if a `Variable` is fixed, use `vexity(v) == ConstVexity()`.
+    `AffineVexity()` unless the variable is `fix!`'d, in which case it is
+    `ConstVexity()`. Accessed by `vexity(v::Variable)`. To check if a
+    `Variable` is fixed, use `vexity(v) == ConstVexity()`.
     """
     vexity::Vexity
     """
-    The sign of the variable. Can be  `Positive()`, `Negative()`, `NoSign()` (i.e. real), or `ComplexSign()`.
-    Accessed by `sign(v::Variable)`. 
+    The sign of the variable. Can be  `Positive()`, `Negative()`, `NoSign()`
+    (i.e. real), or `ComplexSign()`. Accessed by `sign(v::Variable)`. 
     """
     sign::Sign
     """
-    Vector of constraints which are enforced whenever the variable is used in a problem.
+    Vector of constraints which are enforced whenever the variable is used
+    in a problem.
     """
     constraints::Vector{Constraint}
     """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,4 +42,5 @@ push!(solvers, SCSSolver(verbose=0, eps=1e-6))
     include("test_exp.jl")
     include("test_sdp_and_exp.jl")
     include("test_mip.jl")
+    include("test_abstract_variable.jl")
 end

--- a/test/test_abstract_variable.jl
+++ b/test/test_abstract_variable.jl
@@ -41,7 +41,7 @@ Convex.vartype(x::TypedVector) = global_cache[x.id_hash][:vartype]
 Convex.vartype!(x::TypedVector, s::Convex.VarType) = global_cache[x.id_hash][:vartype] = s
 
 Convex.constraints(x::TypedVector) = global_cache[x.id_hash][:constraints]
-Convex.constraints!(x::TypedVector, s::Vector{Constraint}) = global_cache[x.id_hash][:constraints] = s
+Convex.add_constraint!(x::TypedVector, s::Constraint) = push!(global_cache[x.id_hash][:constraints], s)
 
 Convex.eltype(x::TypedVector{T}) where {T} = T
 
@@ -60,6 +60,13 @@ import .TypedVectors
     @test p.optval ≈ 5 atol=TOL
     @test evaluate(x + y) ≈ 5 atol=TOL
     @test Convex.eltype(x) == BigFloat
+
+    add_constraint!(x, x >= 4)
+    solve!(p, solver)
+    @test p.optval ≈ 6 atol=TOL
+    @test evaluate(x + y) ≈ 6 atol=TOL
+    @test length(constraints(x)) == 1
+
 end
 
 

--- a/test/test_abstract_variable.jl
+++ b/test/test_abstract_variable.jl
@@ -1,0 +1,63 @@
+# We provide a non-`Variable` implementation of the `AbstractVariable` interface
+# to test that only the interface is used (and not, e.g. direct field access).
+    
+module TypedVectors
+using Convex
+
+# To make sure `Convex` isn't using field access on `AbstractVariable`'s
+# we'll use a global dictionary to store information about each instance
+# our of mock variable type, `TypedVector`.
+const global_cache = Dict{UInt64, Any}()
+
+mutable struct TypedVector{T} <: Convex.AbstractVariable
+    head::Symbol
+    id_hash::UInt64
+    size::Tuple{Int, Int}
+    function TypedVector{T}(d) where {T}
+        this = new(:ConstSizeVariable, 0, (d,1))
+        this.id_hash = objectid(this)
+        Convex.id_to_variables[this.id_hash] = this
+        global_cache[this.id_hash] = Dict(  :value => nothing,
+                                            :sign => T <: Complex ? ComplexSign() : NoSign(), 
+                                            :vartype => ContVar,
+                                            :constraints => Constraint[],
+                                            :vexity => AffineVexity())
+        this
+    end
+end
+
+Convex.value(x::TypedVector) = global_cache[x.id_hash][:value]
+
+Convex.value!(x::TypedVector, v::AbstractArray) = global_cache[x.id_hash][:value] = v
+Convex.value!(x::TypedVector, v::Number) = global_cache[x.id_hash][:value] = v
+
+Convex.vexity(x::TypedVector) = global_cache[x.id_hash][:vexity]
+Convex.vexity!(x::TypedVector, v::Vexity) = global_cache[x.id_hash][:vexity] = v
+
+Convex.sign(x::TypedVector) = global_cache[x.id_hash][:sign]
+Convex.sign!(x::TypedVector, s::Sign) = global_cache[x.id_hash][:sign] = s
+
+Convex.vartype(x::TypedVector) = global_cache[x.id_hash][:vartype]
+Convex.vartype!(x::TypedVector, s::Convex.VarType) = global_cache[x.id_hash][:vartype] = s
+
+Convex.constraints(x::TypedVector) = global_cache[x.id_hash][:constraints]
+Convex.constraints!(x::TypedVector, s::Vector{Constraint}) = global_cache[x.id_hash][:constraints] = s
+
+Convex.eltype(x::TypedVector{T}) where {T} = T
+
+end
+
+import .TypedVectors
+
+@testset "AbstractVariable interface" for solver in solvers
+    # Basic problem
+
+    x = TypedVectors.TypedVector{BigFloat}(1)
+    y = TypedVectors.TypedVector{BigFloat}(1)
+    p = minimize(x + y, [x >= 3, y >= 2])
+    @test vexity(p) == AffineVexity()
+    solve!(p, solver)
+    @test p.optval ≈ 5 atol=TOL
+    @test evaluate(x + y) ≈ 5 atol=TOL
+    @test Convex.eltype(x) == BigFloat
+end

--- a/test/test_mip.jl
+++ b/test/test_mip.jl
@@ -20,7 +20,7 @@
             y = Variable()
             vartype!(y, IntVar)
 
-            for x in [ Variable(:Int), Variable(vartype = IntVar), y ]
+            for x in [ Variable(:Int), Variable(IntVar), y ]
                 @test vartype(x) == IntVar
                 p = minimize(x, x>=4.3)
                 @test vexity(p) == AffineVexity()

--- a/test/test_mip.jl
+++ b/test/test_mip.jl
@@ -17,11 +17,16 @@
         end
 
         @testset "integer variables" begin
-            x = Variable(:Int)
-            p = minimize(x, x>=4.3)
-            @test vexity(p) == AffineVexity()
-            solve!(p, mip_solver)
-            @test p.optval ≈ 5 atol=TOL
+            y = Variable()
+            vartype!(y, IntVar)
+
+            for x in [ Variable(:Int), Variable(vartype = IntVar), y ]
+                @test vartype(x) == IntVar
+                p = minimize(x, x>=4.3)
+                @test vexity(p) == AffineVexity()
+                solve!(p, mip_solver)
+                @test p.optval ≈ 5 atol=TOL
+            end
 
             x = Variable(2, :Int)
             p = minimize(sum(x), x>=4.3)

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -5,7 +5,12 @@
 
         @testset "Variable constructors with functions" begin
             let
-                density_matrix(d) = ComplexVariable((d,d), x -> x ⪰ 0, x -> tr(x) == 1)
+                function density_matrix(d)
+                    x = ComplexVariable(d,d)
+                    add_constraint!(x, x ⪰ 0)
+                    add_constraint!(x, tr(x) == 1)
+                    return x
+                end
                 ρ = density_matrix(2) 
                 prob = minimize( real(ρ[1,1]) )
                 solve!(prob, solver)

--- a/test/test_sdp.jl
+++ b/test/test_sdp.jl
@@ -2,6 +2,18 @@
 # TODO: uncomment vexity checks once SDP on vars/constraints changes vexity of problem
 @testset "SDP Atoms: $solver" for solver in solvers
     if can_solve_sdp(solver)
+
+        @testset "Variable constructors with functions" begin
+            let
+                density_matrix(d) = ComplexVariable((d,d), x -> x ⪰ 0, x -> tr(x) == 1)
+                ρ = density_matrix(2) 
+                prob = minimize( real(ρ[1,1]) )
+                solve!(prob, solver)
+                @test prob.optval ≈ 0.0 atol = TOL
+                @test tr(evaluate(ρ)) ≈ 1.0 atol = TOL
+            end   
+        end
+
         @testset "sdp variables" begin
             y = Variable((2,2), :Semidefinite)
             p = minimize(y[1,1])

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -17,20 +17,20 @@
         @test isempty(Convex.conic_constr_to_constr)
     end
 
-    @testset "get_vartype and set_vartype" begin
+    @testset "vartype and set_vartype" begin
         for x in (Variable(), Variable(1), ComplexVariable(2,2))
-            @test get_vartype(x) == ContVar
+            @test vartype(x) == ContVar
             
-            set_vartype(x, BinVar)
-            @test get_vartype(x) == BinVar
+            vartype!(x, BinVar)
+            @test vartype(x) == BinVar
             @test x.vartype == BinVar
 
-            set_vartype(x, IntVar)
-            @test get_vartype(x) == IntVar
+            vartype!(x, IntVar)
+            @test vartype(x) == IntVar
             @test x.vartype == IntVar
 
-            set_vartype(x, ContVar)
-            @test get_vartype(x) == ContVar
+            vartype!(x, ContVar)
+            @test vartype(x) == ContVar
             @test x.vartype == ContVar
 
         end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -36,6 +36,65 @@
         end
     end
 
+    @testset "Constructors" begin
+
+        # Constructors with sign
+        sgn = Positive()
+        for x in    [   # tuple size
+                        Variable((2,2), sgn), 
+                        Variable((2,2), sgn, x -> x <= 3),
+                        Variable((2,2), sgn, x -> x <= 3; vartype = BinVar),
+                        Variable((2,2), sgn, :Bin),
+                        # individual size 
+                        Variable(2,2, sgn),
+                        Variable(2,2, sgn, x -> x <= 3),
+                        Variable(2,2, sgn, x -> x <= 3; vartype = BinVar),
+                        Variable(2,2, sgn, :Bin),
+                        # single dimension
+                        Variable(2, sgn),
+                        Variable(2, sgn, x -> x <= 3),
+                        Variable(2, sgn, x -> x <= 3; vartype = BinVar),
+                        Variable(2, sgn, :Bin),
+                        # no dimension
+                        Variable(sgn),
+                        Variable(sgn, x -> x <= 3),
+                        Variable(sgn, x -> x <= 3; vartype = BinVar),
+                        Variable(sgn, :Bin),  ]
+            @test x isa Variable
+            @test sign(x) == Positive()
+            @test x.sign == Positive()
+        end
+
+        # constructors without sign
+        for x in    [   # tuple size
+                        Variable((2,2)), 
+                        Variable((2,2), x -> x <= 3),
+                        Variable((2,2), x -> x <= 3; vartype = BinVar),
+                        Variable((2,2), :Bin),
+                        # individual size 
+                        Variable(2,2),
+                        Variable(2,2, x -> x <= 3),
+                        Variable(2,2, x -> x <= 3; vartype = BinVar),
+                        Variable(2,2, :Bin),
+                        # single dimension
+                        Variable(2),
+                        Variable(2, x -> x <= 3),
+                        Variable(2, x -> x <= 3; vartype = BinVar),
+                        Variable(2, :Bin),
+                        # no dimension
+                        Variable(),
+                        Variable(x -> x <= 3),
+                        Variable(x -> x <= 3; vartype = BinVar),
+                        Variable(:Bin),  ]
+                @test x isa Variable
+                @test sign(x) == NoSign()
+                @test x.sign == NoSign()
+        end
+
+
+
+    end
+
     @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -42,27 +42,23 @@
         for sgn in (Positive(), NoSign())
             for x in    [   # tuple size
                             Variable((2, 2), sgn), 
-                            Variable((2, 2), sgn, x->x <= 3),
-                            Variable((2, 2), sgn, x->x <= 3; vartype = BinVar),
+                            Variable((2, 2), sgn, BinVar),
                             Variable((2, 2), sgn, :Bin),
                             # individual size 
                             Variable(2, 2, sgn),
-                            Variable(2, 2, sgn, x->x <= 3),
-                            Variable(2, 2, sgn, x->x <= 3; vartype = BinVar),
+                            Variable(2, 2, sgn, BinVar),
                             Variable(2, 2, sgn, :Bin),
                             # single dimension
                             Variable(2, sgn),
-                            Variable(2, sgn, x->x <= 3),
-                            Variable(2, sgn, x->x <= 3; vartype = BinVar),
+                            Variable(2, sgn, BinVar),
                             Variable(2, sgn, :Bin),
                             # no dimension
                             Variable(sgn),
-                            Variable(sgn, x->x <= 3),
-                            Variable(sgn, x->x <= 3; vartype = BinVar),
+                            Variable(sgn, BinVar),
                             Variable(sgn, :Bin),  ]
                 @test x isa Variable
-                @test sign(x) == Positive()
-                @test x.sign == Positive()
+                @test sign(x) == sgn
+                @test x.sign == sgn
                 @test eltype(x) == Float64
             end
         end
@@ -70,23 +66,19 @@
         # constructors without sign
         for x in    [   # tuple size
                         Variable((2, 2)), 
-                        Variable((2, 2), x->x <= 3),
-                        Variable((2, 2), x->x <= 3; vartype = BinVar),
+                        Variable((2, 2), BinVar),
                         Variable((2, 2), :Bin),
                         # individual size 
                         Variable(2, 2),
-                        Variable(2, 2, x->x <= 3),
-                        Variable(2, 2, x->x <= 3; vartype = BinVar),
+                        Variable(2, 2, BinVar),
                         Variable(2, 2, :Bin),
                         # single dimension
                         Variable(2),
-                        Variable(2, x->x <= 3),
-                        Variable(2, x->x <= 3; vartype = BinVar),
+                        Variable(2, BinVar),
                         Variable(2, :Bin),
                         # no dimension
                         Variable(),
-                        Variable(x->x <= 3),
-                        Variable(x->x <= 3; vartype = BinVar),
+                        Variable(BinVar),
                         Variable(:Bin),  ]
             @test x isa Variable
             @test sign(x) == NoSign()
@@ -100,23 +92,19 @@
                 for x in    [
                     # tuple size
                     Variable{T}((2, 2), sgn), 
-                    Variable{T}((2, 2), sgn, x->x <= 3),
-                    Variable{T}((2, 2), sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}((2, 2), sgn, BinVar),
                     Variable{T}((2, 2), sgn, :Bin),
                     # individual size 
                     Variable{T}(2, 2, sgn),
-                    Variable{T}(2, 2, sgn, x->x <= 3),
-                    Variable{T}(2, 2, sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(2, 2, sgn, BinVar),
                     Variable{T}(2, 2, sgn, :Bin),
                     # single dimension
                     Variable{T}(2, sgn),
-                    Variable{T}(2, sgn, x->x <= 3),
-                    Variable{T}(2, sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(2, sgn, BinVar),
                     Variable{T}(2, sgn, :Bin),
                     # no dimension
                     Variable{T}(sgn),
-                    Variable{T}(sgn, x->x <= 3),
-                    Variable{T}(sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(sgn, BinVar),
                     Variable{T}(sgn, :Bin),  ]
 
                     @test x isa Variable
@@ -128,23 +116,19 @@
             for x in [
                 # tuple size
                 Variable{T}((2, 2)), 
-                Variable{T}((2, 2), x->x <= 3),
-                Variable{T}((2, 2), x->x <= 3; vartype = BinVar),
+                Variable{T}((2, 2), BinVar),
                 Variable{T}((2, 2), :Bin),
                 # individual size 
                 Variable{T}(2, 2),
-                Variable{T}(2, 2, x->x <= 3),
-                Variable{T}(2, 2, x->x <= 3; vartype = BinVar),
+                Variable{T}(2, 2, BinVar),
                 Variable{T}(2, 2, :Bin),
                 # single dimension
                 Variable{T}(2),
-                Variable{T}(2, x->x <= 3),
-                Variable{T}(2, x->x <= 3; vartype = BinVar),
+                Variable{T}(2, BinVar),
                 Variable{T}(2, :Bin),
                 # no dimension
                 Variable{T}(),
-                Variable{T}(x->x <= 3),
-                Variable{T}(x->x <= 3; vartype = BinVar),
+                Variable{T}(BinVar),
                 Variable{T}(:Bin), 
             ]
                 @test x isa Variable

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -21,7 +21,7 @@
         let
             density_matrix(d) = ComplexVariable((d,d), x -> x ⪰ 0, x -> tr(x) == 1)
             ρ = density_matrix(2) 
-            prob = minimize( ρ[1,1] )
+            prob = minimize( real(ρ[1,1]) )
             solve!(prob, solver)
             @test prob.optval ≈ 0.0 atol = TOL
             @test tr(evaluate(ρ)) ≈ 1.0 atol = TOL

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -18,7 +18,7 @@
     end
 
     @testset "vartype and set_vartype" begin
-        for x in (Variable(), Variable(1), ComplexVariable(2,2))
+        for x in (Variable(), Variable(1), ComplexVariable(2, 2))
             @test vartype(x) == ContVar
             
             vartype!(x, BinVar)
@@ -39,60 +39,120 @@
     @testset "Constructors" begin
 
         # Constructors with sign
-        sgn = Positive()
-        for x in    [   # tuple size
-                        Variable((2,2), sgn), 
-                        Variable((2,2), sgn, x -> x <= 3),
-                        Variable((2,2), sgn, x -> x <= 3; vartype = BinVar),
-                        Variable((2,2), sgn, :Bin),
-                        # individual size 
-                        Variable(2,2, sgn),
-                        Variable(2,2, sgn, x -> x <= 3),
-                        Variable(2,2, sgn, x -> x <= 3; vartype = BinVar),
-                        Variable(2,2, sgn, :Bin),
-                        # single dimension
-                        Variable(2, sgn),
-                        Variable(2, sgn, x -> x <= 3),
-                        Variable(2, sgn, x -> x <= 3; vartype = BinVar),
-                        Variable(2, sgn, :Bin),
-                        # no dimension
-                        Variable(sgn),
-                        Variable(sgn, x -> x <= 3),
-                        Variable(sgn, x -> x <= 3; vartype = BinVar),
-                        Variable(sgn, :Bin),  ]
-            @test x isa Variable
-            @test sign(x) == Positive()
-            @test x.sign == Positive()
+        for sgn in (Positive(), NoSign())
+            for x in    [   # tuple size
+                            Variable((2, 2), sgn), 
+                            Variable((2, 2), sgn, x->x <= 3),
+                            Variable((2, 2), sgn, x->x <= 3; vartype = BinVar),
+                            Variable((2, 2), sgn, :Bin),
+                            # individual size 
+                            Variable(2, 2, sgn),
+                            Variable(2, 2, sgn, x->x <= 3),
+                            Variable(2, 2, sgn, x->x <= 3; vartype = BinVar),
+                            Variable(2, 2, sgn, :Bin),
+                            # single dimension
+                            Variable(2, sgn),
+                            Variable(2, sgn, x->x <= 3),
+                            Variable(2, sgn, x->x <= 3; vartype = BinVar),
+                            Variable(2, sgn, :Bin),
+                            # no dimension
+                            Variable(sgn),
+                            Variable(sgn, x->x <= 3),
+                            Variable(sgn, x->x <= 3; vartype = BinVar),
+                            Variable(sgn, :Bin),  ]
+                @test x isa Variable
+                @test sign(x) == Positive()
+                @test x.sign == Positive()
+                @test eltype(x) == Float64
+            end
         end
 
         # constructors without sign
         for x in    [   # tuple size
-                        Variable((2,2)), 
-                        Variable((2,2), x -> x <= 3),
-                        Variable((2,2), x -> x <= 3; vartype = BinVar),
-                        Variable((2,2), :Bin),
+                        Variable((2, 2)), 
+                        Variable((2, 2), x->x <= 3),
+                        Variable((2, 2), x->x <= 3; vartype = BinVar),
+                        Variable((2, 2), :Bin),
                         # individual size 
-                        Variable(2,2),
-                        Variable(2,2, x -> x <= 3),
-                        Variable(2,2, x -> x <= 3; vartype = BinVar),
-                        Variable(2,2, :Bin),
+                        Variable(2, 2),
+                        Variable(2, 2, x->x <= 3),
+                        Variable(2, 2, x->x <= 3; vartype = BinVar),
+                        Variable(2, 2, :Bin),
                         # single dimension
                         Variable(2),
-                        Variable(2, x -> x <= 3),
-                        Variable(2, x -> x <= 3; vartype = BinVar),
+                        Variable(2, x->x <= 3),
+                        Variable(2, x->x <= 3; vartype = BinVar),
                         Variable(2, :Bin),
                         # no dimension
                         Variable(),
-                        Variable(x -> x <= 3),
-                        Variable(x -> x <= 3; vartype = BinVar),
+                        Variable(x->x <= 3),
+                        Variable(x->x <= 3; vartype = BinVar),
                         Variable(:Bin),  ]
+            @test x isa Variable
+            @test sign(x) == NoSign()
+            @test x.sign == NoSign()
+            @test eltype(x) == Float64
+        end
+
+        # Various element types
+        for T in (Float32, Float64, BigFloat)
+            for sgn in (Positive(), NoSign())
+                for x in    [
+                    # tuple size
+                    Variable{T}((2, 2), sgn), 
+                    Variable{T}((2, 2), sgn, x->x <= 3),
+                    Variable{T}((2, 2), sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}((2, 2), sgn, :Bin),
+                    # individual size 
+                    Variable{T}(2, 2, sgn),
+                    Variable{T}(2, 2, sgn, x->x <= 3),
+                    Variable{T}(2, 2, sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(2, 2, sgn, :Bin),
+                    # single dimension
+                    Variable{T}(2, sgn),
+                    Variable{T}(2, sgn, x->x <= 3),
+                    Variable{T}(2, sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(2, sgn, :Bin),
+                    # no dimension
+                    Variable{T}(sgn),
+                    Variable{T}(sgn, x->x <= 3),
+                    Variable{T}(sgn, x->x <= 3; vartype = BinVar),
+                    Variable{T}(sgn, :Bin),  ]
+
+                    @test x isa Variable
+                    @test sign(x) == sgn
+                    @test x.sign == sgn
+                    @test eltype(x) == T
+                end
+            end
+            for x in [
+                # tuple size
+                Variable{T}((2, 2)), 
+                Variable{T}((2, 2), x->x <= 3),
+                Variable{T}((2, 2), x->x <= 3; vartype = BinVar),
+                Variable{T}((2, 2), :Bin),
+                # individual size 
+                Variable{T}(2, 2),
+                Variable{T}(2, 2, x->x <= 3),
+                Variable{T}(2, 2, x->x <= 3; vartype = BinVar),
+                Variable{T}(2, 2, :Bin),
+                # single dimension
+                Variable{T}(2),
+                Variable{T}(2, x->x <= 3),
+                Variable{T}(2, x->x <= 3; vartype = BinVar),
+                Variable{T}(2, :Bin),
+                # no dimension
+                Variable{T}(),
+                Variable{T}(x->x <= 3),
+                Variable{T}(x->x <= 3; vartype = BinVar),
+                Variable{T}(:Bin), 
+            ]
                 @test x isa Variable
                 @test sign(x) == NoSign()
                 @test x.sign == NoSign()
+                @test eltype(x) == T
+            end
         end
-
-
-
     end
 
     @testset "ConicObj" for T = [UInt32, UInt64]
@@ -111,7 +171,7 @@
     end
 
     @testset "length and size" begin
-        x = Variable(2,3)
+        x = Variable(2, 3)
         @test length(x) == 6
         @test size(x) == (2, 3)
         @test size(x, 1) == 2
@@ -159,8 +219,8 @@
         @test Convex._sign([-1,-1,-1]) == Negative()
         @test Convex._size([0 0; 0 0]) == (2, 2)
         @test Convex._sign([0 0; 0 0]) == Positive()
-        @test Convex._size(0+1im) == (1, 1)
-        @test Convex._sign(0+1im) == ComplexSign()
+        @test Convex._size(0 + 1im) == (1, 1)
+        @test Convex._sign(0 + 1im) == ComplexSign()
 
         @test Convex.imag_conic_form(Constant(1.0)) == [0.0]
         @test Convex.imag_conic_form(Constant([1.0, 2.0])) == [0.0, 0.0]
@@ -168,11 +228,11 @@
 
     @testset "Base.vect" begin
     # Issue #223: ensure we can make vectors of variables
-    @test size([Variable(2), Variable(3,4)]) == (2,)
+        @test size([Variable(2), Variable(3, 4)]) == (2,)
     end
 
     @testset "Iteration" begin
-        x = Variable(2,3)
+        x = Variable(2, 3)
         s = sum([xi for xi in x])
         x.value = [1 2 3; 4 5 6]
         # evaluate(s) == [21] (which might be wrong? expected 21)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -17,33 +17,21 @@
         @test isempty(Convex.conic_constr_to_constr)
     end
 
-    @testset "Variable constructors with functions" begin
-        let
-            density_matrix(d) = ComplexVariable((d,d), x -> x ⪰ 0, x -> tr(x) == 1)
-            ρ = density_matrix(2) 
-            prob = minimize( real(ρ[1,1]) )
-            solve!(prob, solver)
-            @test prob.optval ≈ 0.0 atol = TOL
-            @test tr(evaluate(ρ)) ≈ 1.0 atol = TOL
-        end   
-
-    end
-
     @testset "get_vartype and set_vartype" begin
         for x in (Variable(), Variable(1), ComplexVariable(2,2))
             @test get_vartype(x) == ContVar
             
             set_vartype(x, BinVar)
             @test get_vartype(x) == BinVar
-            @test x.vartype = BinVar
+            @test x.vartype == BinVar
 
             set_vartype(x, IntVar)
             @test get_vartype(x) == IntVar
-            @test x.vartype = IntVar
+            @test x.vartype == IntVar
 
             set_vartype(x, ContVar)
             @test get_vartype(x) == ContVar
-            @test x.vartype = ContVar
+            @test x.vartype == ContVar
 
         end
     end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -17,6 +17,37 @@
         @test isempty(Convex.conic_constr_to_constr)
     end
 
+    @testset "Variable constructors with functions" begin
+        let
+            density_matrix(d) = ComplexVariable((d,d), x -> x ⪰ 0, x -> tr(x) == 1)
+            ρ = density_matrix(2) 
+            prob = minimize( ρ[1,1] )
+            solve!(prob, solver)
+            @test prob.optval ≈ 0.0 atol = TOL
+            @test tr(evaluate(ρ)) ≈ 1.0 atol = TOL
+        end   
+
+    end
+
+    @testset "get_vartype and set_vartype" begin
+        for x in (Variable(), Variable(1), ComplexVariable(2,2))
+            @test get_vartype(x) == ContVar
+            
+            set_vartype(x, BinVar)
+            @test get_vartype(x) == BinVar
+            @test x.vartype = BinVar
+
+            set_vartype(x, IntVar)
+            @test get_vartype(x) == IntVar
+            @test x.vartype = IntVar
+
+            set_vartype(x, ContVar)
+            @test get_vartype(x) == ContVar
+            @test x.vartype = ContVar
+
+        end
+    end
+
     @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)


### PR DESCRIPTION
Remaining things to do:

- [ ] Wait for #330 and then rebase
- [ ] Add examples and explanations to the documentation
- [ ] Add more tests (complex variable constructors, various numeric types, problems using the new variables)
- [ ] Improve style and formatting
- [ ] ideally get some feedback :).

This PR introduces an `AbstractVariable{T}` type with a corresponding interface. User-defined types can implement the interface to have custom variable types which can be dispatched on in user-code. The interface consists of

* `value`, `value!`: get or set the numeric value of the variable. `value` should return `nothing` when no numeric value is set.
* `vexity`, `vexity!`: get or set the `vexity` of the variable. The `vexity` should be `AffineVexity()` unless the variable has been `fix!`'d, in which case it is `ConstVexity()`.
* `sign`, `vartype`, and `constraints`: get the `Sign`, `VarType` (a new enum, for binary, integer, or continuous variables), numeric type, and a (possibly empty) vector of constraints which are to be applied to any problem in which the variable is used.

Optionally, also users can also implement `sign!`, `vartype!`, and `add_constraint!` to allow users to modify those values or add a constraint to a list of constraints which are applied to any problem in which the variable is used.

Subtypes of `AbstractVariable` are expected to have fields (or `getproperty` overloads) for `head`, `id_hash` and `size`, as those are expected of all `AbstractExpr`'s. Future work could be to clarify the `AbstractExpr` interface. Moreover, `AbstractVariable`'s need to add themselves to Convex's global registrar of variables, and set their own hash. This sounds confusing but I will add several examples to the docs. Moreover, subtyping `AbstractVariable` is definitely not necessary for casual use (we got this far without it anyway!).

The type parameter `T` gives the `eltype` of the variable. This allows variables which accept e.g. `BigFloats` to be created, instead of implicitly assuming variables are all `Float64`. The `Problem` companion to this change is https://github.com/JuliaOpt/Convex.jl/pull/289. 

The venerable `Variable` is the first user of this interface. The new `constraints` and `vartype` methods lets us finish what we started in #299: getting rid of `sets`. The problem with `sets` is that it tried to serve several orthogonal purposes simultaneously while at the same time, it wasn't always very clear what you could put in there that would have an effect.

* `sets` was populated by `:fixed` to indicate a variable was constant; this was changed in #299 by using the `vexity` to indicate constantness.
* `sets` was also used to add one particular constraint to a variable: semidefiniteness. This is replaced by the much more flexible `constraints` (and `add_constraint!`) method. Now, a `Variable` can carry around arbitrary constraints which automatically get applied to any problem the variable is in, just like `:semidefinite` in `sets` did.
* `sets` was finally used to indicate if a variable was binary, integer, or continuous. This was replaced by `vartype` which uses an enum. I prefer the enum because it makes clear what the possible choices are, whereas when entering symbols, it wasn't immediately obvious (e.g. `:bin` or `:binary`?)

What is the benefit? One nice thing you can do now is
```julia
function probabilityvector(d::Int)
    x = Variable(d, Positive())
    add_constraint!(x, sum(x) == 1)
    x
end
```
Then later, `p = probabilityvector(3)` can be used like any other variable, but the constraints of having non-negative entries which add to 1 will be automatically applied to any problem it is used in. This allows very simple implementations of DSLs.

The introduction of `AbstractVariable` allows more ambitious extensions as well. Since custom types can subtype `AbstractVariable`, variables can be used in dispatch, or even be used as callable types. Continuing with the probability example, let's say I often use my probability vectors for getting the expectation value of other variables, and I want to use function notation for this. I could define

```julia
using Convex
mutable struct ProbabilityVector <: Convex.AbstractVariable{Float64}
    head::Symbol
    id_hash::UInt64
    size::Tuple{Int, Int}
    value::Convex.ValueOrNothing
    vexity::Vexity
    function ProbabilityVector(d)
        this = new(:ProbabilityVector, 0, (d,1), nothing, Convex.AffineVexity())
        this.id_hash = objectid(this)
        Convex.id_to_variables[this.id_hash] = this
        this
    end
end
Convex.constraints(p::ProbabilityVector) = [ sum(p) == 1 ]
Convex.sign(::ProbabilityVector) = Convex.Positive()
Convex.vartype(::ProbabilityVector) = Convex.ContVar

(p::ProbabilityVector)(x) = dot(p, x)
```
And then I can use the new type freely in Convex problems. E.g.
```julia
p = ProbabilityVector(3)
x = [1.0, 2.0, 3.0]
prob = minimize( p(x) )
solve!(prob, solver)
evaluate(p) # [1.0, 0.0, 0.0]
```

I've been experimenting with a similar DSL for quantum information theory in https://github.com/ericphanson/QuantumSDPs.jl.

These changes should be entirely non-breaking (as long as user code was not dipping into `Variable` fields too much). I re-implemented the old constructors that accept symbols for `set`, and translate them to the new variable type. (These could be deprecated at some point). Many of the internals changes are simply changing e.g. `x.sign` to `sign(x)`, to use the interface instead.

Lines 310-312 of `variables.jl` contain the core logic change; instead of adding constraints for hardcoded symbols that correspond to constraints, we just apply each constraint given in `constraints(x)`. Most of the lines of code changed are new constructors, fallback constructors for the old `set` behavior, and tests for the constructors.