### PR TITLE
Rearrange exports; deprecate `lambdamin`, `lambdamax`

### DIFF
--- a/docs/examples_literate/general_examples/basic_usage.jl
+++ b/docs/examples_literate/general_examples/basic_usage.jl
@@ -81,7 +81,7 @@ x.value
 
 
 y = Semidefinite(2)
-p = maximize(lambdamin(y), tr(y)<=6)
+p = maximize(eigmin(y), tr(y)<=6)
 solve!(p, SCS.Optimizer(verbose=0))
 p.optval
 

--- a/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
+++ b/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
@@ -8,9 +8,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-
-import Convex.sign, Convex.monotonicity, Convex.curvature, Convex.evaluate, Convex.conic_form!
-export antidiag, sign, monotonicity, curvature, evaluate, conic_form!
+export antidiag
 
 ### Diagonal
 ### Represents the kth diagonal of an mxn matrix as a (min(m, n) - k) x 1 vector

--- a/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
+++ b/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
@@ -8,6 +8,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
+import Convex.sign, Convex.monotonicity, Convex.curvature, Convex.evaluate, Convex.conic_form!
 export antidiag
 
 ### Diagonal

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -110,8 +110,8 @@ solver (including SCS and Mosek).
 | ------------------ | --------------------------------- | ------- | ------------- | ------------------------------ |
 | `nuclearnorm(x)`   | sum of singular values of $x$ | convex  | not monotonic | none                           |
 | `operatornorm(x)`  | max of singular values of $x$ | convex  | not monotonic | none                           |
-| `lambdamax(x)`     | max eigenvalue of $x$         | convex  | not monotonic | none                           |
-| `lambdamin(x)`     | min eigenvalue of $x$         | concave | not monotonic | none                           |
+| `eigmax(x)`     | max eigenvalue of $x$         | convex  | not monotonic | none                           |
+| `eigmin(x)`     | min eigenvalue of $x$         | concave | not monotonic | none                           |
 | `matrixfrac(x, P)` | $x^TP^{-1}x$                  | convex  | not monotonic | IC: P is positive semidefinite |
 
 Exponential + SDP representable Functions

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -31,7 +31,6 @@ export curvature, evaluate, fix!, free!, monotonicity, sign, vexity
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
-global DEFAULT_SOLVER = nothing
 ### modeling framework
 include("dcp.jl")
 include("expressions.jl")

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -25,8 +25,11 @@ export isposdef, ⪰, ⪯ # PSD constraints
 export socp
 
 # Variables
-export Constant, ComplexVariable, HermitianSemidefinite, Positive, Semidefinite, Variable
+export Constant, ComplexVariable, HermitianSemidefinite, Semidefinite, Variable
 export curvature, evaluate, fix!, free!, monotonicity, sign, vexity
+
+# Signs
+export Positive, Negative, ComplexSign, NoSign
 
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -12,13 +12,13 @@ const MOIU = MOI.Utilities
 const MOIB = MOI.Bridges
 
 # Functions
-export conv, dotsort, entropy, exp, geomean, hinge_loss, huber, inner_product, invpos, lambdamax, lambdamin
+export conv, dotsort, entropy, exp, geomean, hinge_loss, huber, inner_product, invpos
 export log_perspective, logisticloss, logsumexp, matrixfrac, neg, norm2, norm_1, norm_inf, nuclearnorm
 export partialtrace, partialtranspose, pos, qol_elementwise, quadform, quadoverlin, rationalnorm
 export relative_entropy, scaledgeomean, sigmamax, square, sumlargest, sumlargesteigs, sumsmallest, sumsquares
 
 # rexports from LinearAlgebra
-export diag, diagm, Diagonal, dot, kron, logdet, norm, tr
+export diag, diagm, Diagonal, dot, eigmax, eigmin, kron, logdet, norm, tr
 
 # Constraints
 export isposdef, ⪰, ⪯ # PSD constraints
@@ -91,7 +91,7 @@ include("atoms/second_order_cone/huber.jl")
 ### SDP atoms
 include("atoms/sdp_cone/nuclearnorm.jl")
 include("atoms/sdp_cone/operatornorm.jl")
-include("atoms/sdp_cone/lambda_min_max.jl")
+include("atoms/sdp_cone/eig_min_max.jl")
 include("atoms/sdp_cone/matrixfrac.jl")
 include("atoms/sdp_cone/sumlargesteigs.jl")
 
@@ -117,5 +117,8 @@ include("problem_depot/problem_depot.jl")
 function clearmemory()
     Base.depwarn("Convex.clearmemory() is deprecated, as the memory leak it works around has been closed (in https://github.com/JuliaOpt/Convex.jl/pull/322). This function no longer does anything and will be removed in a future Convex.jl release.", :clearmemory )
 end
+
+@deprecate lambdamin eigmin
+@deprecate lambdamax eigmax
 
 end

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -4,11 +4,32 @@ module Convex
 using OrderedCollections: OrderedDict
 using LinearAlgebra
 using SparseArrays
+using AbstractTrees: AbstractTrees
 
 using MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 const MOIB = MOI.Bridges
+
+# Functions
+export conv, dotsort, entropy, exp, geomean, hinge_loss, huber, inner_product, invpos, lambdamax, lambdamin
+export log_perspective, logisticloss, logsumexp, matrixfrac, neg, norm2, norm_1, norm_inf, nuclearnorm
+export partialtrace, partialtranspose, pos, qol_elementwise, quadform, quadoverlin, rationalnorm
+export relative_entropy, scaledgeomean, sigmamax, square, sumlargest, sumlargesteigs, sumsmallest, sumsquares
+
+# rexports from LinearAlgebra
+export diag, diagm, Diagonal, dot, kron, logdet, norm, tr
+
+# Constraints
+export isposdef, ⪰, ⪯ # PSD constraints
+export socp
+
+# Variables
+export Constant, ComplexVariable, HermitianSemidefinite, Positive, Semidefinite, Variable
+export curvature, evaluate, fix!, free!, monotonicity, sign, vexity
+
+# Problems
+export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
 global DEFAULT_SOLVER = nothing
 ### modeling framework

--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -6,9 +6,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export +, -
-export sign, curvature, monotonicity, evaluate
-
 ### Unary Negation
 
 struct NegateAtom <: AbstractExpr

--- a/src/atoms/affine/conjugate.jl
+++ b/src/atoms/affine/conjugate.jl
@@ -1,6 +1,4 @@
 import Base.conj
-export conj
-export sign, curvature, monotonicity, evaluate, conic_form!
 struct ConjugateAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/src/atoms/affine/conv.jl
+++ b/src/atoms/affine/conv.jl
@@ -3,8 +3,6 @@
 # Handles convolution between a constant vector and an expression vector.
 #############################################################################
 
-export conv
-
 function conv(x::Value, y::AbstractExpr)
     if (size(x,2) != 1 && length(size(x)) != 1) || size(y,2) != 1
         error("convolution only supported between two vectors")

--- a/src/atoms/affine/diag.jl
+++ b/src/atoms/affine/diag.jl
@@ -7,8 +7,6 @@
 
 # k >= min(num_cols, num_rows) || k <= -min(num_rows, num_cols)
 import LinearAlgebra.diag
-export diag
-#export sign, curvature, monotonicity, evaluate
 
 ### Diagonal
 ### Represents the kth diagonal of an mxn matrix as a (min(m, n) - k) x 1 vector

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -6,7 +6,6 @@
 #############################################################################
 
 import LinearAlgebra.diagm, LinearAlgebra.Diagonal
-export diagm, Diagonal
 
 struct DiagMatrixAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/affine/dot.jl
+++ b/src/atoms/affine/dot.jl
@@ -1,5 +1,4 @@
 import LinearAlgebra.dot
-export dot
 
 ismatrix(x::AbstractExpr) = (s = size(x); length(s) == 2 && s[1] > 1 && s[2] > 1)
 ismatrix(::AbstractMatrix) = true

--- a/src/atoms/affine/index.jl
+++ b/src/atoms/affine/index.jl
@@ -1,5 +1,4 @@
-import Base: getindex, to_index
-export IndexAtom, getindex
+import Base.getindex
 
 const ArrayOrNothing = Union{AbstractArray, Nothing}
 

--- a/src/atoms/affine/inner_product.jl
+++ b/src/atoms/affine/inner_product.jl
@@ -1,5 +1,3 @@
-export inner_product
-
 function inner_product(x::AbstractExpr, y::AbstractExpr)
     if x.size == y.size && x.size[1] == x.size[2]
         return real(tr(x'*y))

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -1,5 +1,4 @@
 import LinearAlgebra.kron
-export kron
 
 function kron(a::Value, b::AbstractExpr)
     rows = AbstractExpr[]

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -7,7 +7,6 @@
 #############################################################################
 
 import Base.Broadcast.broadcasted
-export sign, monotonicity, curvature, evaluate, conic_form!
 
 ### Scalar and matrix multiplication
 

--- a/src/atoms/affine/partialtrace.jl
+++ b/src/atoms/affine/partialtrace.jl
@@ -1,4 +1,3 @@
-export partialtrace
 
 # We compute the partial trace of x by summing over
 # (I ⊗ <j| ⊗ I) x (I ⊗ |j> ⊗ I) for all j's

--- a/src/atoms/affine/partialtranspose.jl
+++ b/src/atoms/affine/partialtranspose.jl
@@ -1,6 +1,4 @@
 import Base.sign
-export partialtranspose, PartialTransposeAtom
-export sign, curvature, monotonicity, evaluate, conic_form!
 
 struct PartialTransposeAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/affine/real_imag.jl
+++ b/src/atoms/affine/real_imag.jl
@@ -5,9 +5,6 @@
 #############################################################################
 
 import Base.real, Base.imag
-export real, imag
-export sign, monotonicity, curvature, evaluate
-
 
 ### Real
 struct RealAtom <: AbstractExpr

--- a/src/atoms/affine/reshape.jl
+++ b/src/atoms/affine/reshape.jl
@@ -1,7 +1,4 @@
 import Base.reshape, Base.vec
-export reshape, vec
-export sign, curvature, monotonicity, evaluate, conic_form!
-
 
 struct ReshapeAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/affine/stack.jl
+++ b/src/atoms/affine/stack.jl
@@ -1,7 +1,4 @@
 import Base.vcat, Base.hcat, Base.hvcat
-export vcat, hcat, hvcat, HcatAtom
-export sign, curvature, monotonicity, evaluate, conic_form!
-
 struct HcatAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/src/atoms/affine/sum.jl
+++ b/src/atoms/affine/sum.jl
@@ -4,9 +4,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-
 import Base.sum
-export sum
 
 ### Sum Atom
 struct SumAtom <: AbstractExpr

--- a/src/atoms/affine/trace.jl
+++ b/src/atoms/affine/trace.jl
@@ -1,5 +1,4 @@
 import LinearAlgebra.tr
-export tr
 
 function tr(e::AbstractExpr)
     return sum(diag(e))

--- a/src/atoms/affine/transpose.jl
+++ b/src/atoms/affine/transpose.jl
@@ -6,8 +6,6 @@
 #############################################################################
 
 import Base.transpose, Base.adjoint
-export transpose, adjoint, TransposeAtom, AdjointAtom
-export sign, curvature, monotonicity, evaluate, conic_form!
 
 struct TransposeAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/exp_+_sdp_cone/logdet.jl
+++ b/src/atoms/exp_+_sdp_cone/logdet.jl
@@ -1,5 +1,4 @@
 import LinearAlgebra.logdet
-export logdet
 
 struct LogDetAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/exp_cone/entropy.jl
+++ b/src/atoms/exp_cone/entropy.jl
@@ -5,9 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export entropy
-export sign, curvature, monotonicity, evaluate
-
 ### Entropy: sum_i -x_i log (x_i)
 
 # TODO: make this work for a *list* of inputs, rather than just for scalar/vector/matrix inputs

--- a/src/atoms/exp_cone/exp.jl
+++ b/src/atoms/exp_cone/exp.jl
@@ -4,10 +4,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-
 import Base.exp
-export exp
-export sign, curvature, monotonicity, evaluate
 
 ### Exponential
 

--- a/src/atoms/exp_cone/log.jl
+++ b/src/atoms/exp_cone/log.jl
@@ -4,10 +4,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-
 import Base.log
-export log
-export sign, curvature, monotonicity, evaluate
 
 ### Logarithm
 

--- a/src/atoms/exp_cone/logsumexp.jl
+++ b/src/atoms/exp_cone/logsumexp.jl
@@ -5,9 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export logsumexp, logisticloss
-export sign, curvature, monotonicity, evaluate
-
 ### LogSumExp
 
 # TODO: make this work for a *list* of inputs, rather than just for vector/matrix inputs

--- a/src/atoms/exp_cone/relative_entropy.jl
+++ b/src/atoms/exp_cone/relative_entropy.jl
@@ -5,9 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export relative_entropy, log_perspective
-export sign, curvature, monotonicity, evaluate
-
 # TODO: make this work for a *list* of inputs, rather than just for scalar/vector/matrix inputs
 
 struct RelativeEntropyAtom <: AbstractExpr

--- a/src/atoms/lp_cone/abs.jl
+++ b/src/atoms/lp_cone/abs.jl
@@ -4,10 +4,7 @@
 # All expressions and atoms are subtpyes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-
 import Base.abs, Base.abs2
-export abs, abs2
-export sign, curvature, monotonicity, evaluate
 
 ### Absolute Value
 

--- a/src/atoms/lp_cone/dotsort.jl
+++ b/src/atoms/lp_cone/dotsort.jl
@@ -5,9 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export dotsort
-export sign, curvature, monotonicity, evaluate
-
 # This atom computes dot(sort(x), sort(w)), where w is constant
 # for example, if w = [1 1 1 0 0 0 ... 0], it computes the sum of the 3 largest elements of x
 struct DotSortAtom <: AbstractExpr

--- a/src/atoms/lp_cone/max.jl
+++ b/src/atoms/lp_cone/max.jl
@@ -5,7 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import Base.max
-export max, pos, hinge_loss
 
 # TODO: This can easily be extended to work
 ### Max Atom

--- a/src/atoms/lp_cone/maximum.jl
+++ b/src/atoms/lp_cone/maximum.jl
@@ -5,7 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import Base.maximum
-export maximum
 
 ### Maximum Atom
 struct MaximumAtom <: AbstractExpr

--- a/src/atoms/lp_cone/min.jl
+++ b/src/atoms/lp_cone/min.jl
@@ -5,7 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import Base.min
-export min, neg
 
 # TODO: This can easily be extended to work
 ### Min Atom

--- a/src/atoms/lp_cone/minimum.jl
+++ b/src/atoms/lp_cone/minimum.jl
@@ -5,7 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import Base.minimum
-export minimum
 
 ### Minimum Atom
 struct MinimumAtom <: AbstractExpr

--- a/src/atoms/lp_cone/sumlargest.jl
+++ b/src/atoms/lp_cone/sumlargest.jl
@@ -5,9 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 
-export sumlargest, sumsmallest
-export sign, curvature, monotonicity, evaluate
-
 struct SumLargestAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/src/atoms/sdp_cone/eig_min_max.jl
+++ b/src/atoms/sdp_cone/eig_min_max.jl
@@ -40,7 +40,7 @@ function curvature(x::EigMaxAtom)
 end
 
 function evaluate(x::EigMaxAtom)
-    eigvals(evaluate(x.children[1]))[end]
+    eigmax(evaluate(x.children[1]))
 end
 
 eigmax(x::AbstractExpr) = EigMaxAtom(x)
@@ -93,7 +93,7 @@ function curvature(x::EigMinAtom)
 end
 
 function evaluate(x::EigMinAtom)
-    eigvals(evaluate(x.children[1]))[1]
+    eigmin(evaluate(x.children[1]))
 end
 
 eigmin(x::AbstractExpr) = EigMinAtom(x)

--- a/src/atoms/sdp_cone/lambda_min_max.jl
+++ b/src/atoms/sdp_cone/lambda_min_max.jl
@@ -5,7 +5,6 @@
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-export lambdamax, lambdamin
 
 ### Lambda max
 

--- a/src/atoms/sdp_cone/matrixfrac.jl
+++ b/src/atoms/sdp_cone/matrixfrac.jl
@@ -5,7 +5,6 @@
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-export matrixfrac
 
 struct MatrixFracAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/sdp_cone/nuclearnorm.jl
+++ b/src/atoms/sdp_cone/nuclearnorm.jl
@@ -4,7 +4,6 @@
 # All expressions and atoms are subtypes of AbstractExpr.
 # Please read expressions.jl first.
 #############################################################################
-export nuclearnorm
 
 ### Nuclear norm
 

--- a/src/atoms/sdp_cone/operatornorm.jl
+++ b/src/atoms/sdp_cone/operatornorm.jl
@@ -6,7 +6,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import LinearAlgebra: opnorm
-export sigmamax
 
 ### Operator norm
 

--- a/src/atoms/sdp_cone/sumlargesteigs.jl
+++ b/src/atoms/sdp_cone/sumlargesteigs.jl
@@ -6,7 +6,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import LinearAlgebra.eigvals
-export sumlargesteigs
 
 ### sumlargesteigs
 

--- a/src/atoms/second_order_cone/geomean.jl
+++ b/src/atoms/second_order_cone/geomean.jl
@@ -1,6 +1,4 @@
 import Base.sqrt
-export GeoMeanAtom, geomean, sqrt
-export sign, monotonicity, curvature, conic_form!
 
 struct GeoMeanAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/second_order_cone/huber.jl
+++ b/src/atoms/second_order_cone/huber.jl
@@ -1,5 +1,3 @@
-export huber
-
 struct HuberAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/src/atoms/second_order_cone/norm.jl
+++ b/src/atoms/second_order_cone/norm.jl
@@ -1,5 +1,4 @@
 import LinearAlgebra.norm
-export norm_inf, norm, norm_1
 
 # deprecate these soon
 norm_inf(x::AbstractExpr) = maximum(abs(x))

--- a/src/atoms/second_order_cone/norm2.jl
+++ b/src/atoms/second_order_cone/norm2.jl
@@ -5,8 +5,6 @@
 # Please read expressions.jl first.
 #############################################################################
 import LinearAlgebra.norm2
-export EucNormAtom, norm2
-export sign, monotonicity, curvature, conic_form!
 
 
 struct EucNormAtom <: AbstractExpr

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -1,6 +1,4 @@
 import Base.Broadcast.broadcasted
-export QolElemAtom, qol_elementwise, square, sumsquares, invpos, /
-export sign, monotonicity, curvature, conic_form!
 
 struct QolElemAtom <: AbstractExpr
     head::Symbol

--- a/src/atoms/second_order_cone/quadform.jl
+++ b/src/atoms/second_order_cone/quadform.jl
@@ -1,4 +1,3 @@
-export quadform
 
 function quadform(x::Value, A::AbstractExpr)
     return x' * A * x

--- a/src/atoms/second_order_cone/quadoverlin.jl
+++ b/src/atoms/second_order_cone/quadoverlin.jl
@@ -1,6 +1,3 @@
-export QuadOverLinAtom, quadoverlin
-export sign, monotonicity, curvature, conic_form!
-
 struct QuadOverLinAtom <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/src/atoms/second_order_cone/rationalnorm.jl
+++ b/src/atoms/second_order_cone/rationalnorm.jl
@@ -11,8 +11,6 @@
 # https://github.com/JuliaOpt/Convex.jl/raw/master/docs/supplementary/rational_to_socp.pdf
 #############################################################################
 
-export rationalnorm
-
 ### k-norm for rational k
 
 struct RationalNormAtom <: AbstractExpr

--- a/src/atoms/second_order_cone/scaledgeomean.jl
+++ b/src/atoms/second_order_cone/scaledgeomean.jl
@@ -1,6 +1,4 @@
 import Base.sqrt
-export ScaledGeoMeanAtom, scaledgeomean, sqrt
-export sign, monotonicity, curvature, conic_form!
 
 function power_of_2_gt(n::Int)
     Int(2^ceil(log(2,n)))

--- a/src/conic_form.jl
+++ b/src/conic_form.jl
@@ -1,7 +1,3 @@
-export ConicObj, ConicConstr, UniqueConicForms
-export promote_size, get_row
-export cache_conic_form!, has_conic_form, get_conic_form
-
 # TODO: Comment every single line
 
 # ConicObj represents an affine function of the variables

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -2,8 +2,6 @@
 # constant.jl
 # Defines Constant, which is a subtype of AbstractExpr
 #############################################################################
-export Constant
-export vexity, evaluate, sign, conic_form!
 
 ispos(x::Real) = x >= 0
 ispos(v::AbstractVecOrMat{<:Real}) = all(ispos, v)

--- a/src/constraints/constraints.jl
+++ b/src/constraints/constraints.jl
@@ -1,6 +1,4 @@
 import Base.==, Base.<=, Base.>=, Base.<, Base.>
-export EqConstraint, LtConstraint, GtConstraint
-export ==, <=, >=
 
 ### Linear equality constraint
 mutable struct EqConstraint <: Constraint

--- a/src/constraints/exp_constraints.jl
+++ b/src/constraints/exp_constraints.jl
@@ -1,5 +1,3 @@
-export ExpConstraint, conic_form!, vexity
-
 ### (Primal) exponential cone constraint ExpConstraint(x,y,z) => y exp(x/y) <= z & y>=0
 struct ExpConstraint <: Constraint
     head::Symbol

--- a/src/constraints/sdp_constraints.jl
+++ b/src/constraints/sdp_constraints.jl
@@ -1,7 +1,5 @@
 import LinearAlgebra.isposdef
 import Base.in
-export SDPConstraint, isposdef, in, ⪰, ⪯
-
 ### Positive semidefinite cone constraint
 
 # TODO: Terrible documentation. Please fix.

--- a/src/constraints/signs_and_sets.jl
+++ b/src/constraints/signs_and_sets.jl
@@ -1,5 +1,3 @@
-export conic_form!
-
 conic_form!(s::Positive, x::Variable, unique_conic_forms) = conic_form!(x>=0, unique_conic_forms)
 conic_form!(s::Negative, x::Variable, unique_conic_forms) = conic_form!(x<=0, unique_conic_forms)
 

--- a/src/constraints/soc_constraints.jl
+++ b/src/constraints/soc_constraints.jl
@@ -1,6 +1,3 @@
-export SOCConstraint, SOCElemConstraint, conic_form!
-export socp
-
 # TODO: Document this. How is this different from SOCElemConstraint? Why do we need both. How does
 # conic form work for SOC constraints.
 struct SOCConstraint <: Constraint

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -11,10 +11,6 @@
 #############################################################################
 
 import Base.-, Base.+, Base.*, Base./
-export Vexity, ConstVexity, AffineVexity, ConvexVexity, ConcaveVexity, NotDcp
-export Monotonicity, Nonincreasing, Nondecreasing, NoMonotonicity
-export Sign, Positive, Negative, NoSign, ComplexSign
-export -, +, *
 
 # Vexity subtypes
 abstract type Vexity end

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -29,11 +29,6 @@
 #############################################################################
 
 import Base.sign, Base.size, Base.length, Base.lastindex, Base.ndims, Base.convert, Base.axes
-export AbstractExpr, Constraint
-export vexity, sign, size, evaluate, monotonicity, curvature, length, convert
-export conic_form!
-export lastindex, ndims
-export Value, ValueOrNothing
 
 ### Abstract types
 abstract type AbstractExpr end
@@ -42,7 +37,6 @@ abstract type Constraint end
 # Override hash function because of
 # https://github.com/JuliaLang/julia/issues/10267
 import Base.hash
-export hash
 
 const hashaa_seed = UInt === UInt64 ? 0x7f53e68ceb575e76 : 0xeb575e7
 function hash(a::Array{AbstractExpr}, h::UInt)

--- a/src/problem_depot/problem_depot.jl
+++ b/src/problem_depot/problem_depot.jl
@@ -8,6 +8,7 @@ const MOI = MathOptInterface
 using Convex
 using LinearAlgebra
 using LinearAlgebra: eigen, I, opnorm
+using Convex: AffineVexity, ConcaveVexity, ConvexVexity
 
 randperm(d) = sortperm(rand(d))
 shuffle(x) = x[randperm(length(x))]

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -114,7 +114,7 @@ end
 
 @add_problem sdp function sdp_dual_lambda_max_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     y = Semidefinite(3)
-    p = minimize(lambdamax(y), y[1,1]>=4; numeric_type = T)
+    p = minimize(eigmax(y), y[1,1]>=4; numeric_type = T)
 
     if test
         @test vexity(p) == ConvexVexity()
@@ -122,12 +122,12 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 4 atol=atol rtol=rtol
-        @test evaluate(lambdamax(y)) ≈ 4 atol=atol rtol=rtol
+        @test evaluate(eigmax(y)) ≈ 4 atol=atol rtol=rtol
     end
 
     # https://github.com/JuliaOpt/Convex.jl/issues/337
     x = ComplexVariable(2, 2)
-    p = minimize( lambdamax(x), [ x[1,2] == im, x[2,2] == 1.0, x ⪰ - eye(2) ]; numeric_type = T)
+    p = minimize( eigmax(x), [ x[1,2] == im, x[2,2] == 1.0, x ⪰ - eye(2) ]; numeric_type = T)
     handle_problem!(p)
     if test
         @test p.optval ≈ 1.5 atol=atol rtol=rtol
@@ -138,7 +138,7 @@ end
 
 @add_problem sdp function sdp_lambda_min_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     y = Semidefinite(3)
-    p = maximize(lambdamin(y), tr(y)<=6; numeric_type = T)
+    p = maximize(eigmin(y), tr(y)<=6; numeric_type = T)
 
     if test
         @test vexity(p) == ConvexVexity()
@@ -146,7 +146,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 2 atol=atol rtol=rtol
-        @test evaluate(lambdamin(y)) ≈ 2 atol=atol rtol=rtol
+        @test evaluate(eigmin(y)) ≈ 2 atol=atol rtol=rtol
     end
 end
 
@@ -168,7 +168,7 @@ end
 @add_problem sdp function sdp_matrix_frac_atom_both_arguments_variable(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
     x = Variable(3)
     P = Variable(3, 3)
-    p = minimize(matrixfrac(x, P), lambdamax(P) <= 2, x[1] >= 1; numeric_type = T)
+    p = minimize(matrixfrac(x, P), eigmax(P) <= 2, x[1] >= 1; numeric_type = T)
 
     if test
         @test vexity(p) == ConvexVexity()
@@ -201,7 +201,7 @@ end
     end
 
     x1 = Semidefinite(3)
-    p1 = minimize(lambdamax(x1), x1[1,1]>=4; numeric_type = T)
+    p1 = minimize(eigmax(x1), x1[1,1]>=4; numeric_type = T)
 
     handle_problem!(p1)
 
@@ -215,7 +215,7 @@ end
     end
 
     x1 = Semidefinite(3)
-    p1 = minimize(lambdamax(x1), [x1[i,:] >= i for i=1:3]...; numeric_type = T)
+    p1 = minimize(eigmax(x1), [x1[i,:] >= i for i=1:3]...; numeric_type = T)
 
     handle_problem!(p1)
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -1,5 +1,3 @@
-export Problem, minimize, maximize, satisfy, add_constraint!, add_constraints!
-
 mutable struct Problem{T<:Real}
     head::Symbol
     objective::AbstractExpr

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -1,5 +1,3 @@
-export solve!
-
 # Convert from sets used within Convex to MOI sets
 function get_MOI_set(cone, length_inds)
     if cone == :SDP

--- a/src/utilities/broadcast.jl
+++ b/src/utilities/broadcast.jl
@@ -2,7 +2,6 @@
 # because overloading broadcast no longer works in Julia v0.6
 
 import LinearAlgebra.dot
-export dot
 
 # multiplication
 dot(::typeof(*)) = applyDotMultiplyAtom

--- a/src/utilities/iteration.jl
+++ b/src/utilities/iteration.jl
@@ -1,5 +1,4 @@
 import Base.iterate
-export iterate
 
 function iterate(x::Variable, s=0)
     return s >= length(x) ? nothing : (x[s+1], s+1)

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -1,6 +1,4 @@
 import Base.show, Base.summary
-export show, summary
-using AbstractTrees: AbstractTrees
 using .TreePrint
 
 """

--- a/src/utilities/tree_interface.jl
+++ b/src/utilities/tree_interface.jl
@@ -1,5 +1,3 @@
-using AbstractTrees: AbstractTrees
-
 AbstractTrees.children(p::Problem) = (p.objective, p.constraints)
 
 AbstractTrees.children(e::AbstractExpr) = e.children

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -3,9 +3,6 @@
 # Defines Variable, which is a subtype of AbstractExpr
 #############################################################################
 
-export Variable, Semidefinite, ComplexVariable, HermitianSemidefinite
-export vexity, evaluate, sign, conic_form!, fix!, free!
-
 mutable struct Variable <: AbstractExpr
     head::Symbol
     id_hash::UInt64

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,7 @@
+@testset "Deprecations" begin
+    A = Semidefinite(2)
+    @test_deprecated lambdamin(A)
+    @test_deprecated lambdamax(A)
+
+    @test_deprecated Convex.clearmemory()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
 
 @testset "Convex" begin
     include("test_utilities.jl")
+    include("deprecations.jl")
 
     @testset "SCS with warmstarts" begin
         # We exclude `sdp_matrix_frac_atom` due to the bug https://github.com/JuliaOpt/SCS.jl/issues/153

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,4 +1,4 @@
-using Convex: AbstractExpr, ComplexSign, ConicObj, Negative, NoSign
+using Convex: AbstractExpr, ConicObj
 
 @testset "Utilities" begin
 

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -125,10 +125,6 @@ using Convex: AbstractExpr, ComplexSign, ConicObj, Negative, NoSign
                 dual status: FEASIBLE_POINT"""
     end
 
-    @testset "clearmemory" begin
-        @test_deprecated Convex.clearmemory()
-    end
-
     @testset "ConicObj with type $T" for T = [UInt32, UInt64]
         c = ConicObj()
         z = zero(T)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,3 +1,5 @@
+using Convex: AbstractExpr, ComplexSign, ConicObj, Negative, NoSign
+
 @testset "Utilities" begin
 
     @testset "`solve!` does not return anything" begin


### PR DESCRIPTION
I'm thinking about the API we should expose in Convex.jl v0.13 (see https://github.com/JuliaOpt/Convex.jl/issues/346), and realized it's hard to know what API we expose now, since the exports are scattered across files.

I've therefore moved them all to the top of `src/Convex.jl`. I also unexported many functions that I feel should be internal:

* All types corresponding to Atoms (these should be constructed via functions, e.g. using `+` instead of `AdditionAtom`)
* All types corresponding to constraints and vexities (these likewise be automatically constructed from the exposed API)
* `Base.to_index`, `promote_size`, `get_row`, `conic_form!`, `Value`, `ValueOrNothing`, which just don't seem to need to be exported
* Functions already exported from Base

I have left the re-exports from LinearAlgebra, though maybe we should revisit that (maybe a user should need to do `using LinearAlgebra` in order to get e.g. `norm` and `eigmin`).

I also deprecated `lambdamin` and `lambdamax` in favor of `LinearAlgebra.eigmin` and `LinearAlgebra.eigmax`, which closes https://github.com/JuliaOpt/Convex.jl/issues/336.