### PR TITLE
Fix `fix!` for vector inputs

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -124,6 +124,13 @@ function fix!(x::Variable, v::AbstractArray)
     fix!(x)
 end
 
+function fix!(x::Variable, v::AbstractVector)
+    size(x, 2) == 1 || throw(DimensionMismatch("Cannot set value of a variable of size $(size(x)) to a vector"))
+    size(x, 1) == length(v) || throw(DimensionMismatch("Variable and value sizes do not match!"))
+    x.value = sign(x) == ComplexSign() ? convert(Array{ComplexF64}, v) : convert(Array{Float64}, v)
+    fix!(x)
+end
+
 function fix!(x::Variable, v::Number)
     size(x) == (1,1) || throw(DimensionMismatch("Variable and value sizes do not match!"))
     x.value = sign(x) == ComplexSign() ? convert(ComplexF64, v) : convert(Float64, v)

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -78,4 +78,23 @@
         @test evaluate(y) ≈ 0.5 atol=TOL
     end
 
+    @testset "fix! with vectors" begin
+        x = ComplexVariable(5)
+        fix!(x, ones(5) + im*ones(5))
+        y = Variable()
+        prob = minimize( real(y*sum(x)), [ y >= .5, real(x) >= .5, imag(x) >= 0])
+        solve!(prob, solver)
+        @test prob.optval ≈ 2.5 atol=TOL
+        @test evaluate(real(y*sum(x))) ≈ 2.5 atol=TOL
+        @test evaluate(y) ≈ 0.5 atol=TOL
+
+        free!(x)
+        fix!(y)
+        solve!(prob, solver)
+        @test prob.optval ≈ 1.25 atol=TOL
+        @test evaluate(real(y*sum(x))) ≈ 1.25 atol=TOL
+        @test real(evaluate(x)) ≈ 0.5*ones(5) atol=TOL
+        @test evaluate(y) ≈ 0.5 atol=TOL
+    end
+
 end

--- a/test/test_const.jl
+++ b/test/test_const.jl
@@ -76,6 +76,9 @@
         @test evaluate(real(x*y)) ≈ 0.25 atol=TOL
         @test real(evaluate(x)) ≈ 0.5 atol=TOL
         @test evaluate(y) ≈ 0.5 atol=TOL
+
+        @test_throws DimensionMismatch fix!(x, rand(2))
+        @test_throws DimensionMismatch fix!(x, rand(2,2))
     end
 
     @testset "fix! with vectors" begin
@@ -95,6 +98,10 @@
         @test evaluate(real(y*sum(x))) ≈ 1.25 atol=TOL
         @test real(evaluate(x)) ≈ 0.5*ones(5) atol=TOL
         @test evaluate(y) ≈ 0.5 atol=TOL
+
+        @test_throws DimensionMismatch fix!(x, rand(5,5))
+        @test_throws DimensionMismatch fix!(x, rand(4))
+
     end
 
 end


### PR DESCRIPTION
Another annoying `fix!` bug; since we check the dimensions, but Convex expects vectors to be size `(d,1)`, we get errors. 