### PR TITLE
Improve printing of problems, constraints, and variables

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,8 +24,9 @@ The Convex.jl package is licensed under the Simplified "2-clause" BSD License:
 > (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 > OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-The file benchmark/benchmarks/benchmark.jl contains some utilities copied from the MathOptInterface.jl package
-(https://github.com/JuliaOpt/MathOptInterface.jl) which is licensed under the MIT License:
+The file benchmark/benchmarks/benchmark.jl contains some utilities copied
+from the MathOptInterface.jl package (https://github.com/JuliaOpt/MathOptInterface.jl)
+which is licensed under the MIT License:
 
 >Copyright (c) 2017: Miles Lubin and contributors Copyright (c) 2017: Google Inc.
 >
@@ -71,3 +72,28 @@ and .travis.yml contain code copied from the Transducers.jl package
 >LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 >OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 >SOFTWARE.
+
+The `TreePrint` module contains code from the AbstractTrees.jl package
+(https://github.com/Keno/AbstractTrees.jl) which is licensed under the
+MIT "Expat" License:
+
+> Copyright (c) 2015: Keno Fischer.
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
 version = "0.12.4"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+AbstractTrees = "^0.2.1"
 MathProgBase = "^0.7"
 OrderedCollections = "^1.0"
 julia = "^1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -98,3 +98,26 @@ for i=1:10
     free!(x)
 end
 ```
+
+Using the tree structure
+------------------------
+
+A Convex problem is structured as a *tree*, with the *root* being the
+problem object, with branches to the objective and the set of constraints.
+The objective is an `AbstractExpr` which itself is a tree, with each atom
+being a node and having `children` which are other atoms, variables, or
+constants. Convex provides `children` methods from
+[AbstractTrees.jl](https://github.com/Keno/AbstractTrees.jl) so that the
+tree-traversal functions of that package can be used with Convex.jl problems
+and structures. This is what allows powers the printing of problems, expressions,
+and constraints. This can also be used to analyze the structure of a Convex.jl
+problem. For example,
+
+```@repl
+using Convex, AbstractTrees
+x = Variable()
+p = maximize( log(x), x >= 1, x <= 3 )
+for leaf in AbstractTrees.Leaves(p)
+    println("Here's a leaf: $(summary(leaf))")
+end
+```

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -113,11 +113,47 @@ and structures. This is what allows powers the printing of problems, expressions
 and constraints. This can also be used to analyze the structure of a Convex.jl
 problem. For example,
 
-```@repl
+```@repl 1
 using Convex, AbstractTrees
 x = Variable()
 p = maximize( log(x), x >= 1, x <= 3 )
 for leaf in AbstractTrees.Leaves(p)
     println("Here's a leaf: $(summary(leaf))")
+end
+```
+
+We can also iterate over the problem in various orders. The following descriptions
+are taken from the AbstractTrees.jl docstrings, which have more information.
+
+### PostOrderDFS
+
+Iterator to visit the nodes of a tree, guaranteeing that children
+will be visited before their parents.
+
+```@repl 1
+for (i, node) in enumerate(AbstractTrees.PostOrderDFS(p))
+    println("Here's node $i via PostOrderDFS: $(summary(node))")
+end
+```
+
+### PreOrderDFS
+
+Iterator to visit the nodes of a tree, guaranteeing that parents
+will be visited before their children.
+
+```@repl 1
+for (i, node) in enumerate(AbstractTrees.PreOrderDFS(p))
+    println("Here's node $i via PreOrderDFS: $(summary(node))")
+end
+```
+
+### StatelessBFS
+
+Iterator to visit the nodes of a tree, guaranteeing that all nodes of a level
+will be visited before their children.
+
+```@repl 1
+for (i, node) in enumerate(AbstractTrees.StatelessBFS(p))
+    println("Here's node $i via StatelessBFS: $(summary(node))")
 end
 ```

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -79,8 +79,9 @@ include("atoms/exp_cone/relative_entropy.jl")
 include("atoms/exp_+_sdp_cone/logdet.jl")
 
 ### utilities
-include("utilities/show.jl")
+include("utilities/tree_print.jl")
 include("utilities/tree_interface.jl")
+include("utilities/show.jl")
 include("utilities/iteration.jl")
 include("utilities/broadcast.jl")
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -80,6 +80,7 @@ include("atoms/exp_+_sdp_cone/logdet.jl")
 
 ### utilities
 include("utilities/show.jl")
+include("utilities/tree_interface.jl")
 include("utilities/iteration.jl")
 include("utilities/broadcast.jl")
 

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -95,13 +95,15 @@ struct ShowProblemConstraints
     constraints::Vector{Constraint}
 end
 
-AbstractTrees.children(p::ShowProblemConstraints) = tuple(p.constraints)
+AbstractTrees.children(p::ShowProblemConstraints) = p.constraints
 AbstractTrees.printnode(io::IO, p::ShowProblemConstraints) = print(io,"subject to")
 
 
 function show(io::IO, p::Problem)
     AbstractTrees.print_tree(io, ShowProblemObjective(p.head, p.objective))
-    AbstractTrees.print_tree(io, ShowProblemConstraints(p.constraints))
+    if !(isempty(p.constraints))
+        AbstractTrees.print_tree(io, ShowProblemConstraints(p.constraints))
+    end
     print(io, "\ncurrent status: $(p.status)")
     if p.status == "solved"
         print(io, " with optimal value of $(round(p.optval, digits=4))")

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -11,7 +11,7 @@ Controls depth of tree printing globally for Convex.jl
 const MAXDEPTH = Ref(3)
 
 """
-    show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 4)
+    show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 3)
 
 Print a truncated version of the objects `id_hash` field.
 
@@ -21,15 +21,14 @@ Print a truncated version of the objects `id_hash` field.
 julia> x = Variable();
 
 julia> Convex.show_id(stdout, x)
-id: 6201...
+id: 163…906
 ```
 """
-show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 4) = print(io, show_id(x))
+show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 3) = print(io, show_id(x; digits=digits))
 
-function show_id(x::Union{AbstractExpr, Constraint}; digits = 4)
+function show_id(x::Union{AbstractExpr, Constraint}; digits = 3)
     hash_str = string(x.id_hash)
-    hash_str = hash_str[1:nextind(hash_str, digits-1)]
-    return "id: " * hash_str * "..."
+    return "id: " * first(hash_str, digits) * "…" * last(hash_str, digits)
 end
 
 """
@@ -42,7 +41,7 @@ Prints a one-line summary of a variable `x` to `io`.
 julia> x = ComplexVariable(3,2);
 
 julia> summary(stdout, x)
-3×2 complex variable (id: 5455...)
+3×2 complex variable (id: 732…737)
 ```
 """
 function Base.summary(io::IO, x::Variable)
@@ -92,7 +91,7 @@ show(io::IO, x::Constant) = print(io, x.value)
 # size: (3, 4)
 # sign: real
 # vexity: affine
-# id: 7385...
+# id: 758…633
 # here, the `id` will change from run to run.
 function show(io::IO, x::Variable)
     print(io, "Variable")

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -1,5 +1,23 @@
-import Base.show
-export show
+import Base.show, Base.summary
+export show, summary
+
+
+function Base.summary(io::IO, x::Variable)
+    sgn = sign(x) == ComplexSign() ? " complex " : " "
+    cst = vexity(x) == ConstVexity() ? " (fixed)" : ""
+    if size(x) == (1,1)
+        if sign(x) == ComplexSign()
+            print(io, "complex variable$(cst)")
+        else
+            print(io, "variable$(cst)")
+        end
+    elseif size(x,2) == 1
+        print(io, "$(size(x,1))-element$(sgn)variable$(cst)")
+    else
+        print(io, "$(size(x,1))×$(size(x,2))$(sgn)variable$(cst)")
+
+    end
+end
 
 # A Constant is simply a wrapper around a native Julia constant
 # Hence, we simply display its value

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -2,13 +2,45 @@ import Base.show, Base.summary
 export show, summary
 import AbstractTrees
 
+"""
+    show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 4)
 
-function Base.summary(io::IO, x::Variable)
+Print a truncated version of the objects `id_hash` field.
+
+## Example
+
+```julia-repl
+julia> x = Variable();
+
+julia> Convex.show_id(stdout, x)
+id: 6201...
+```
+"""
+show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 4) = print(io, show_id(x))
+
+function show_id(x::Union{AbstractExpr, Constraint}; digits = 4)
     hash_str = string(x.id_hash)
-    hash_str = hash_str[1:nextind(hash_str, 3)]
+    hash_str = hash_str[1:nextind(hash_str, digits-1)]
+    return "id: " * hash_str * "..."
+end
+
+"""
+    Base.summary(io::IO, x::Variable)
+
+Prints a one-line summary of a variable `x` to `io`.
+
+## Examples
+```julia-repl
+julia> x = ComplexVariable(3,2);
+
+julia> summary(stdout, x)
+3×2 complex variable (id: 5455...)
+```
+"""
+function Base.summary(io::IO, x::Variable)
     sgn = summary(sign(x))
     cst = vexity(x) == ConstVexity() ? " (fixed)" : ""
-    cst = cst * " (id: " * hash_str * "...)"
+    cst = cst * " (" * sprint(show_id, x) * ")"
     if size(x) == (1,1)
         print(io, "$(sgn) variable$(cst)")
     elseif size(x,2) == 1
@@ -48,62 +80,95 @@ end
 show(io::IO, x::Constant) = print(io, x.value)
 
 # A variable, for example, Variable(3, 4), will be displayed as:
-# Variable of
+# julia> Variable(3,4)
+# Variable
 # size: (3, 4)
-# sign: NoSign()
-# vexity: AffineVexity()
+# sign: real
+# vexity: affine
+# id: 7385...
+# here, the `id` will change from run to run.
 function show(io::IO, x::Variable)
-    print(io, """Variable of
-          size: ($(x.size[1]), $(x.size[2]))
-          sign: $(x.sign)
-          vexity: $(x.vexity)""")
+    print(io, "Variable")
+    print(io, "\nsize: $(size(x))")
+    print(io, "\nsign: ")
+    summary(io, sign(x))
+    print(io, "\nvexity: ")
+    summary(io, vexity(x))
+    println(io)
+    show_id(io, x)
     if x.value !== nothing
         print(io, "\nvalue: $(x.value)")
     end
 end
 
-struct ShowConstraint
+"""
+    print_tree_rstrip(io::IO, x)
+
+Prints the results of `AbstractTrees.print_tree(io, x)`
+without the final newline. Used for `show` methods which
+invoke `print_tree`.
+"""
+function print_tree_rstrip(io::IO, x)
+    str = sprint(AbstractTrees.print_tree, x)
+    print(io, rstrip(str))
+end
+
+# This object is used to work around the fact that
+# Convex overloads booleans for AbstractExpr's
+# in order to generate constraints. This is problematic
+# for `AbstractTrees.print_tree` which wants to compare
+# the root of the tree to itself at some point.
+# By wrapping all tree roots in structs, this comparison
+# occurs on the level of the `struct`, and `==` falls
+# back to object equality (`===`), which is what we
+# want in this case.
+#
+# The same construct is used below for other tree roots.
+struct ConstraintRoot
     constraint::Constraint
 end
+AbstractTrees.print_tree(io::IO, c::Constraint) = AbstractTrees.print_tree(io, ConstraintRoot(c))
+AbstractTrees.children(c::ConstraintRoot) = AbstractTrees.children(c.constraint)
+AbstractTrees.printnode(io::IO, c::ConstraintRoot) = AbstractTrees.printnode(io, c.constraint)
 
-AbstractTrees.children(c::ShowConstraint) = AbstractTrees.children(c.constraint)
-AbstractTrees.printnode(io::IO, c::ShowConstraint) = AbstractTrees.printnode(io, c.constraint)
+show(io::IO, c::Constraint) = print_tree_rstrip(io, c)
 
-show(io::IO, c::Constraint) = AbstractTrees.print_tree(io, ShowConstraint(c))
-
-
-
-struct ShowExpr
+struct ExprRoot
     expr::AbstractExpr
 end
-
-AbstractTrees.children(c::ShowExpr) = AbstractTrees.children(c.expr)
-AbstractTrees.printnode(io::IO, c::ShowExpr) = AbstractTrees.printnode(io, c.expr)
-
-show(io::IO, c::AbstractExpr) = AbstractTrees.print_tree(io, ShowExpr(c))
+AbstractTrees.print_tree(io::IO, e::AbstractExpr) = AbstractTrees.print_tree(io, ExprRoot(e))
+AbstractTrees.children(e::ExprRoot) = AbstractTrees.children(e.expr)
+AbstractTrees.printnode(io::IO, e::ExprRoot) = AbstractTrees.printnode(io, e.expr)
 
 
-struct ShowProblemObjective
+show(io::IO, e::AbstractExpr) = print_tree_rstrip(io, e)
+
+
+struct ProblemObjectiveRoot
     head::Symbol
     objective::AbstractExpr
 end
 
-AbstractTrees.children(p::ShowProblemObjective) = (p.objective,)
-AbstractTrees.printnode(io::IO, p::ShowProblemObjective) =  print(io,string(p.head))
+AbstractTrees.children(p::ProblemObjectiveRoot) = (p.objective,)
+AbstractTrees.printnode(io::IO, p::ProblemObjectiveRoot) =  print(io, string(p.head))
 
-struct ShowProblemConstraints
+struct ProblemConstraintsRoot
     constraints::Vector{Constraint}
 end
 
-AbstractTrees.children(p::ShowProblemConstraints) = p.constraints
-AbstractTrees.printnode(io::IO, p::ShowProblemConstraints) = print(io,"subject to")
+AbstractTrees.children(p::ProblemConstraintsRoot) = p.constraints
+AbstractTrees.printnode(io::IO, p::ProblemConstraintsRoot) = print(io, "subject to")
 
+
+function AbstractTrees.print_tree(io::IO, p::Problem)
+    AbstractTrees.print_tree(io, ProblemObjectiveRoot(p.head, p.objective))
+    if !(isempty(p.constraints))
+        AbstractTrees.print_tree(io, ProblemConstraintsRoot(p.constraints))
+    end
+end
 
 function show(io::IO, p::Problem)
-    AbstractTrees.print_tree(io, ShowProblemObjective(p.head, p.objective))
-    if !(isempty(p.constraints))
-        AbstractTrees.print_tree(io, ShowProblemConstraints(p.constraints))
-    end
+    AbstractTrees.print_tree(io, p)
     print(io, "\ncurrent status: $(p.status)")
     if p.status == "solved"
         print(io, " with optimal value of $(round(p.optval, digits=4))")

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -55,7 +55,6 @@ function Base.summary(io::IO, x::Variable)
         print(io, "$(size(x,1))-element $(sgn) variable$(cst)")
     else
         print(io, "$(size(x,1))×$(size(x,2)) $(sgn) variable$(cst)")
-
     end
 end
 
@@ -135,6 +134,7 @@ end
 struct ConstraintRoot
     constraint::Constraint
 end
+
 TreePrint.print_tree(io::IO, c::Constraint, maxdepth = 5) = TreePrint.print_tree(io, ConstraintRoot(c), maxdepth)
 AbstractTrees.children(c::ConstraintRoot) = AbstractTrees.children(c.constraint)
 AbstractTrees.printnode(io::IO, c::ConstraintRoot) = AbstractTrees.printnode(io, c.constraint)

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -1,4 +1,4 @@
-import AbstractTrees
+using AbstractTrees: AbstractTrees
 
 AbstractTrees.children(p::Problem) = (p.objective, p.constraints)
 

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -17,7 +17,7 @@ AbstractTrees.children(C::SOCConstraint) = C.children
 AbstractTrees.children(C::SOCElemConstraint) = C.children
 AbstractTrees.children(C::ExpConstraint) = C.children
 
-AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io,node)
+AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io, node)
 AbstractTrees.printnode(io::IO, node::Constraint) = summary(io, node)
 
 function AbstractTrees.printnode(io::IO, node::Vector{Constraint})

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -1,0 +1,28 @@
+import AbstractTrees
+
+function AbstractTrees.children(p::Problem)
+    return (p.objective, p.constraints)
+end
+
+function AbstractTrees.children(e::AbstractExpr)
+    return e.children
+end
+
+AbstractTrees.children(v::Variable) = ()
+AbstractTrees.children(c::Constant) = ()
+
+AbstractTrees.children(C::Constraint) = (C.lhs, C.rhs)
+
+AbstractTrees.printnode(io::IO, node::AbstractExpr) = print(io,node.head)
+AbstractTrees.printnode(io::IO, node::Constraint) = print(io,node.head)
+
+AbstractTrees.printnode(io::IO, node::Vector{Constraint}) = print(io, "constraints")
+
+
+AbstractTrees.printnode(io::IO, node::Problem) = print(io,node.head)
+
+AbstractTrees.printnode(io::IO, node::Constant) = show(IOContext(io, :compact => true), node.value)
+
+AbstractTrees.printnode(io::IO, node::Variable) = summary(io, node)
+
+

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -1,12 +1,8 @@
 import AbstractTrees
 
-function AbstractTrees.children(p::Problem)
-    return (p.objective, p.constraints)
-end
+AbstractTrees.children(p::Problem) = (p.objective, p.constraints)
 
-function AbstractTrees.children(e::AbstractExpr)
-    return e.children
-end
+AbstractTrees.children(e::AbstractExpr) = e.children
 
 AbstractTrees.children(v::Variable) = ()
 AbstractTrees.children(c::Constant) = ()
@@ -28,7 +24,7 @@ function AbstractTrees.printnode(io::IO, node::Vector{Constraint})
     end
 end
 
-AbstractTrees.printnode(io::IO, node::Problem) = print(io,node.head)
+AbstractTrees.printnode(io::IO, node::Problem) = print(io, node.head)
 
 function AbstractTrees.printnode(io::IO, node::Constant)
     if length(node.value) <= 3

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -12,17 +12,30 @@ AbstractTrees.children(v::Variable) = ()
 AbstractTrees.children(c::Constant) = ()
 
 AbstractTrees.children(C::Constraint) = (C.lhs, C.rhs)
+AbstractTrees.children(C::SDPConstraint) = (C.child,)
+AbstractTrees.children(C::SOCConstraint) = C.children
+AbstractTrees.children(C::SOCElemConstraint) = C.children
+AbstractTrees.children(C::ExpConstraint) = C.children
 
-AbstractTrees.printnode(io::IO, node::AbstractExpr) = print(io,node.head)
-AbstractTrees.printnode(io::IO, node::Constraint) = print(io,node.head)
+AbstractTrees.printnode(io::IO, node::AbstractExpr) = summary(io,node)
+AbstractTrees.printnode(io::IO, node::Constraint) = summary(io, node)
 
-AbstractTrees.printnode(io::IO, node::Vector{Constraint}) = print(io, "constraints")
-
+function AbstractTrees.printnode(io::IO, node::Vector{Constraint})
+    if length(node) == 0
+        print(io, "no constraints")
+    else
+        print(io, "constraints")
+    end
+end
 
 AbstractTrees.printnode(io::IO, node::Problem) = print(io,node.head)
 
-AbstractTrees.printnode(io::IO, node::Constant) = show(IOContext(io, :compact => true), node.value)
+function AbstractTrees.printnode(io::IO, node::Constant)
+    if length(node.value) <= 3
+        show(IOContext(io, :compact => true), node.value)
+    else
+        summary(io, node.value)
+    end
+end
 
 AbstractTrees.printnode(io::IO, node::Variable) = summary(io, node)
-
-

--- a/src/utilities/tree_print.jl
+++ b/src/utilities/tree_print.jl
@@ -1,0 +1,108 @@
+# This module is needed until AbstractTrees.jl#37 is fixed.
+# (PR: https://github.com/Keno/AbstractTrees.jl/pull/38)
+# because currently `print_tree` does not respect `maxdepth`.
+# This just implements the changes in the above PR.
+# Code in this file is modified from AbstractTrees.jl
+# See LICENSE for a copy of its MIT license.
+module TreePrint
+
+using AbstractTrees: printnode, treekind, IndexedTree, children
+
+
+# Printing
+struct TreeCharSet
+    mid
+    terminator
+    skip
+    dash
+    ellipsis
+end
+
+# Default charset
+TreeCharSet() = TreeCharSet('├','└','│','─','…')
+
+function print_prefix(io, depth, charset, active_levels)
+    for current_depth in 0:(depth-1)
+        if current_depth in active_levels
+            print(io,charset.skip," "^(textwidth(charset.dash)+1))
+        else
+            print(io," "^(textwidth(charset.skip)+textwidth(charset.dash)+1))
+        end
+    end
+end
+
+@doc raw"""
+# Usage
+Prints an ASCII formatted representation of the `tree` to the given `io` object.
+By default all children will be printed up to a maximum level of 5, though this
+valud can be overriden by the `maxdepth` parameter. The charset to use in
+printing can be customized using the `charset` keyword argument.
+
+# Examples
+```julia
+julia> print_tree(STDOUT,Dict("a"=>"b","b"=>['c','d']))
+Dict{String,Any}("b"=>['c','d'],"a"=>"b")
+├─ b
+│  ├─ c
+│  └─ d
+└─ a
+   └─ b
+
+julia> print_tree(STDOUT,Dict("a"=>"b","b"=>['c','d']);
+        charset = TreeCharSet('+','\\','|',"--"))
+Dict{String,Any}("b"=>['c','d'],"a"=>"b")
++-- b
+|   +-- c
+|   \-- d
+\-- a
+   \-- b
+```
+
+"""
+print_tree
+
+function _print_tree(printnode::Function, io::IO, tree, maxdepth = 5; depth = 0, active_levels = Int[],
+    charset = TreeCharSet(), withinds = false, inds = [], from = nothing, to = nothing, roottree = tree)
+    nodebuf = IOBuffer()
+    isa(io, IOContext) && (nodebuf = IOContext(nodebuf, io))
+    if withinds
+        printnode(nodebuf, tree, inds)
+    else
+        tree != roottree && isa(treekind(roottree), IndexedTree) ?
+            printnode(nodebuf, roottree[tree]) :
+            printnode(nodebuf, tree)
+    end
+    str = String(take!(isa(nodebuf, IOContext) ? nodebuf.io : nodebuf))
+    for (i,line) in enumerate(split(str, '\n'))
+        i != 1 && print_prefix(io, depth, charset, active_levels)
+        println(io, line)
+    end
+    depth > maxdepth && return
+    c = isa(treekind(roottree), IndexedTree) ?
+        childindices(roottree, tree) : children(roottree, tree)
+    if c !== ()
+        s = Iterators.Stateful(from === nothing ? pairs(c) : Iterators.Rest(pairs(c), from))
+        while !isempty(s)
+            ind, child = popfirst!(s)
+            ind === to && break
+            active = false
+            child_active_levels = active_levels
+            print_prefix(io, depth, charset, active_levels)
+            if isempty(s)
+                print(io, charset.terminator)
+            else
+                print(io, charset.mid)
+                child_active_levels = push!(copy(active_levels), depth)
+            end
+            print(io, charset.dash, ' ')
+            print_tree(depth == maxdepth ? (io, val) -> print(io, charset.ellipsis) : printnode,
+                io, child, maxdepth; depth = depth + 1,
+                active_levels = child_active_levels, charset = charset, withinds=withinds,
+                inds = withinds ? [inds; ind] : [], roottree = roottree)
+        end
+    end
+end
+print_tree(f::Function, io::IO, tree, args...; kwargs...) = _print_tree(f, io, tree, args...; kwargs...)
+print_tree(io::IO, tree, args...; kwargs...) = print_tree(printnode, io, tree, args...; kwargs...)
+print_tree(tree, args...; kwargs...) = print_tree(stdout::IO, tree, args...; kwargs...)
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,5 +1,54 @@
 @testset "Utilities" begin
 
+    @testset "Show" begin
+        x = Variable()
+        @test sprint(show, x) == raw"""
+        Variable
+        size: (1, 1)
+        sign: real
+        vexity: affine
+        """ * "$(Convex.show_id(x))"
+        fix!(x, 1.0)
+        @test sprint(show, x) == raw"""
+        Variable
+        size: (1, 1)
+        sign: real
+        vexity: constant
+        """ * "$(Convex.show_id(x))" *
+        "\nvalue: 1.0"
+
+        @test sprint(show, 2*x) == raw"""
+        * (constant; real)
+        ├─ 2
+        └─ real variable (fixed) (""" * "$(Convex.show_id(x)))"
+        
+        free!(x)
+        p = maximize( log(x), x >= 1, x <= 3 )
+
+        @test sprint(show, p) == raw"""
+        maximize
+        └─ log (concave; real)
+           └─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+        subject to
+        ├─ >= constraint (affine)
+        │  ├─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+        │  └─ 1
+        └─ <= constraint (affine)
+           ├─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+           └─ 3
+        
+        current status: not yet solved"""
+        
+        x = ComplexVariable(2,3)
+        @test sprint(show, x) == raw"""
+        Variable
+        size: (2, 3)
+        sign: complex
+        vexity: affine
+        """ * "$(Convex.show_id(x))"
+
+    end
+
     @testset "clearmemory" begin
         # solve a problem to populate globals
         x = Variable()

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -2,51 +2,56 @@
 
     @testset "Show" begin
         x = Variable()
-        @test sprint(show, x) == raw"""
+        @test sprint(show, x) == """
         Variable
         size: (1, 1)
         sign: real
         vexity: affine
-        """ * "$(Convex.show_id(x))"
+        $(Convex.show_id(x))"""
         fix!(x, 1.0)
-        @test sprint(show, x) == raw"""
+        @test sprint(show, x) == """
         Variable
         size: (1, 1)
         sign: real
         vexity: constant
-        """ * "$(Convex.show_id(x))" *
-        "\nvalue: 1.0"
+        $(Convex.show_id(x))
+        value: 1.0"""
 
-        @test sprint(show, 2*x) == raw"""
+        @test sprint(show, 2*x) == """
         * (constant; real)
         ├─ 2
-        └─ real variable (fixed) (""" * "$(Convex.show_id(x)))"
+        └─ real variable (fixed) ($(Convex.show_id(x)))"""
         
         free!(x)
         p = maximize( log(x), x >= 1, x <= 3 )
 
-        @test sprint(show, p) == raw"""
+        @test sprint(show, p) == """
         maximize
         └─ log (concave; real)
-           └─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+           └─ real variable ($(Convex.show_id(x)))
         subject to
         ├─ >= constraint (affine)
-        │  ├─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+        │  ├─ real variable ($(Convex.show_id(x)))
         │  └─ 1
         └─ <= constraint (affine)
-           ├─ real variable (""" *  "$(Convex.show_id(x))" * raw""")
+           ├─ real variable ($(Convex.show_id(x)))
            └─ 3
         
         current status: not yet solved"""
         
         x = ComplexVariable(2,3)
-        @test sprint(show, x) == raw"""
+        @test sprint(show, x) == """
         Variable
         size: (2, 3)
         sign: complex
         vexity: affine
-        """ * "$(Convex.show_id(x))"
+        $(Convex.show_id(x))"""
 
+        # test `maxdepth`
+        x = Variable(2)
+        y = Variable(2)
+        p = minimize(sum(x), hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))) == hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))))
+        @test sprint(show, p) == "minimize\n└─ sum (affine; real)\n   └─ 2-element real variable ($(Convex.show_id(x)))\nsubject to\n└─ == constraint (affine)\n   ├─ hcat (affine; real)\n   │  ├─ hcat (affine; real)\n   │  │  ├─ …\n   │  │  └─ …\n   │  └─ hcat (affine; real)\n   │     ├─ …\n   │     └─ …\n   └─ hcat (affine; real)\n      ├─ hcat (affine; real)\n      │  ├─ …\n      │  └─ …\n      └─ hcat (affine; real)\n         ├─ …\n         └─ …\n\ncurrent status: not yet solved" 
     end
 
     @testset "clearmemory" begin


### PR DESCRIPTION
I find myself usually ignoring the printing of problems, because it's quite verbose while not being very informative. Here, I propose new printing that I think helps with both problems.

Old printing:
```julia
julia> x = Variable(4, 1)
Variable of
size: (4, 1)
sign: NoSign()
vexity: AffineVexity()

julia> p = minimize(dotsort(x, [1, 2, 3, 4]), sum(x) >= 7, x >= 0, x <= 2, x[4] <= 1)
Problem:
minimize AbstractExpr with
head: dotsort
size: (1, 1)
sign: NoSign()
vexity: ConvexVexity()

subject to
Constraint:
>= constraint
lhs: AbstractExpr with
head: sum
size: (1, 1)
sign: NoSign()
vexity: AffineVexity()

rhs: 7
vexity: AffineVexity()
                Constraint:
>= constraint
lhs: Variable of
size: (4, 1)
sign: NoSign()
vexity: AffineVexity()
rhs: 0
vexity: AffineVexity()
                Constraint:
<= constraint
lhs: Variable of
size: (4, 1)
sign: NoSign()
vexity: AffineVexity()
rhs: 2
vexity: AffineVexity()
                Constraint:
<= constraint
lhs: AbstractExpr with
head: index
size: (1, 1)
sign: NoSign()
vexity: AffineVexity()

rhs: 1
vexity: AffineVexity()
current status: not yet solved

```

After:
```julia
julia> x = Variable(4, 1)
Variable
size: (4, 1)
sign: real
vexity: affine
id: 1033...

julia> p = minimize(dotsort(x, [1, 2, 3, 4]), sum(x) >= 7, x >= 0, x <= 2, x[4] <= 1)
minimize
└─ dotsort (convex; real)
   └─ 4-element real variable (id: 1033...)
subject to
├─ >= constraint (affine)
│  ├─ sum (affine; real)
│  │  └─ 4-element real variable (id: 1033...)
│  └─ 7
├─ >= constraint (affine)
│  ├─ 4-element real variable (id: 1033...)
│  └─ 0
├─ <= constraint (affine)
│  ├─ 4-element real variable (id: 1033...)
│  └─ 2
└─ <= constraint (affine)
   ├─ index (affine; real)
   │  └─ 4-element real variable (id: 1033...)
   └─ 1

current status: not yet solved

```

It's both shorter and much more informative: the old printing does not recurse down the tree. So for example, for the last constraint in the above problem, with the old way of printing you see
```julia
<= constraint
lhs: AbstractExpr with
head: index
size: (1, 1)
sign: NoSign()
vexity: AffineVexity()

rhs: 1
vexity: AffineVexity()
```
which doesn't tell you what is being indexed. Now you see
```julia
└─ <= constraint (affine)
   ├─ index (affine; real)
   │  └─ 4-element real variable (id: 1033...)
   └─ 1
```
which tells you what variable is being indexed. This is only compounded for large problems. Note, we only recurse three levels down by default, so recursion shouldn't cause problems if a huge problem gets printed. This can be controlled by `Convex.MAXDEPTH[] = 5` e.g., for users who wish to customize this.

I think the new printing will often be shorter than the current printing even accounting for recursion: adding a constraint in the current method of printing means 10 more lines get printed when the problem is printed. With the recursion depth set to three, it is possible to add a constraint yielding more lines, but the worst case is 15 lines (nested binary operators all the way down on both sides):
```julia
julia> x = Variable(2);

julia> y = Variable(2);

julia> p = minimize(sum(x), hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))) == hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))))
minimize
└─ sum (affine; real)
   └─ 2-element real variable (id: 1024...)
subject to
└─ == constraint (affine)
   ├─ hcat (affine; real)
   │  ├─ hcat (affine; real)
   │  │  ├─ …
   │  │  └─ …
   │  └─ hcat (affine; real)
   │     ├─ …
   │     └─ …
   └─ hcat (affine; real)
      ├─ hcat (affine; real)
      │  ├─ …
      │  └─ …
      └─ hcat (affine; real)
         ├─ …
         └─ …

current status: not yet solved

```
and most times it will be less (unary operators, or reaching a leaf such as a variable or constant).


Why am I trying to justify the improvements so much? Because it doesn't come for free: I'm using Keno's [AbstractTrees.jl](https://github.com/Keno/AbstractTrees.jl) to do the hard work of printing these nice trees, so we would need to take on a dependency on that package. It's 700 lines of Julia with no dependencies, so it's quite a light dependency. It also means Convex problems can be treated as trees in other packages that respect the AbstractTrees API. For example, using GraphRecipes master and this branch, one can do
```julia
using Convex, GraphRecipes, Plots
plot(TreePlot(p); nodeshape=:rect, method=:tree)
```
where `p::Problem` is a Convex.jl problem. It doesn't look perfect though:

![tree](https://user-images.githubusercontent.com/5846501/64125431-dba58f80-cda1-11e9-96a4-70bd8e0dd4bd.png)

(overlapping nodes etc).
Still, it's kind of cool that it's easily integrated, and maybe stuff like that can be improved on the GraphRecipes side. Another example of what you can do is one I added to the docs: use `AbstractTrees` to iterate over the problem in various orders, or iterate over the "leaves" of the problem, and so forth. For example
```julia
using Convex, AbstractTrees
x = Variable()
p = maximize( log(x), x >= 1, x <= 3 )
for leaf in AbstractTrees.Leaves(p)
    println("Here's a leaf: $(summary(leaf))")
end
```
yields
```julia
Here's a leaf: real variable (id: 3942...)
Here's a leaf: real variable (id: 3942...)
Here's a leaf: constant (constant; positive)
Here's a leaf: real variable (id: 3942...)
Here's a leaf: constant (constant; positive)
```

One can also iterate over the problem in various orders, as shown in the docs in this PR. I imagine these iterators could be useful for figuring out what's going on in a problem. For example, one could count how many of a certain kind of atom is in the problem, etc, particularly if parts of the problem are being programatically generated, which might be the case for DSLs sitting on top of Convex. Note, however, we don't recurse into the internal structure of an atom, and some atoms create internal variables and constraints etc in the conic form; this doesn't help for seeing into that.

This is optional item 1 of the list in #320. I initially wasn't sold on adding a dependency to Convex, nor complicating the printing of its objects, but after using this, it's hard to go back.

Note: AbstractTrees.jl does not actually respect the `maxdepth` argument for `print_tree` (it looks like it's just not implemented). I made a PR to fix that (https://github.com/Keno/AbstractTrees.jl/pull/38), but it might be some time before that gets merged, judging by the repo's activity. So I vendored `tree_print` with the changes from that PR to a submodule in `utilities/tree_print.jl`. When the PR to AbstractTrees (or equivalent) eventually goes through, we can just replace all `TreePrint.print_tree` by `AbstractTrees.print_tree`, and delete the file `utilities/tree_print.jl`.

Fun note: somehow I've been very into improving printing the past few days-- a kind of sibling PR to this is pretty printing for MOI optimizers: https://github.com/JuliaOpt/MathOptInterface.jl/pull/864.