### PR TITLE
Remove global variables

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -88,8 +88,7 @@ include("utilities/broadcast.jl")
 
 # Deprecated workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
-    Base.depwarn("Convex.clearmemory() is deprecated, as the memory leak it works around has been closed. See https://github.com/JuliaOpt/Convex.jl/issues/83. Use `GC.gc()` for a literal translation of the remaining functionality.", :clearmemory )
-    GC.gc()
+    Base.depwarn("Convex.clearmemory() is deprecated, as the memory leak it works around has been closed (in https://github.com/JuliaOpt/Convex.jl/pull/322). This function no longer does anything and will be removed in a future Convex.jl release.", :clearmemory )
 end
 
 end

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -9,8 +9,11 @@ global DEFAULT_SOLVER = nothing
 ### modeling framework
 include("dcp.jl")
 include("expressions.jl")
-include("conic_form.jl")
+# need to define `Variable` before `UniqueConicForms`
 include("variable.jl")
+include("conic_form.jl")
+# need to define `conic_form!` for `Variable`s after `UniqueConicForms`
+include("variable_conic_form.jl")
 include("constant.jl")
 include("constraints/constraints.jl")
 include("constraints/signs_and_sets.jl")
@@ -85,8 +88,6 @@ include("utilities/broadcast.jl")
 
 #Temporary workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
-    global id_to_variables
-    empty!(id_to_variables)
     global conic_constr_to_constr 
     empty!(conic_constr_to_constr)
     GC.gc()

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -86,10 +86,9 @@ include("utilities/show.jl")
 include("utilities/iteration.jl")
 include("utilities/broadcast.jl")
 
-#Temporary workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
+# Deprecated workaround for memory leak (https://github.com/JuliaOpt/Convex.jl/issues/83)
 function clearmemory()
-    global conic_constr_to_constr 
-    empty!(conic_constr_to_constr)
+    Base.depwarn("Convex.clearmemory() is deprecated, as the memory leak it works around has been closed. See https://github.com/JuliaOpt/Convex.jl/issues/83. Use `GC.gc()` for a literal translation of the remaining functionality.", :clearmemory )
     GC.gc()
 end
 

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -54,7 +54,7 @@ function conic_form!(x::HcatAtom, unique_conic_forms::UniqueConicForms=UniqueCon
                     if id == objectid(:constant)
                         variable_to_sizes[id] = 1
                     else
-                        variable_to_sizes[id] = length(id_to_variables[id])
+                        variable_to_sizes[id] = length(unique_conic_forms.id_to_variables[id])
                     end
                 end
             end

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -106,15 +106,18 @@ const UniqueExpMap = OrderedDict{Tuple{Symbol, UInt64}, ConicObj}
 const UniqueConstrMap = OrderedDict{Tuple{Symbol, UInt64}, Int}
 # records each ConicConstr created
 const UniqueConstrList = Vector{ConicConstr}
+# map variables' hash to the variable itself 
+const IdToVariables = OrderedDict{UInt64, Variable}
 
 # UniqueConicForms caches all the conic forms of expressions we've parsed so far
 struct UniqueConicForms
     exp_map::UniqueExpMap
     constr_map::UniqueConstrMap
     constr_list::UniqueConstrList
+    id_to_variables::IdToVariables
 end
 
-UniqueConicForms() = UniqueConicForms(UniqueExpMap(), UniqueConstrMap(), ConicConstr[])
+UniqueConicForms() = UniqueConicForms(UniqueExpMap(), UniqueConstrMap(), ConicConstr[], IdToVariables())
 
 function has_conic_form(conic_forms::UniqueConicForms, exp::AbstractExpr)
     return haskey(conic_forms.exp_map, (exp.head, exp.id_hash))
@@ -144,4 +147,8 @@ end
 function cache_conic_form!(conic_forms::UniqueConicForms, constr::Constraint, new_conic_forms::UniqueConstrList)
     conic_forms.constr_map[(constr.head, constr.id_hash)] = 0
     append!(conic_forms.constr_list, new_conic_forms)
+end
+
+function cache_conic_form!(conic_forms::UniqueConicForms, var::Variable)
+    conic_forms.id_to_variables[var.id_hash] = var
 end

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -149,6 +149,6 @@ function cache_conic_form!(conic_forms::UniqueConicForms, constr::Constraint, ne
     append!(conic_forms.constr_list, new_conic_forms)
 end
 
-function cache_conic_form!(conic_forms::UniqueConicForms, var::Variable)
+function add_to_id_to_variables!(conic_forms::UniqueConicForms, var::Variable)
     conic_forms.id_to_variables[var.id_hash] = var
 end

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -108,16 +108,17 @@ const UniqueConstrMap = OrderedDict{Tuple{Symbol, UInt64}, Int}
 const UniqueConstrList = Vector{ConicConstr}
 # map variables' hash to the variable itself 
 const IdToVariables = OrderedDict{UInt64, Variable}
-
+const ConicConstrToConstr = Dict{ConicConstr, Constraint}
 # UniqueConicForms caches all the conic forms of expressions we've parsed so far
 struct UniqueConicForms
     exp_map::UniqueExpMap
     constr_map::UniqueConstrMap
     constr_list::UniqueConstrList
     id_to_variables::IdToVariables
+    conic_constr_to_constr::ConicConstrToConstr
 end
 
-UniqueConicForms() = UniqueConicForms(UniqueExpMap(), UniqueConstrMap(), ConicConstr[], IdToVariables())
+UniqueConicForms() = UniqueConicForms(UniqueExpMap(), UniqueConstrMap(), ConicConstr[], IdToVariables(), ConicConstrToConstr())
 
 function has_conic_form(conic_forms::UniqueConicForms, exp::AbstractExpr)
     return haskey(conic_forms.exp_map, (exp.head, exp.id_hash))

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -2,7 +2,7 @@ import Base.==, Base.<=, Base.>=, Base.<, Base.>
 export EqConstraint, LtConstraint, GtConstraint
 export ==, <=, >=
 
-const conic_constr_to_constr = Dict{ConicConstr, Constraint}()
+# const conic_constr_to_constr = Dict{ConicConstr, Constraint}()
 
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint
@@ -42,14 +42,14 @@ function conic_form!(c::EqConstraint, unique_conic_forms::UniqueConicForms=Uniqu
             expr = c.lhs - c.rhs
             objective = conic_form!(expr, unique_conic_forms)
             new_constraint = ConicConstr([objective], :Zero, [c.size[1] * c.size[2]])
-            conic_constr_to_constr[new_constraint] = c
+            unique_conic_forms.conic_constr_to_constr[new_constraint] = c
         else
             real_expr = real(c.lhs - c.rhs)
             imag_expr = imag(c.lhs - c.rhs)
             real_objective = conic_form!(real_expr, unique_conic_forms)
             imag_objective = conic_form!(imag_expr, unique_conic_forms)
             new_constraint = ConicConstr([real_objective, imag_objective], :Zero, [c.size[1] * c.size[2], c.size[1] * c.size[2]])
-            conic_constr_to_constr[new_constraint] = c
+            unique_conic_forms.conic_constr_to_constr[new_constraint] = c
         end
         cache_conic_form!(unique_conic_forms, c, new_constraint)
     end
@@ -100,7 +100,7 @@ function conic_form!(c::LtConstraint, unique_conic_forms::UniqueConicForms=Uniqu
         expr = c.rhs - c.lhs
         objective = conic_form!(expr, unique_conic_forms)
         new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
-        conic_constr_to_constr[new_constraint] = c
+        unique_conic_forms.conic_constr_to_constr[new_constraint] = c
         cache_conic_form!(unique_conic_forms, c, new_constraint)
     end
     return get_conic_form(unique_conic_forms, c)
@@ -152,7 +152,7 @@ function conic_form!(c::GtConstraint, unique_conic_forms::UniqueConicForms=Uniqu
         expr = c.lhs - c.rhs
         objective = conic_form!(expr, unique_conic_forms)
         new_constraint = ConicConstr([objective], :NonNeg, [c.size[1] * c.size[2]])
-        conic_constr_to_constr[new_constraint] = c
+        unique_conic_forms.conic_constr_to_constr[new_constraint] = c
         cache_conic_form!(unique_conic_forms, c, new_constraint)
     end
     return get_conic_form(unique_conic_forms, c)

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -2,8 +2,6 @@ import Base.==, Base.<=, Base.>=, Base.<, Base.>
 export EqConstraint, LtConstraint, GtConstraint
 export ==, <=, >=
 
-# const conic_constr_to_constr = Dict{ConicConstr, Constraint}()
-
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint
     head::Symbol

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -52,7 +52,7 @@ end
 # constr_size: m
 # var_to_ranges a dictionary mapping from variable id to (start_index, end_index)
 # where start_index and end_index are the start and end indexes of the variable in A
-function find_variable_ranges(constraints)
+function find_variable_ranges(constraints, id_to_variables)
     index = 0
     constr_size = 0
     var_to_ranges = Dict{UInt64, Tuple{Int, Int}}()
@@ -127,10 +127,12 @@ function conic_problem(p::Problem)
     unique_conic_forms = UniqueConicForms()
     objective, objective_var_id = conic_form!(p, unique_conic_forms)
     constraints = unique_conic_forms.constr_list
+    id_to_variables = unique_conic_forms.id_to_variables
+
     # var_to_ranges maps from variable id to the (start_index, stop_index) pairs of the columns of A corresponding to that variable
     # var_size is the sum of the lengths of all variables in the problem
     # constr_size is the sum of the lengths of all constraints in the problem
-    var_size, constr_size, var_to_ranges = find_variable_ranges(constraints)
+    var_size, constr_size, var_to_ranges = find_variable_ranges(constraints, id_to_variables)
     c = spzeros(var_size, 1)
     objective_range = var_to_ranges[objective_var_id]
     c[objective_range[1]:objective_range[2]] .= 1
@@ -188,7 +190,7 @@ function conic_problem(p::Problem)
         c = -c
     end
 
-    return c, A, b, cones, var_to_ranges, vartypes, constraints
+    return c, A, b, cones, var_to_ranges, vartypes, constraints, id_to_variables
 end
 
 Problem(head::Symbol, objective::AbstractExpr, constraints::Constraint...) =

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -127,6 +127,7 @@ function conic_problem(p::Problem)
     unique_conic_forms = UniqueConicForms()
     objective, objective_var_id = conic_form!(p, unique_conic_forms)
     constraints = unique_conic_forms.constr_list
+    conic_constr_to_constr = unique_conic_forms.conic_constr_to_constr
     id_to_variables = unique_conic_forms.id_to_variables
 
     # var_to_ranges maps from variable id to the (start_index, stop_index) pairs of the columns of A corresponding to that variable
@@ -190,7 +191,7 @@ function conic_problem(p::Problem)
         c = -c
     end
 
-    return c, A, b, cones, var_to_ranges, vartypes, constraints, id_to_variables
+    return c, A, b, cones, var_to_ranges, vartypes, constraints, id_to_variables, conic_constr_to_constr
 end
 
 Problem(head::Symbol, objective::AbstractExpr, constraints::Constraint...) =

--- a/src/variable_conic_form.jl
+++ b/src/variable_conic_form.jl
@@ -1,6 +1,6 @@
 function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
     if !has_conic_form(unique_conic_forms, x)
-        cache_conic_form!(unique_conic_forms, x)
+        add_to_id_to_variables!(unique_conic_forms, x)
         if vexity(x) == ConstVexity()
             # do exactly what we would for a constant
             objective = ConicObj()

--- a/src/variable_conic_form.jl
+++ b/src/variable_conic_form.jl
@@ -1,0 +1,26 @@
+function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
+    if !has_conic_form(unique_conic_forms, x)
+        cache_conic_form!(unique_conic_forms, x)
+        if vexity(x) == ConstVexity()
+            # do exactly what we would for a constant
+            objective = ConicObj()
+            objective[objectid(:constant)] = (vec([real(x.value);]),vec([imag(x.value);]))
+            cache_conic_form!(unique_conic_forms, x, objective)
+        else
+            objective = ConicObj()
+            vec_size = length(x)
+
+            objective[x.id_hash] = (real_conic_form(x), imag_conic_form(x))
+            objective[objectid(:constant)] = (spzeros(vec_size, 1), spzeros(vec_size, 1))
+            # placeholder values in unique constraints prevent infinite recursion depth
+            cache_conic_form!(unique_conic_forms, x, objective)
+            if !(x.sign == NoSign() || x.sign == ComplexSign())
+                conic_form!(x.sign, x, unique_conic_forms)
+            end
+            for set in x.sets
+                conic_form!(set, x, unique_conic_forms)
+            end
+        end
+    end
+    return get_conic_form(unique_conic_forms, x)
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,18 +1,7 @@
 @testset "Utilities" begin
 
     @testset "clearmemory" begin
-        # solve a problem to populate global
-        x = Variable()
-        p = minimize(-x, [x <= 0])
-        @test vexity(p) == AffineVexity()
-        solve!(p, solvers[1])
-
-        @test !isempty(Convex.conic_constr_to_constr)
-
-        Convex.clearmemory()
-
-        # check it is cleared
-        @test isempty(Convex.conic_constr_to_constr)
+        @test_deprecated Convex.clearmemory()
     end
 
     @testset "ConicObj" for T = [UInt32, UInt64]

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,19 +1,17 @@
 @testset "Utilities" begin
 
     @testset "clearmemory" begin
-        # solve a problem to populate globals
+        # solve a problem to populate global
         x = Variable()
         p = minimize(-x, [x <= 0])
         @test vexity(p) == AffineVexity()
         solve!(p, solvers[1])
 
-        @test !isempty(Convex.id_to_variables)
         @test !isempty(Convex.conic_constr_to_constr)
 
         Convex.clearmemory()
 
-        # check they are cleared
-        @test isempty(Convex.id_to_variables)
+        # check it is cleared
         @test isempty(Convex.conic_constr_to_constr)
     end
 


### PR DESCRIPTION
Addresses half of #83 by removing one of the two global variables Convex uses. (Edit: second half addressed in a later commit in this PR; see https://github.com/JuliaOpt/Convex.jl/pull/322#issuecomment-526923615).

Currently (i.e. on master), `id_to_variables` is a global dictionary associating the `id_hash` field of Variables to the Variable object itself, forming a global registry of variables. This allows one nice feature of Convex: Variables don't have to be explicitly added to a problem, since they are accessible to all problems via the global registry. To populate the registry, each variable must add itself to `id_to_variables` upon creation.

The aim here is to replace this global registry with a local one for each problem. This has the advantage that when all the problems using a particular variable go out of scope, the variable itself can be GC'd. With the global registry, no variable can ever be GC'd, because it could be accessed via the registry. This causes applications using lots of problems to run out of memory (e.g. solving a new problem for every pixel in an image).

It turns out, however, Convex already creates a sort of local registry for each problem to hold constraints and expressions: `unique_conic_forms`. Thus, all we need to do is also store variables in this local registry. Variables *already* have their conic form cached in `unique_conic_forms`; all we have to do is also store the `id_to_variables` association too during cache time. It took me several iterations to figure out this obvious solution! (Previous iterations involved traversing the problem tree separately to find and register variables, and were less performant).

The only annoyance is that we need to define `Variable` before `UniqueConicForms` to have the type information available to define `UniqueConicForms`, but we need to define `conic_form!` for a `Variable` after we define `UniqueConicForms`. My solution was to make a separate file for the latter, put the rest of `variable.jl` first, then `conic_form.jl`, then this new file. This unfortunately causes a more complicated diff; the only change in this `conic_form!` method is the addition of the line
```julia
 add_to_id_to_variables!(unique_conic_forms, x)
```
which adds the variable `x` to the local registry now stored in `unique_conic_forms`.

Note 1: `conic_form!` functions have been written with an optional second argument, as, e.g.
```julia
function conic_form!(x::Variable, unique_conic_forms::UniqueConicForms=UniqueConicForms())
```
The second argument should not be optional; it's actually crucial that we pass along the `unique_conic_forms` generated during `Convex.conic_problem`, because we take the constraints placed in that object as the constraints on the problem. So if this optional argument actually gets used, we won't be adding constraints to the problem during that `conic_form!`. However, the good news is that optional argument is **never** used; one can delete every instance of `=UniqueConicForms()` (besides the one in `Convex.conic_problem`), and all the tests pass. Thus, I think these optional arguments should be made mandatory. However, I'll do that in a separate PR to not complicate the diff here.

Note 2: by removing the need for variables to register themselves in the global registry, we present a simpler interface for custom variables once we have https://github.com/JuliaOpt/Convex.jl/pull/313. That PR thus will need to be updated, but it'll be better for it.

This is priority 2 of #320.