### PR TITLE
Pass solver constructors instead of instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-# Changes in v0.13.0
+# Major changes in v0.13.0
 
 * The intermediate layer has changed from MathProgBase.jl to
   [MathOptInterface.jl](https://github.com/JuliaOpt/MathOptInterface.jl)
-  ([#330](https://github.com/JuliaOpt/Convex.jl/pull/330)).
+  ([#330](https://github.com/JuliaOpt/Convex.jl/pull/330)). To solve problems,
+  one should pass a MathOptInterface optimizer constructor, such as
+  `SCS.Optimizer`, or `() -> SCS.Optimizer(verbose=false)`.
 * `lambdamin` and `lambdamax` have been deprecated in favor of `eigmin` and
   `eigmax`. ([#357](https://github.com/JuliaOpt/Convex.jl/pull/357))
 * `evaluate(x::Variable)` and `evaluate(c::Constant)` now return scalars and

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ x = Variable(n)
 problem = minimize(sumsquares(A * x - b), [x >= 0])
 
 # Solve the problem by calling solve!
-solve!(problem, SCS.Optimizer())
+solve!(problem, SCS.Optimizer)
 
 # Check the status of the problem
 problem.status # :Optimal, :Infeasible, :Unbounded etc.

--- a/docs/examples_literate/general_examples/basic_usage.jl
+++ b/docs/examples_literate/general_examples/basic_usage.jl
@@ -8,7 +8,7 @@ end
 
 using SCS
 ## passing in verbose=0 to hide output from SCS
-solver = SCS.Optimizer(verbose=0)
+solver = () -> SCS.Optimizer(verbose=0)
 
 # ### Linear program
 #
@@ -73,7 +73,7 @@ p.optval
 
 x = Variable(4)
 p = satisfy(norm(x) <= 100, exp(x[1]) <= 5, x[2] >= 7, geomean(x[3], x[4]) >= x[2])
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, solver)
 println(p.status)
 x.value
 
@@ -82,7 +82,7 @@ x.value
 
 y = Semidefinite(2)
 p = maximize(eigmin(y), tr(y)<=6)
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, solver)
 p.optval
 
 #-
@@ -108,7 +108,7 @@ y.value
 using GLPK
 x = Variable(4, :Int)
 p = minimize(sum(x), x >= 0.5)
-solve!(p, GLPK.Optimizer())
+solve!(p, GLPK.Optimizer)
 x.value
 
 #-

--- a/docs/examples_literate/general_examples/chebyshev_center.jl
+++ b/docs/examples_literate/general_examples/chebyshev_center.jl
@@ -25,7 +25,7 @@ p.constraints += a1' * x_c + r * norm(a1, 2) <= b[1];
 p.constraints += a2' * x_c + r * norm(a2, 2) <= b[2];
 p.constraints += a3' * x_c + r * norm(a3, 2) <= b[3];
 p.constraints += a4' * x_c + r * norm(a4, 2) <= b[4];
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 p.optval
 
 # Generate the figure

--- a/docs/examples_literate/general_examples/control.jl
+++ b/docs/examples_literate/general_examples/control.jl
@@ -121,7 +121,7 @@ push!(constraints, velocity[:, T] == 0)
 
 ## Solve the problem
 problem = minimize(sumsquares(force), constraints)
-solve!(problem, SCS.Optimizer(verbose=0))
+solve!(problem, () -> SCS.Optimizer(verbose=0))
 
 # We can plot the trajectory taken by the object.
 

--- a/docs/examples_literate/general_examples/huber_regression.jl
+++ b/docs/examples_literate/general_examples/huber_regression.jl
@@ -40,18 +40,18 @@ for i=1:length(p_vals)
     fit = norm(beta - beta_true) / norm(beta_true);
     cost = norm(X' * beta - Y);
     prob = minimize(cost);
-    solve!(prob, SCS.Optimizer(verbose=0));
+    solve!(prob, () -> SCS.Optimizer(verbose=0));
     lsq_data[i] = evaluate(fit);
     
     ## Form and solve a prescient regression problem,
     ## i.e., where the sign changes are known.
     cost = norm(factor .* (X'*beta) - Y);
-    solve!(minimize(cost), SCS.Optimizer(verbose=0))
+    solve!(minimize(cost), () -> SCS.Optimizer(verbose=0))
     prescient_data[i] = evaluate(fit);
     
     ## Form and solve the Huber regression problem.
     cost = sum(huber(X' * beta - Y, 1));
-    solve!(minimize(cost), SCS.Optimizer(verbose=0))
+    solve!(minimize(cost), () -> SCS.Optimizer(verbose=0))
     huber_data[i] = evaluate(fit);
 end
 

--- a/docs/examples_literate/general_examples/logistic_regression.jl
+++ b/docs/examples_literate/general_examples/logistic_regression.jl
@@ -23,7 +23,7 @@ X = hcat(ones(size(iris, 1)), iris.SepalLength, iris.SepalWidth, iris.PetalLengt
 n, p = size(X)
 beta = Variable(p)
 problem = minimize(logisticloss(-Y.*(X*beta)))
-solve!(problem, SCS.Optimizer(verbose=false))
+solve!(problem, () -> SCS.Optimizer(verbose=false))
 
 # Let's see how well the model fits.
 using Plots

--- a/docs/examples_literate/general_examples/max_entropy.jl
+++ b/docs/examples_literate/general_examples/max_entropy.jl
@@ -23,7 +23,7 @@ b = rand(m, 1);
 
 x = Variable(n);
 problem = maximize(entropy(x), sum(x) == 1, A * x <= b)
-solve!(problem, SCS.Optimizer(verbose=false))
+solve!(problem, () -> SCS.Optimizer(verbose=false))
 problem.optval
 
 #-

--- a/docs/examples_literate/general_examples/optimal_advertising.jl
+++ b/docs/examples_literate/general_examples/optimal_advertising.jl
@@ -46,7 +46,7 @@ D = Variable(m, n);
 Si = [min(R[i]*dot(P[i,:], D[i,:]'), B[i]) for i=1:m];
 problem = maximize(sum(Si),
                [D >= 0, sum(D, dims=1)' <= T, sum(D, dims=2) >= c]);
-solve!(problem, SCS.Optimizer(verbose=0));
+solve!(problem, () -> SCS.Optimizer(verbose=0));
 
 #-
 

--- a/docs/examples_literate/general_examples/robust_approx_fitting.jl
+++ b/docs/examples_literate/general_examples/robust_approx_fitting.jl
@@ -43,18 +43,18 @@ x = Variable(n)
 
 # Case 1: Nominal optimal solution
 p = minimize(norm(A * x - b, 2))
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 x_nom = evaluate(x)
 
 # Case 2: Stochastic robust approximation
 P = 1 / 3 * B' * B;
 p = minimize(square(pos(norm(A * x - b))) + quadform(x, Symmetric(P)))
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 x_stoch = evaluate(x)
 
 # Case 3: Worst-case robust approximation
 p = minimize(max(norm((A - B) * x - b), norm((A + B) * x - b)))
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 x_wc = evaluate(x)
 
 # Plot residuals:

--- a/docs/examples_literate/general_examples/svm.jl
+++ b/docs/examples_literate/general_examples/svm.jl
@@ -34,7 +34,7 @@ neg_data = rand(MvNormal([-1.0, 2.0], 1.0), M);
 
 #-
 
-function svm(pos_data, neg_data, solver=SCS.Optimizer(verbose=0))
+function svm(pos_data, neg_data, solver=() -> SCS.Optimizer(verbose=0))
     ## Create variables for the separating hyperplane w'*x = b.
     w = Variable(n)
     b = Variable()

--- a/docs/examples_literate/general_examples/svm_l1regularization.jl
+++ b/docs/examples_literate/general_examples/svm_l1regularization.jl
@@ -34,7 +34,7 @@ beta_vals = zeros(length(beta), TRIALS);
 for i = 1:TRIALS
     lambda = lambda_vals[i];
     problem = minimize(loss/m + lambda*reg);
-    solve!(problem, ECOS.Optimizer(verbose=0));
+    solve!(problem, () -> ECOS.Optimizer(verbose=0));
     ## solve!(problem, SCS.Optimizer(verbose=0,linear_solver=SCS.Direct, eps=1e-3))
     train_error[i] = sum(float(sign.(X*beta_true .+ offset) .!= sign.(evaluate(X*beta - v))))/m;
     test_error[i] = sum(float(sign.(X_test*beta_true .+ offset) .!= sign.(evaluate(X_test*beta - v))))/TEST;

--- a/docs/examples_literate/general_examples/trade_off_curves.jl
+++ b/docs/examples_literate/general_examples/trade_off_curves.jl
@@ -18,7 +18,7 @@ x = Variable(n);
 for i=1:length(gammas)
     cost = sumsquares(A*x - b) + gammas[i]*norm(x,1);
     problem = minimize(cost, [norm(x, Inf) <= 1]);
-    solve!(problem, SCS.Optimizer(verbose=0));
+    solve!(problem, () -> SCS.Optimizer(verbose=0));
     x_values[:,i] = evaluate(x);
 end
 

--- a/docs/examples_literate/general_examples/worst_case_analysis.jl
+++ b/docs/examples_literate/general_examples/worst_case_analysis.jl
@@ -18,7 +18,7 @@ w = Variable(n);
 ret = dot(r, w);
 risk = sum(quadform(w, Sigma_nom));
 problem = minimize(risk, [sum(w) == 1, ret >= 0.1, norm(w, 1) <= 2])
-solve!(problem, SCS.Optimizer(verbose=0));
+solve!(problem, () -> SCS.Optimizer(verbose=0));
 wval = vec(evaluate(w))
 
 #-
@@ -31,7 +31,7 @@ problem = maximize(risk, [Sigma == Sigma_nom + Delta,
                     diag(Delta) == 0,
                     abs(Delta) <= 0.2,
                     Delta == Delta']);
-solve!(problem, SCS.Optimizer(verbose=0));
+solve!(problem, () -> SCS.Optimizer(verbose=0));
 println("standard deviation = ", round(sqrt(wval' * Sigma_nom * wval), sigdigits=2));
 println("worst-case standard deviation = ", round(sqrt(evaluate(risk)), sigdigits=2));
 println("worst-case Delta = ");

--- a/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
+++ b/docs/examples_literate/mixed_integer/aux_files/antidiag.jl
@@ -9,6 +9,8 @@
 # Please read expressions.jl first.
 #############################################################################
 import Convex.sign, Convex.monotonicity, Convex.curvature, Convex.evaluate, Convex.conic_form!
+using Convex: AbstractExpr, Nondecreasing, ConstVexity, UniqueConicForms, has_conic_form, cache_conic_form, get_conic_form
+using LinearAlgebra, SparseArrays
 export antidiag
 
 ### Diagonal

--- a/docs/examples_literate/mixed_integer/binary_knapsack.jl
+++ b/docs/examples_literate/mixed_integer/binary_knapsack.jl
@@ -24,5 +24,5 @@ n = length(w)
 using Convex, GLPK
 x = Variable(n, :Bin)
 problem = maximize(dot(p, x), dot(w, x) <= C)
-solve!(problem, GLPK.Optimizer())
+solve!(problem, GLPK.Optimizer)
 evaluate(x)

--- a/docs/examples_literate/mixed_integer/n_queens.jl
+++ b/docs/examples_literate/mixed_integer/n_queens.jl
@@ -16,7 +16,7 @@ constr += Constraint[sum(diag(x, k)) <= 1 for k = -n+2:n-2]
 ## Exactly one queen per row and one queen per column
 constr += Constraint[sum(x, dims=1) == 1, sum(x, dims=2) == 1]
 p = satisfy(constr)
-solve!(p, GLPK.Optimizer())
+solve!(p, GLPK.Optimizer)
 
 # Let us test the results:
 for k = -n+2:n-2

--- a/docs/examples_literate/mixed_integer/section_allocation.jl
+++ b/docs/examples_literate/mixed_integer/section_allocation.jl
@@ -30,5 +30,5 @@ constraints = [sum(X, dims=2) == 1, sum(X, dims=1) <= 10, sum(X, dims=1) >= 6]
 # students since the ranking of the first choice is 1.
 p = minimize(vec(X)' * vec(P), constraints)
 
-solve!(p, GLPK.Optimizer())
+solve!(p, GLPK.Optimizer)
 p.optval

--- a/docs/examples_literate/optimization_with_complex_variables/Fidelity in Quantum Information Theory.jl
+++ b/docs/examples_literate/optimization_with_complex_variables/Fidelity in Quantum Information Theory.jl
@@ -33,7 +33,7 @@ Z = ComplexVariable(n,n)
 objective = 0.5*real(tr(Z+Z'))
 constraint = [P Z;Z' Q] ⪰ 0
 problem = maximize(objective,constraint)
-solve!(problem, SCS.Optimizer(verbose=0))
+solve!(problem, () -> SCS.Optimizer(verbose=0))
 computed_fidelity = evaluate(objective)
 
 #-

--- a/docs/examples_literate/optimization_with_complex_variables/phase_recovery_using_MaxCut.jl
+++ b/docs/examples_literate/optimization_with_complex_variables/phase_recovery_using_MaxCut.jl
@@ -69,7 +69,7 @@ objective = inner_product(U,M)
 c1 = diag(U) == 1 
 c2 = U in :SDP
 p = minimize(objective,c1,c2)
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 U.value
 
 #-

--- a/docs/examples_literate/optimization_with_complex_variables/povm_simulation.jl
+++ b/docs/examples_literate/optimization_with_complex_variables/povm_simulation.jl
@@ -55,7 +55,7 @@ function get_visibility(K)
     constraints += t*K[3] + (1-t)*noise[3] == P[2][2] + P[4][2] + P[6][1]
     constraints += t*K[4] + (1-t)*noise[4] == P[3][2] + P[5][2] + P[6][2]
     p = maximize(t, constraints)
-    solve!(p, SCS.Optimizer(verbose=0))
+    solve!(p, () -> SCS.Optimizer(verbose=0))
     return p.optval
 end
 

--- a/docs/examples_literate/optimization_with_complex_variables/power_flow_optimization.jl
+++ b/docs/examples_literate/optimization_with_complex_variables/power_flow_optimization.jl
@@ -25,7 +25,7 @@ c3 = real(W[1,1]) == 1.06^2;
 push!(c1, c2)
 push!(c1, c3)
 p = maximize(objective, c1);
-solve!(p, SCS.Optimizer(verbose = 0))
+solve!(p, () -> SCS.Optimizer(verbose = 0))
 p.optval
 #15.125857662600703
 evaluate(objective)

--- a/docs/examples_literate/portfolio_optimization/portfolio_optimization.jl
+++ b/docs/examples_literate/portfolio_optimization/portfolio_optimization.jl
@@ -56,7 +56,7 @@ p = minimize( risk,
               w_lower <= w, 
               w <= w_upper )
 
-solve!(p, SCS.Optimizer())     #use SCS.Optimizer(verbose = false) to suppress printing
+solve!(p, () -> SCS.Optimizer())     #use SCS.Optimizer(verbose = false) to suppress printing
 
 #-
 

--- a/docs/examples_literate/portfolio_optimization/portfolio_optimization2.jl
+++ b/docs/examples_literate/portfolio_optimization/portfolio_optimization2.jl
@@ -52,7 +52,7 @@ for i = 1:N
     λ = λ_vals[i]
     p = minimize( λ*risk - (1-λ)*ret,
                   sum(w) == 1 )
-    solve!(p, SCS.Optimizer(verbose = false))
+    solve!(p, () -> SCS.Optimizer(verbose = false))
     MeanVarA[i,:]= [evaluate(ret),evaluate(risk)]
 end
 
@@ -68,7 +68,7 @@ for i = 1:N
                   sum(w) == 1,
                   w_lower <= w,     #w[i] is bounded
                   w <= w_upper )
-    solve!(p, SCS.Optimizer(verbose = false))
+    solve!(p, () -> SCS.Optimizer(verbose = false))
     MeanVarB[i,:]= [evaluate(ret),evaluate(risk)]
 end
 
@@ -95,7 +95,7 @@ for i = 1:N
     p = minimize( λ*risk - (1-λ)*ret,
                   sum(w) == 1,
                   (norm(w, 1)-1) <= Lmax)
-    solve!(p, SCS.Optimizer(verbose = false))
+    solve!(p, () -> SCS.Optimizer(verbose = false))
     MeanVarC[i,:]= [evaluate(ret),evaluate(risk)]
 end
 

--- a/docs/examples_literate/supplemental_material/Convex.jl_intro_ISMP2015.jl
+++ b/docs/examples_literate/supplemental_material/Convex.jl_intro_ISMP2015.jl
@@ -41,7 +41,7 @@ problem = minimize(square(norm(A * x - b)) + λ*square(norm(x)) + μ*norm(x, 1),
                    x >= 0)
 
 ## Solve the problem by calling solve!
-solve!(problem, SCS.Optimizer(verbose=0))
+solve!(problem, () -> SCS.Optimizer(verbose=0))
 
 println("problem status is ", problem.status) # :Optimal, :Infeasible, :Unbounded etc.
 println("optimal value is ", problem.optval)
@@ -54,7 +54,7 @@ using Interact, Plots
     global A
     problem = minimize(square(norm(A * x - b)) + λ*square(norm(x)) + μ*norm(x, 1),
                    x >= 0)
-    solve!(problem, SCS.Optimizer(verbose=0))
+    solve!(problem, () -> SCS.Optimizer(verbose=0))
     histogram(evaluate(x), xlims=(0,3.5), label="x")
 end
 
@@ -128,7 +128,7 @@ p = minimize(objective, constraint)
 #-
 
 ## solve the problem
-solve!(p, SCS.Optimizer(verbose=0))
+solve!(p, () -> SCS.Optimizer(verbose=0))
 p.status
 
 #-
@@ -152,7 +152,7 @@ evaluate(objective)
 # to solve problem using a different solver, just import the solver package and pass the solver to the `solve!` method: eg
 #
 #     using Mosek
-#     solve!(p, Mosek.Optimizer())
+#     solve!(p, Mosek.Optimizer)
 
 #-
 
@@ -173,9 +173,9 @@ x = Variable(n)
 μ = 1
 problem = minimize(square(norm(A * x - b)) + λ*square(norm(x)) + μ*norm(x, 1), 
                    x >= 0)
-@time solve!(problem, SCS.Optimizer(verbose=0))
+@time solve!(problem, () -> SCS.Optimizer(verbose=0))
 λ = 1.5
-@time solve!(problem, SCS.Optimizer(verbose=0), warmstart = true)
+@time solve!(problem, () -> SCS.Optimizer(verbose=0), warmstart = true)
 
 # # DCP examples
 

--- a/docs/examples_literate/supplemental_material/paper_examples.jl
+++ b/docs/examples_literate/supplemental_material/paper_examples.jl
@@ -13,7 +13,7 @@ e = 0;
   end
   p = minimize(e, x>=1);
 end
-@time solve!(p, ECOS.Optimizer(verbose=0))
+@time solve!(p, () -> ECOS.Optimizer(verbose=0))
 
 # Indexing.
 println("Indexing example")
@@ -26,7 +26,7 @@ e = 0;
   end
   p = minimize(e, x >= ones(1000, 1));
 end
-@time solve!(p, ECOS.Optimizer(verbose=0))
+@time solve!(p, () -> ECOS.Optimizer(verbose=0))
 
 # Matrix constraints.
 println("Matrix constraint example")
@@ -37,7 +37,7 @@ b = randn(p, n);
 @time begin
   p = minimize(norm(vec(X)), A * X == b);
 end
-@time solve!(p, ECOS.Optimizer(verbose=0))
+@time solve!(p, () -> ECOS.Optimizer(verbose=0))
 
 # Transpose.
 println("Transpose example")
@@ -46,12 +46,12 @@ A = randn(5, 5);
 @time begin
   p = minimize(norm2(X - A), X' == X);
 end
-@time solve!(p, ECOS.Optimizer(verbose=0))
+@time solve!(p, () -> ECOS.Optimizer(verbose=0))
 
 n = 3
 A = randn(n, n);
 #@time begin
   X = Variable(n, n);
   p = minimize(norm(vec(X' - A)), X[1,1] == 1);
-  solve!(p, ECOS.Optimizer(verbose=0))
+  solve!(p, () -> ECOS.Optimizer(verbose=0))
 #end

--- a/docs/examples_literate/time_series/time_series.jl
+++ b/docs/examples_literate/time_series/time_series.jl
@@ -40,7 +40,7 @@ eq_constraints = [ yearly[i] == yearly[i - 365] for i in 365 + 1 : n ]
 smoothing = 100
 smooth_objective = sumsquares(yearly[1 : n - 1] - yearly[2 : n])
 problem = minimize(sumsquares(temps - yearly) + smoothing * smooth_objective, eq_constraints);
-solve!(problem, ECOS.Optimizer(maxit=200, verbose=0))
+solve!(problem, () -> ECOS.Optimizer(maxit=200, verbose=0))
 residuals = temps - evaluate(yearly)
 
 ## Plot smooth fit
@@ -82,7 +82,7 @@ end
 ## Solve autoregressive problem
 ar_coef = Variable(ar_len)
 problem = minimize(sumsquares(residuals_mat * ar_coef - residuals[ar_len + 1 : end]))
-solve!(problem, ECOS.Optimizer(max_iters=200, verbose=0))
+solve!(problem, () -> ECOS.Optimizer(max_iters=200, verbose=0))
 
 ## plot autoregressive fit of daily fluctuations for a few days
 ar_range = 1:145

--- a/docs/examples_literate/tomography/tomography.jl
+++ b/docs/examples_literate/tomography/tomography.jl
@@ -62,7 +62,7 @@ pixel_colors = Variable(num_pixels)
 ## to reflect that, we minimize a norm
 objective = sumsquares(line_mat * pixel_colors - line_vals)
 problem = minimize(objective)
-solve!(problem, ECOS.Optimizer(verbose=0))
+solve!(problem, () -> ECOS.Optimizer(verbose=0))
 
 rows = zeros(img_size*img_size)
 cols = zeros(img_size*img_size)

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -41,13 +41,13 @@ x = Variable(n)
 # first solve
 lambda = 100
 problem = minimize(sumsquares(y - x) + lambda * sumsquares(x - 10))
-@time solve!(problem, SCS.Optimizer())
+@time solve!(problem, SCS.Optimizer)
 
 # now warmstart
 # if the solver takes advantage of warmstarts, 
 # this run will be faster
 lambda = 105
-@time solve!(problem, SCS.Optimizer(), warmstart=true)
+@time solve!(problem, SCS.Optimizer, warmstart=true)
 ```
 
 Fixing and freeing variables
@@ -89,12 +89,12 @@ for i=1:10
     # first solve for x
     # with y fixed, the problem is convex
     fix!(y)
-    solve!(problem, SCS.Optimizer(), warmstart = i > 1 ? true : false)
+    solve!(problem, SCS.Optimizer, warmstart = i > 1 ? true : false)
     free!(y)
 
     # now solve for y with x fixed at the previous solution
     fix!(x)
-    solve!(problem, SCS.Optimizer(), warmstart = true)
+    solve!(problem, SCS.Optimizer, warmstart = true)
     free!(x)
 end
 ```

--- a/docs/src/complex-domain_optimization.md
+++ b/docs/src/complex-domain_optimization.md
@@ -106,7 +106,7 @@ constraints = [partialtrace(ρ, 1, [2; 2]) == [1 0; 0 0]
                tr(ρ) == 1
                ρ in :SDP]
 p = satisfy(constraints)
-solve!(p, SCS.Optimizer(verbose=false))
+solve!(p, () -> SCS.Optimizer(verbose=false))
 p.status
 ```
 

--- a/docs/src/problem_depot.md
+++ b/docs/src/problem_depot.md
@@ -11,7 +11,7 @@ For example, to test the solver SCS on all the problems of the depot except the 
 using Convex, SCS, Test
 @testset "SCS" begin
     Convex.ProblemDepot.run_tests(; exclude=[r"mip"]) do p
-        solve!(p, SCS.Optimizer(verbose=0, eps=1e-6))
+        solve!(p, () -> SCS.Optimizer(verbose=0, eps=1e-6))
     end
 end
 ```

--- a/docs/src/quick_tutorial.md
+++ b/docs/src/quick_tutorial.md
@@ -33,7 +33,7 @@ x = Variable(n)
 problem = minimize(sumsquares(A * x - b), [x >= 0])
 
 # Solve the problem by calling solve!
-solve!(problem, SCS.Optimizer(verbose=false))
+solve!(problem, () -> SCS.Optimizer(verbose=false))
 
 # Check the status of the problem
 problem.status # :Optimal, :Infeasible, :Unbounded etc.

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -27,11 +27,11 @@ the documentation for that solver.
 To use a specific solver, you can use the following syntax
 
 ```julia
-solve!(p, Gurobi.Optimizer())
-solve!(p, Mosek.Optimizer())
-solve!(p, GLPK.Optimizer())
-solve!(p, ECOS.Optimizer())
-solve!(p, SCS.Optimizer())
+solve!(p, Gurobi.Optimizer)
+solve!(p, Mosek.Optimizer)
+solve!(p, GLPK.Optimizer)
+solve!(p, ECOS.Optimizer)
+solve!(p, SCS.Optimizer)
 ```
 
 (Of course, the solver must be installed first.) For example, we can use
@@ -39,7 +39,7 @@ GLPK to solve a MILP
 
 ```julia
 using GLPK
-solve!(p, GLPK.Optimizer())
+solve!(p, GLPK.Optimizer)
 ```
 
 Many of the solvers also allow options to be passed in. More details can
@@ -50,7 +50,14 @@ in quiet mode), we can do so by
 
 ```julia
 using SCS
-solve!(p, SCS.Optimizer(verbose=false))
+opt = () -> SCS.Optimizer(verbose=false)
+solve!(p, opt)
+```
+
+or equivalently,
+
+```julia
+solve!(p, () -> SCS.Optimizer(verbose=false))
 ```
 
 If we wish to increase the maximum number of iterations for ECOS or SCS,
@@ -58,9 +65,9 @@ we can do so by
 
 ```julia
 using ECOS
-solve!(p, ECOS.Optimizer(maxit=10000))
+solve!(p, () -> ECOS.Optimizer(maxit=10000))
 using SCS
-solve!(p, SCS.Optimizer(max_iters=10000))
+solve!(p, () -> SCS.Optimizer(max_iters=10000))
 ```
 
 To turn off the problem status warning issued by Convex when a solver is
@@ -69,5 +76,5 @@ not able to solve a problem to optimality, use the keyword argument
 solver parameters:
 
 ```julia
-solve!(p, SCS.Optimizer(verbose=false), verbose=false)
+solve!(p, () -> SCS.Optimizer(verbose=false), verbose=false)
 ```

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -73,7 +73,7 @@ y = Variable()
 z = Variable()
 expr = x + y + z
 problem = minimize(expr, x >= 1, y >= x, 4 * z >= y)
-solve!(problem, SCS.Optimizer())
+solve!(problem, SCS.Optimizer)
 
 # Once the problem is solved, we can call evaluate() on expr:
 evaluate(expr)

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -188,6 +188,13 @@ function load_MOI_model!(model, problem::Problem{T}) where {T}
     return id_to_variables, conic_constr_to_constr, conic_constraints, var_to_indices, constraint_indices
 end
 
+function solve!(problem::Problem{T}, optimizer; kwargs...) where {T}
+    if Base.applicable(optimizer)
+        return solve!(problem, optimizer(); kwargs...)
+    else
+        throw(ArgumentError("MathProgBase solvers like `solve!(problem, SCSSolver())` are no longer supported. Use instead e.g. `solve!(problem, SCS.Optimizer)`."))
+    end
+end
 
 function solve!(problem::Problem{T}, optimizer::MOI.ModelLike;
     check_vexity = true,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,26 +38,26 @@ end
         # We exclude `sdp_matrix_frac_atom` due to the bug https://github.com/JuliaOpt/SCS.jl/issues/153
         # Likewise, `sdp_sdp_constraints` hits a bug https://github.com/JuliaOpt/SCS.jl/issues/167
         run_tests(; exclude=[r"mip", r"sdp_matrix_frac_atom", r"sdp_sdp_constraints"]) do p
-            solve!(p, SCS.Optimizer(verbose=0, eps=1e-6); warmstart = true)
+            solve!(p, () -> SCS.Optimizer(verbose=0, eps=1e-6); warmstart = true)
         end
     end
 
     @testset "SCS" begin
         # Exclusions same as for "SCS with warmstarts"
         run_tests(; exclude=[r"mip", r"sdp_matrix_frac_atom", r"sdp_sdp_constraints"]) do p
-            solve!(p, SCS.Optimizer(verbose=0, eps=1e-6))
+            solve!(p, () -> SCS.Optimizer(verbose=0, eps=1e-6))
         end
     end
 
     @testset "ECOS" begin
         run_tests(; exclude=[r"mip", r"sdp"]) do p
-            solve!(p, ECOS.Optimizer(verbose=0))
+            solve!(p, () -> ECOS.Optimizer(verbose=0))
         end
     end
 
     @testset "GLPK" begin
         run_tests(; exclude=[r"exp", r"sdp", r"socp"]) do p
-            solve!(p, GLPK.Optimizer(msg_lev = GLPK.OFF))
+            solve!(p, () -> GLPK.Optimizer(msg_lev = GLPK.OFF))
         end
     end
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -5,8 +5,22 @@ using Convex: AbstractExpr, ConicObj
     @testset "`solve!` does not return anything" begin
         x = Variable()
         p = satisfy(x >= 0)
+        output = solve!(p, () -> SCS.Optimizer(verbose=0, eps=1e-6))
+        @test output === nothing
+    end
+
+    # This might get deprecated later.
+    @testset "`solve!` can take an optimizer directly" begin
+        x = Variable()
+        p = satisfy(x >= 0)
         output = solve!(p, SCS.Optimizer(verbose=0, eps=1e-6))
         @test output === nothing
+    end
+
+    @testset "`solve!` with MPB solver errors" begin
+        x = Variable()
+        p = satisfy(x >= 0)
+        @test_throws ArgumentError solve!(p, SCSSolver())
     end
 
     @testset "Show" begin

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -33,4 +33,3 @@ lambda = 105
 println("this run should be faster than the last and have slightly higher optimal value")
 @time solve!(problem, warmstart=true)
 @show problem.optval
-


### PR DESCRIPTION
A simple resolution to https://github.com/JuliaOpt/Convex.jl/issues/346#issuecomment-559259462: we encourage passing constructors instead of optimizer instances (and document doing so everywhere). In this release, I haven't actually disallowed passing optimizer instances yet; I think maybe that can wait for next release, along with a more strict and coherent API in general (https://github.com/JuliaOpt/Convex.jl/issues/346), as well as supporing MOI's new `optimizer_with_attributes`. I think this is enough to tag a release finally. (Next time, I'll try to make all the breaking changes in one PR so that we don't have to hold off tagging for minor fixes, compat, etc, just because there are unfinished breaking changes sitting on the master branch.)

closes https://github.com/JuliaOpt/Convex.jl/issues/361