### PR TITLE
Only benchmark on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
               using Pkg; Pkg.instantiate();
               include("benchmark/pprintjudge.jl");'
       after_success: skip
+      if: type = pull_request
     - stage: Documentation
       julia: 1.0
       script: julia --project=docs -e '


### PR DESCRIPTION
This prevents also benchmarking again after merging a PR, which is slow and prevents Travis from running other jobs.