### PR TITLE
export `Constraint`

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -21,6 +21,7 @@ export relative_entropy, scaledgeomean, sigmamax, square, sumlargest, sumlargest
 export diag, diagm, Diagonal, dot, eigmax, eigmin, kron, logdet, norm, tr
 
 # Constraints
+export Constraint
 export isposdef, ⪰, ⪯ # PSD constraints
 export socp
 


### PR DESCRIPTION
This was removed in #357 along with a lot of other exports, but I don't think I meant to remove `Constraint`. It's pretty useful for doing things like
```julia
constraints = Constraint[]
...
push!(constraints, ...)
...
problem = minimize(objective, constraints)
```
which doesn't work with `constraints = []` due to the way the`Problem` constructors are typed. I think those should be revisited along with other API stuff in #346 later, but for now let's just add back the export. This export being missing also breaks one of the examples; I'm not sure why CI didn't catch that.