### PR TITLE
Allow setting max print width of IDs via `Convex.MAXDIGITS`.

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -143,6 +143,11 @@ only the first `MAXWIDTH` of the constraints will be printed. Vertical dots,
 "⋮", will be printed indicating that some constraints were omitted in the
 printing.
 
+A related setting is [`Convex.MAXDIGITS`](@ref), which controls
+printing the internal IDs of atoms: if the string representation of an
+ID is longer than double the value of `MAXDIGITS`, then it is
+shortened by printing only the first and last `MAXDIGITS` characters.
+
 The AbstractTrees methods can also be used to analyze the structure
 of a Convex.jl problem. For example,
 
@@ -197,4 +202,5 @@ Reference
 ```@docs
 Convex.MAXDEPTH
 Convex.MAXWIDTH
+Convex.MAXDIGITS
 ```

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -66,6 +66,23 @@ Controls width of tree printing globally for Convex.jl; defaults to 15. Set via
 """
 const MAXWIDTH= Ref(15)
 
+"""
+    MAXDIGITS
+
+When priting IDs of variables, only show the initial and final digits
+if the full ID has more than double the number of digits specified
+here.  So, with the default setting MAXDIGITS=3, any ID longer than 7
+digits would be shortened; for example, ID `14656210999710729289`
+would be printed as `146…289`.
+
+This setting controls tree printing globally for Convex.jl; defaults to 3.
+
+Set via:
+
+    Convex.MAXDIGITS[] = 3
+"""
+const MAXDIGITS= Ref(3)
+
 ### modeling framework
 include("dcp.jl")
 include("expressions.jl")

--- a/src/utilities/show.jl
+++ b/src/utilities/show.jl
@@ -16,11 +16,15 @@ julia> Convex.show_id(stdout, x)
 id: 163…906
 ```
 """
-show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = 3) = print(io, show_id(x; digits=digits))
+show_id(io::IO, x::Union{AbstractExpr, Constraint}; digits = MAXDIGITS[]) = print(io, show_id(x; digits=digits))
 
-function show_id(x::Union{AbstractExpr, Constraint}; digits = 3)
+function show_id(x::Union{AbstractExpr, Constraint}; digits = MAXDIGITS[])
     hash_str = string(x.id_hash)
-    return "id: " * first(hash_str, digits) * "…" * last(hash_str, digits)
+    if length(hash_str) > (2*digits + 1);
+        return "id: " * first(hash_str, digits) * "…" * last(hash_str, digits)
+    else
+        return "id: " * hash_str
+    end
 end
 
 """

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -137,6 +137,21 @@ using Convex: AbstractExpr, ConicObj
                 termination status: OPTIMAL
                 primal status: FEASIBLE_POINT
                 dual status: FEASIBLE_POINT"""
+
+        # test small `MAXDIGITS`
+        x = Variable()
+        old_maxdigits = Convex.MAXDIGITS[]
+        Convex.MAXDIGITS[] = 2
+        @test length(Convex.show_id(x)) == length("id: ") + 5
+        Convex.MAXDIGITS[] = old_maxdigits
+
+        # test large `MAXDIGITS`
+        x = Variable()
+        old_maxdigits = Convex.MAXDIGITS[]
+        Convex.MAXDIGITS[] = 100
+        @test length(Convex.show_id(x)) == length("id: ") + length(string(x.id_hash))
+        Convex.MAXDIGITS[] = old_maxdigits
+
     end
 
     @testset "ConicObj with type $T" for T = [UInt32, UInt64]


### PR DESCRIPTION
Follow-up to https://discourse.julialang.org/t/convex-jl-how-to-print-full-variable-id/35917