### PR TITLE
Remove slow `hash` by defining `isequal`

### DIFF
--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -34,19 +34,8 @@ import Base.sign, Base.size, Base.length, Base.lastindex, Base.ndims, Base.conve
 abstract type AbstractExpr end
 abstract type Constraint end
 
-# Override hash function because of
-# https://github.com/JuliaLang/julia/issues/10267
-import Base.hash
-
-const hashaa_seed = UInt === UInt64 ? 0x7f53e68ceb575e76 : 0xeb575e7
-function hash(a::Array{AbstractExpr}, h::UInt)
-    h += hashaa_seed
-    h += hash(size(a))
-    for x in a
-        h = hash(x, h)
-    end
-    return h
-end
+Base.isequal(a::AbstractExpr, b::AbstractExpr) = a.id_hash == b.id_hash && a.head == b.head
+Base.hash(a::AbstractExpr, h::UInt) = hash((a.id_hash, a.head), h)
 
 
 # If h(x)=f∘g(x), then (for single variable calculus)

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -34,8 +34,18 @@ import Base.sign, Base.size, Base.length, Base.lastindex, Base.ndims, Base.conve
 abstract type AbstractExpr end
 abstract type Constraint end
 
-Base.isequal(a::AbstractExpr, b::AbstractExpr) = a.id_hash == b.id_hash && a.head == b.head
-Base.hash(a::AbstractExpr, h::UInt) = hash((a.id_hash, a.head), h)
+id_hash(x::AbstractExpr) = getfield(x, :id_hash)
+head(x::AbstractExpr) = getfield(x, :head)
+
+const hashaa_seed = hash(AbstractExpr)
+
+Base.hash(ex::AbstractExpr, h::UInt) = xor(id_hash(ex), hash(head(ex), h))::UInt
+
+function Base.hash(A::Array{<:AbstractExpr}, h::UInt)
+    h = xor(hashaa_seed, hash(size(A), h))
+    return mapreduce(hash, xor, A, init=h)
+end
+
 
 
 # If h(x)=f∘g(x), then (for single variable calculus)


### PR DESCRIPTION
See https://discourse.julialang.org/t/convex-jl-slow-in-creating-constraints/34775/13 for context. I'm not 100% sure this is completely correct, so I won't merge it until I know it is. Hopefully someone can chime in;  I'll also try and think it through more.