### PR TITLE
Revert "Make global variables constant"

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -84,10 +84,9 @@ include("utilities/broadcast.jl")
 
 #Temporary workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
-    global id_to_variables
-    empty!(id_to_variables)
-    global conic_constr_to_constr 
-    empty!(conic_constr_to_constr)
+    global id_to_variables = Dict{UInt64, Variable}()
+    global var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
+    global conic_constr_to_constr = Dict{ConicConstr, Constraint}()
     GC.gc()
 end
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -85,7 +85,6 @@ include("utilities/broadcast.jl")
 #Temporary workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
     global id_to_variables = Dict{UInt64, Variable}()
-    global var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
     global conic_constr_to_constr = Dict{ConicConstr, Constraint}()
     GC.gc()
 end

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -2,7 +2,7 @@ import Base.==, Base.<=, Base.>=, Base.<, Base.>
 export EqConstraint, LtConstraint, GtConstraint
 export ==, <=, >=
 
-const conic_constr_to_constr = Dict{ConicConstr, Constraint}()
+conic_constr_to_constr = Dict{ConicConstr, Constraint}()
 
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -57,7 +57,7 @@ end
 # the expression tree will only utilize variable ids during construction
 # full information of the variables will be needed during stuffing
 # and after solving to populate the variables with values
-const id_to_variables = Dict{UInt64, Variable}()
+id_to_variables = Dict{UInt64, Variable}()
 
 function vexity(x::Variable)
     return x.vexity

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,22 +1,5 @@
 @testset "Utilities" begin
 
-    @testset "clearmemory" begin
-        # solve a problem to populate globals
-        x = Variable()
-        p = minimize(-x, [x <= 0])
-        @test vexity(p) == AffineVexity()
-        solve!(p, solvers[1])
-
-        @test !isempty(Convex.id_to_variables)
-        @test !isempty(Convex.conic_constr_to_constr)
-
-        Convex.clearmemory()
-
-        # check they are cleared
-        @test isempty(Convex.id_to_variables)
-        @test isempty(Convex.conic_constr_to_constr)
-    end
-
     @testset "ConicObj" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)


### PR DESCRIPTION
Reverts JuliaOpt/Convex.jl#286

`empty!` doesn't actually free all the memory used by the dictionary, causing problems reported in https://github.com/JuliaOpt/Convex.jl/issues/83.