### PR TITLE
Switch atomics to refs

### DIFF
--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -46,7 +46,7 @@ of disciplined convex form. To turn warnings off, run
 
     Convex.DCP_WARNINGS[] = false
 """
-const DCP_WARNINGS = Threads.Atomic{Bool}(true)
+const DCP_WARNINGS = Ref(true)
 
 """
     MAXDEPTH
@@ -55,7 +55,7 @@ Controls depth of tree printing globally for Convex.jl; defaults to 3. Set via
 
     Convex.MAXDEPTH[] = 5
 """
-const MAXDEPTH = Threads.Atomic{Int}(3)
+const MAXDEPTH = Ref(3)
 
 """
     MAXWIDTH
@@ -64,7 +64,7 @@ Controls width of tree printing globally for Convex.jl; defaults to 15. Set via
 
     Convex.MAXWIDTH[] = 15
 """
-const MAXWIDTH= Threads.Atomic{Int}(15)
+const MAXWIDTH= Ref(15)
 
 ### modeling framework
 include("dcp.jl")


### PR DESCRIPTION
Thanks to @vtjnash on #multithreading who pointed out the atomics don't do anything, because we aren't using `atomic_not!` to flip the boolean one, for example. He emphasized that atomics are relations, not objects, and it's the act of flipping the boolean that could be atomic (i.e. so you could get the current value and negate that, and then set that to be the value, all while knowing another thread hasn't changed the value inbetween getting and setting the value).

Here, however, we don't need to get and set together (atomically), we are just setting, so there is no need for an atomic (and it doesn't do anything).

I think we could use locks if we were concerned about multiple threads changing these values at once, but one just shouldn't do that (just choose the settings at the start of the script; doesn't really make sense to change it partway through a multithreaded computation). I don't think there's a problem with multiple threads *reading* the values at the same time.

This partially reverts https://github.com/JuliaOpt/Convex.jl/pull/372 (i.e. reverts the atomic stuff, not the DCP warnings).