### PR TITLE
Fix #341, add news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,12 @@
+# Changes in v0.13.0
+
+* The intermediate layer has changed from MathProgBase.jl to
+  [MathOptInterface.jl](https://github.com/JuliaOpt/MathOptInterface.jl)
+  ([#330](https://github.com/JuliaOpt/Convex.jl/pull/330)).
+* `lambdamin` and `lambdamax` have been deprecated in favor of `eigmin` and
+  `eigmax`. ([#357](https://github.com/JuliaOpt/Convex.jl/pull/357))
+* `evaluate(x::Variable)` and `evaluate(c::Constant)` now return scalars and
+  vectors as appropriate, instead of `(1,1)`- and `(d,1)`-matrices.
+  ([#359](https://github.com/JuliaOpt/Convex.jl/pull/359)). This affects
+  functions which used to return `(1,1)`-matrices; e.g., now
+  `evaluate(quadform(...))` yields a scalar.

--- a/src/constant.jl
+++ b/src/constant.jl
@@ -38,7 +38,20 @@ end
 
 vexity(::Constant) = ConstVexity()
 
-evaluate(x::Constant) = x.value
+# Lower (1,1)-matrices to scalars and (d,1)-matrices to vectors, for outputting to the user.
+function output(x::Value)
+    if size(x, 2) == 1
+        if size(x, 1) == 1
+            return x[]
+        else
+            return vec(x)
+        end
+    else
+        return x
+    end
+end
+
+evaluate(x::Constant) = output(x.value)
 
 sign(x::Constant) = x.sign
 

--- a/src/problem_depot/problems/sdp.jl
+++ b/src/problem_depot/problems/sdp.jl
@@ -383,7 +383,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 0 atol=atol rtol=rtol
-        @test evaluate(objective) ≈ zeros(1, 1) atol=atol rtol=rtol
+        @test evaluate(objective) ≈ 0.0 atol=atol rtol=rtol
 
         real_diff = real.(x.value) - real.(a)
         imag_diff = imag.(x.value) - imag.(a)
@@ -393,7 +393,7 @@ end
 end
 
 @add_problem sdp function sdp_socp_abs_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
-    a = [5-4im]
+    a = 5-4im
     x = ComplexVariable()
     objective = abs(a-x)
     c1 = real(x)>=0
@@ -402,12 +402,12 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 0 atol=atol rtol=rtol
-        @test evaluate(objective) ≈ zeros(1) atol=atol rtol=rtol
+        @test evaluate(objective) ≈ 0.0 atol=atol rtol=rtol
 
-        real_diff = real(x.value) .- real(a)
-        imag_diff = imag(x.value) .- imag(a)
-        @test real_diff ≈ zeros(1) atol=atol rtol=rtol
-        @test imag_diff ≈ zeros(1) atol=atol rtol=rtol
+        real_diff = real(x.value) - real(a)
+        imag_diff = imag(x.value) - imag(a)
+        @test real_diff ≈ 0.0 atol=atol rtol=rtol
+        @test imag_diff ≈ 0.0 atol=atol rtol=rtol
     end
 end
 

--- a/src/problem_depot/problems/socp.jl
+++ b/src/problem_depot/problems/socp.jl
@@ -81,12 +81,12 @@ end
 end
 
 @add_problem socp function socp_quad_over_lin_atom(handle_problem!, ::Val{test}, atol, rtol, ::Type{T}) where {T, test}
-    x = Variable(3, 1)
+    x = Variable(3)
     A = [2 -3 5; -2 9 -3; 5 -8 3]
     b = [-3; 9; 5]
-    c = [3 2 4]
+    c = [3, 2, 4]
     d = -3
-    p = minimize(quadoverlin(A*x + b, c*x + d); numeric_type = T)
+    p = minimize(quadoverlin(A*x + b, dot(c, x) + d); numeric_type = T)
 
     if test
         @test vexity(p) == ConvexVexity()
@@ -94,7 +94,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 17.7831 atol=atol rtol=rtol
-        @test (evaluate(quadoverlin(A * x + b, c * x + d)))[1] ≈ 17.7831 atol=atol rtol=rtol
+        @test evaluate(quadoverlin(A * x + b, dot(c, x) + d)) ≈ 17.7831 atol=atol rtol=rtol
     end
 end
 
@@ -230,7 +230,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 6.1464 atol=atol rtol=rtol
-        @test (evaluate(quadform(x, A)))[1] ≈ 6.1464 atol=atol rtol=rtol
+        @test evaluate(quadform(x, A)) ≈ 6.1464 atol=atol rtol=rtol
     end
 
     x = Variable(3, 1)
@@ -244,7 +244,7 @@ end
     handle_problem!(p)
     if test
         @test p.optval ≈ 3.7713 atol=atol rtol=rtol
-        @test (evaluate(quadform(x, A)))[1] ≈ -1 atol=atol rtol=rtol
+        @test evaluate(quadform(x, A)) ≈ -1 atol=atol rtol=rtol
     end
 end
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -55,7 +55,7 @@ function vexity(x::Variable)
 end
 
 function evaluate(x::Variable)
-    return x.value === nothing ? error("Value of the variable is yet to be calculated") : x.value
+    return x.value === nothing ? error("Value of the variable is yet to be calculated") : output(x.value)
 end
 
 function sign(x::Variable)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -196,6 +196,18 @@ using Convex: AbstractExpr, ConicObj
         @test Convex.imag_conic_form(Constant([1.0, 2.0])) == [0.0, 0.0]
     end
 
+    @testset "#341: Evaluate for constants" begin
+        A = rand(4,4)
+        @test evaluate(Constant(A)) ≈ copy(A)
+        @test Constant(A).size == (4,4)
+        b = rand(4)
+        @test evaluate(Constant(b)) ≈ copy(b)
+        @test Constant(b).size == (4,1)
+        c = 1.0
+        @test evaluate(Constant(c)) ≈ c
+        @test Constant(c).size == (1,1)
+    end
+
     @testset "Base.vect" begin
     # Issue #223: ensure we can make vectors of variables
     @test size([Variable(2), Variable(3,4)]) == (2,)


### PR DESCRIPTION
The fix is to just have `evaluate(x::Variable)` and `evaluate(c::Constant)` yield scalars and vectors when appropriate. (Not sure why I was getting lots of test failures last time I tried, as I mentioned in #341; I lost that local branch).