### PR TITLE
Add `MAXWIDTH` for printing

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -112,11 +112,17 @@ tree-traversal functions of that package can be used with Convex.jl problems
 and structures. This is what allows powers the printing of problems, expressions,
 and constraints. The depth to which the tree corresponding to a problem,
 expression, or constraint is printed is controlled by the global variable
-`MAXDEPTH`, which defaults to 3. This can be changed by e.g. setting
+[`Convex.MAXDEPTH`](@ref), which defaults to 3. This can be changed by e.g. setting
 
 ```julia
 Convex.MAXDEPTH[] = 5
 ```
+
+Likewise, [`Convex.MAXWIDTH`](@ref), which defaults to 15, controls the "width"
+of the printed tree. For example, when printing a problem with 20 constraints,
+only the first `MAXWIDTH` of the constraints will be printed. Vertical dots,
+"⋮", will be printed indicating that some constraints were omitted in the
+printing.
 
 The AbstractTrees methods can also be used to analyze the structure
 of a Convex.jl problem. For example,
@@ -164,4 +170,12 @@ will be visited before their children.
 for (i, node) in enumerate(AbstractTrees.StatelessBFS(p))
     println("Here's node $i via StatelessBFS: $(summary(node))")
 end
+```
+
+Reference
+---------
+
+```@docs
+Convex.MAXDEPTH
+Convex.MAXWIDTH
 ```

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -11,6 +11,14 @@ Controls depth of tree printing globally for Convex.jl
 const MAXDEPTH = Ref(3)
 
 """
+    const MAXWIDTH = Ref(15)
+
+Controls width of tree printing globally for Convex.jl
+"""
+const MAXWIDTH= Ref(15)
+
+
+"""
     show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 3)
 
 Print a truncated version of the objects `id_hash` field.
@@ -115,7 +123,7 @@ without the final newline. Used for `show` methods which
 invoke `print_tree`.
 """
 function print_tree_rstrip(io::IO, x)
-    str = sprint(TreePrint.print_tree, x, MAXDEPTH[])
+    str = sprint(TreePrint.print_tree, x, MAXDEPTH[], MAXWIDTH[])
     print(io, rstrip(str))
 end
 
@@ -134,7 +142,7 @@ struct ConstraintRoot
     constraint::Constraint
 end
 
-TreePrint.print_tree(io::IO, c::Constraint, maxdepth = 5) = TreePrint.print_tree(io, ConstraintRoot(c), maxdepth)
+TreePrint.print_tree(io::IO, c::Constraint, args...; kwargs...) = TreePrint.print_tree(io, ConstraintRoot(c), args...; kwargs...)
 AbstractTrees.children(c::ConstraintRoot) = AbstractTrees.children(c.constraint)
 AbstractTrees.printnode(io::IO, c::ConstraintRoot) = AbstractTrees.printnode(io, c.constraint)
 
@@ -143,7 +151,7 @@ show(io::IO, c::Constraint) = print_tree_rstrip(io, c)
 struct ExprRoot
     expr::AbstractExpr
 end
-TreePrint.print_tree(io::IO, e::AbstractExpr, maxdepth = 5) = TreePrint.print_tree(io, ExprRoot(e), maxdepth)
+TreePrint.print_tree(io::IO, e::AbstractExpr, args...; kwargs...) = TreePrint.print_tree(io, ExprRoot(e), args...; kwargs...)
 AbstractTrees.children(e::ExprRoot) = AbstractTrees.children(e.expr)
 AbstractTrees.printnode(io::IO, e::ExprRoot) = AbstractTrees.printnode(io, e.expr)
 
@@ -167,15 +175,15 @@ AbstractTrees.children(p::ProblemConstraintsRoot) = p.constraints
 AbstractTrees.printnode(io::IO, p::ProblemConstraintsRoot) = print(io, "subject to")
 
 
-function TreePrint.print_tree(io::IO, p::Problem, maxdepth = 5)
-    TreePrint.print_tree(io, ProblemObjectiveRoot(p.head, p.objective), maxdepth)
+function TreePrint.print_tree(io::IO, p::Problem, args...; kwargs...)
+    TreePrint.print_tree(io, ProblemObjectiveRoot(p.head, p.objective), args...; kwargs...)
     if !(isempty(p.constraints))
-        TreePrint.print_tree(io, ProblemConstraintsRoot(p.constraints), maxdepth)
+        TreePrint.print_tree(io, ProblemConstraintsRoot(p.constraints), args...; kwargs...)
     end
 end
 
 function show(io::IO, p::Problem)
-    TreePrint.print_tree(io, p, MAXDEPTH[])
+    TreePrint.print_tree(io, p, MAXDEPTH[], MAXWIDTH[])
     print(io, "\ncurrent status: $(p.status)")
     if p.status == "solved"
         print(io, " with optimal value of $(round(p.optval, digits=4))")

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -47,11 +47,16 @@
         vexity: affine
         $(Convex.show_id(x))"""
 
-        # test `maxdepth`
+        # test `MAXDEPTH`
         x = Variable(2)
         y = Variable(2)
         p = minimize(sum(x), hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))) == hcat(hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y))),hcat(hcat(hcat(x,y), hcat(x,y)),hcat(hcat(x,y), hcat(x,y)))))
         @test sprint(show, p) == "minimize\n└─ sum (affine; real)\n   └─ 2-element real variable ($(Convex.show_id(x)))\nsubject to\n└─ == constraint (affine)\n   ├─ hcat (affine; real)\n   │  ├─ hcat (affine; real)\n   │  │  ├─ …\n   │  │  └─ …\n   │  └─ hcat (affine; real)\n   │     ├─ …\n   │     └─ …\n   └─ hcat (affine; real)\n      ├─ hcat (affine; real)\n      │  ├─ …\n      │  └─ …\n      └─ hcat (affine; real)\n         ├─ …\n         └─ …\n\ncurrent status: not yet solved" 
+
+        # test `MAXWIDTH`
+        x = Variable()
+        p = satisfy([ x == i for i = 1:100])
+        @test sprint(show, p) == "minimize\n└─ 0\nsubject to\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 1\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 2\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 3\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 4\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 5\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 6\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 7\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 8\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 9\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 10\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 11\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 12\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 13\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 14\n├─ == constraint (affine)\n│  ├─ real variable ($(Convex.show_id(x)))\n│  └─ 15\n⋮\n\ncurrent status: not yet solved"
     end
 
     @testset "clearmemory" begin


### PR DESCRIPTION
Closes #342. This now means our vendored `print_tree` method is ahead of https://github.com/Keno/AbstractTrees.jl/pull/38 by a commit (adding `maxwidth`).

I'm thinking it's probably OK to have this method vendored long-term, since it's nice to be able to control our own printing. I don't think it poses any compatibility problems, since `print_tree` isn't really relied on within the AbstractTrees codebase; it's just a utility. So I don't think there's a problem if `Convex.TreePrint.print_tree` is a different function than `AbstractTrees.print_tree`. We still have interop since we extend `AbstractTrees.children` which is the real interface method.