### PR TITLE
Allow disabling DCP warnings

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -13,10 +13,14 @@ y = Variable()
 x*y
 ```
 
-To disable this, set the module-level parameter `DCP_WARNINGS` via
+These warnings can be very useful to know if a problem has been formulated
+correctly. However, in some circumstances, one may wish to disable these
+warnings. To do so, call [`Convex.disable_DCP_warnings()`](@ref). To restore the
+warnings, call [`Convex.enable_DCP_warnings()`](@ref).
 
-```julia
-Convex.DCP_WARNINGS[] = false
+```@docs
+Convex.enable_DCP_warnings()
+Convex.disable_DCP_warnings()
 ```
 
 

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -1,6 +1,25 @@
 Advanced Features
 =================
 
+DCP warnings
+------------
+
+When an expression is created which is not of [DCP
+form](https://dcp.stanford.edu/), a warning is emitted. For example,
+
+```repl
+x = Variable()
+y = Variable()
+x*y
+```
+
+To disable this, set the module-level parameter `DCP_WARNINGS` via
+
+```julia
+Convex.DCP_WARNINGS[] = false
+```
+
+
 Dual Variables
 --------------
 

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -13,14 +13,10 @@ y = Variable()
 x*y
 ```
 
-These warnings can be very useful to know if a problem has been formulated
-correctly. However, in some circumstances, one may wish to disable these
-warnings. To do so, call [`Convex.disable_DCP_warnings()`](@ref). To restore the
-warnings, call [`Convex.enable_DCP_warnings()`](@ref).
+To disable this, set the module-level parameter `DCP_WARNINGS` via
 
-```@docs
-Convex.enable_DCP_warnings()
-Convex.disable_DCP_warnings()
+```julia
+Convex.DCP_WARNINGS[] = false
 ```
 
 

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -34,13 +34,15 @@ export Positive, Negative, ComplexSign, NoSign
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
-const DCP_WARNINGS = Bool[]
+"""
+    const DCP_WARNINGS = Ref(true)
 
-function __init__()
-    resize!(DCP_WARNINGS, Threads.nthreads())
-    fill!(DCP_WARNINGS, true)
-end
+Controls whether or not warnings are emitted for when an expression fails to be
+of disciplined convex form. To turn warnings off, run
 
+    Convex.DCP_WARNINGS[] = false
+"""
+const DCP_WARNINGS = Ref(true)
 
 ### modeling framework
 include("dcp.jl")

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -34,6 +34,16 @@ export Positive, Negative, ComplexSign, NoSign
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
+"""
+    const DCP_WARNINGS = Ref(true)
+
+Controls whether or not warnings are emitted for when an expression fails to be
+of disciplined convex form. To turn warnings off, run
+
+    Convex.DCP_WARNINGS[] = false
+"""
+const DCP_WARNINGS = Ref(true)
+
 ### modeling framework
 include("dcp.jl")
 include("expressions.jl")

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -34,15 +34,36 @@ export Positive, Negative, ComplexSign, NoSign
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
+
+# Module level globals
+
 """
-    const DCP_WARNINGS = Ref(true)
+    DCP_WARNINGS
 
 Controls whether or not warnings are emitted for when an expression fails to be
 of disciplined convex form. To turn warnings off, run
 
     Convex.DCP_WARNINGS[] = false
 """
-const DCP_WARNINGS = Ref(true)
+const DCP_WARNINGS = Threads.Atomic{Bool}(true)
+
+"""
+    MAXDEPTH
+
+Controls depth of tree printing globally for Convex.jl; defaults to 3. Set via
+
+    Convex.MAXDEPTH[] = 5
+"""
+const MAXDEPTH = Threads.Atomic{Int}(3)
+
+"""
+    MAXWIDTH
+
+Controls width of tree printing globally for Convex.jl; defaults to 15. Set via
+
+    Convex.MAXWIDTH[] = 15
+"""
+const MAXWIDTH= Threads.Atomic{Int}(15)
 
 ### modeling framework
 include("dcp.jl")

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -34,15 +34,13 @@ export Positive, Negative, ComplexSign, NoSign
 # Problems
 export add_constraint!, add_constraints!, maximize, minimize, Problem, satisfy, solve!
 
-"""
-    const DCP_WARNINGS = Ref(true)
+const DCP_WARNINGS = Bool[]
 
-Controls whether or not warnings are emitted for when an expression fails to be
-of disciplined convex form. To turn warnings off, run
+function __init__()
+    resize!(DCP_WARNINGS, Threads.nthreads())
+    fill!(DCP_WARNINGS, true)
+end
 
-    Convex.DCP_WARNINGS[] = false
-"""
-const DCP_WARNINGS = Ref(true)
 
 ### modeling framework
 include("dcp.jl")

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -21,7 +21,9 @@ struct ConcaveVexity <: Vexity            end
 
 struct NotDcp <: Vexity
     function NotDcp()
-        @warn "Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior."
+        if DCP_WARNINGS[]
+            @warn "Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior."
+        end
         return new()
     end
 end

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -19,9 +19,31 @@ struct AffineVexity <: Vexity             end
 struct ConvexVexity <: Vexity             end
 struct ConcaveVexity <: Vexity            end
 
+
+"""
+    enable_DCP_warnings()
+
+Enable warnings from the current thread when an expression fails to be of
+disciplined convex form. This setting is enabled by default. See also
+[`disable_DCP_warnings`](@ref).
+"""
+function enable_DCP_warnings()
+    DCP_WARNINGS[Threads.threadid()] = true
+end
+
+"""
+    disable_DCP_warnings()
+
+Disable warnings from the current thread when an expression fails to be of
+disciplined convex form. See also [`enable_DCP_warnings`](@ref).
+"""
+function disable_DCP_warnings()
+    DCP_WARNINGS[Threads.threadid()] = false
+end
+
 struct NotDcp <: Vexity
     function NotDcp()
-        if DCP_WARNINGS[]
+        if DCP_WARNINGS[Threads.threadid()]
             @warn "Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior."
         end
         return new()

--- a/src/dcp.jl
+++ b/src/dcp.jl
@@ -19,31 +19,9 @@ struct AffineVexity <: Vexity             end
 struct ConvexVexity <: Vexity             end
 struct ConcaveVexity <: Vexity            end
 
-
-"""
-    enable_DCP_warnings()
-
-Enable warnings from the current thread when an expression fails to be of
-disciplined convex form. This setting is enabled by default. See also
-[`disable_DCP_warnings`](@ref).
-"""
-function enable_DCP_warnings()
-    DCP_WARNINGS[Threads.threadid()] = true
-end
-
-"""
-    disable_DCP_warnings()
-
-Disable warnings from the current thread when an expression fails to be of
-disciplined convex form. See also [`enable_DCP_warnings`](@ref).
-"""
-function disable_DCP_warnings()
-    DCP_WARNINGS[Threads.threadid()] = false
-end
-
 struct NotDcp <: Vexity
     function NotDcp()
-        if DCP_WARNINGS[Threads.threadid()]
+        if DCP_WARNINGS[]
             @warn "Expression not DCP compliant. Trying to solve non-DCP compliant problems can lead to unexpected behavior."
         end
         return new()

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -1,20 +1,6 @@
 import Base.show, Base.summary
 using .TreePrint
 
-"""
-    const MAXDEPTH = Ref(3)
-
-Controls depth of tree printing globally for Convex.jl
-"""
-const MAXDEPTH = Ref(3)
-
-"""
-    const MAXWIDTH = Ref(15)
-
-Controls width of tree printing globally for Convex.jl
-"""
-const MAXWIDTH= Ref(15)
-
 
 """
     show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 3)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -255,9 +255,9 @@ using Convex: AbstractExpr, ConicObj
         # default is to log
         @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
         
-        Convex.disable_DCP_warnings()
+        Convex.DCP_WARNINGS[] = false
         @test_logs  Convex.NotDcp()
-        Convex.enable_DCP_warnings()
+        Convex.DCP_WARNINGS[] = true
         @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
         
     end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -255,9 +255,9 @@ using Convex: AbstractExpr, ConicObj
         # default is to log
         @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
         
-        Convex.DCP_WARNINGS[] = false
+        Convex.disable_DCP_warnings()
         @test_logs  Convex.NotDcp()
-        Convex.DCP_WARNINGS[] = true
+        Convex.enable_DCP_warnings()
         @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
         
     end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -250,4 +250,15 @@ using Convex: AbstractExpr, ConicObj
     #     x.value = [1 2 3; 4 5 6]
     #     @fact evaluate(s) --> 21
     # end
+
+    @testset "DCP warnings" begin
+        # default is to log
+        @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
+        
+        Convex.DCP_WARNINGS[] = false
+        @test_logs  Convex.NotDcp()
+        Convex.DCP_WARNINGS[] = true
+        @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
+        
+    end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaOpt/Convex.jl/issues/362

I'm not a big fan of globals (and I spent some time getting rid of them in #322), but since we emit this warning even on things like `x = Variable; y = Variable(); x*y`, there doesn't seem like a good place to pass in an argument `warn=false`. Arguably we could only do the check when calculating the `vexity` of a `Problem`, and then pass warning info through the problem constructor. (We would need to also make sure you can see the check before starting a solve, etc..)

However, (1) the way the `vexity` of a `Problem` is written currently is a little strange and I'd prefer not to mess with it yet, and (2) it might be helpful that we are very eager to warn on non-DCPness (i.e., on `x*y` instead of waiting for the user to put that inside a `Problem` or call a `solve!`), because it can help formulate a DCP problem easily, checking along the way, especially when you are first learning the rules.

So for these reasons, I think a simple fix to the current way of emitting the warnings is best, namely to just check if warnings are enabled from a global before issuing one. In the interests of thread safety (since that appears to be a useful thing to do with Convex: https://github.com/JuliaOpt/Convex.jl/issues/370), ~~I followed the pattern of https://discourse.julialang.org/t/attempting-to-make-my-module-code-threadsafe/30434/2 of making a vector of parameters indexed by `threadid()`. I think the same pattern is also used for Julia's RNG.~~ I used atomics, and added some for the other globals (for printing width and depth).