### PR TITLE
Fix `add_constraint!`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Manifest.toml
 benchmark/*.json
 test/Project.toml
+dev

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Convex"
 uuid = "f65535da-76fb-5f13-bab9-19810c17039a"
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -95,10 +95,9 @@ satisfy(constraints::Array{<:Constraint}=Constraint[]; numeric_type = Float64) =
 satisfy(constraint::Constraint; numeric_type = Float64) = satisfy([constraint]; numeric_type = numeric_type)
 
 # +(constraints, constraints) is defined in constraints.jl
-add_constraints!(p::Problem, constraints::Array{<:Constraint}) =
-    +(p.constraints, constraints)
+add_constraints!(p::Problem, constraints::Array{<:Constraint}) = append!(p.constraints, constraints)
 add_constraints!(p::Problem, constraint::Constraint) = add_constraints!(p, [constraint])
-add_constraint! = add_constraints!
+const add_constraint! = add_constraints!
 
 # caches conic form of x when x is the solution to the optimization problem p
 function cache_conic_form!(conic_forms::UniqueConicForms, x::AbstractExpr, p::Problem)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -274,6 +274,23 @@ using Convex: AbstractExpr, ConicObj
         @test_logs  Convex.NotDcp()
         Convex.DCP_WARNINGS[] = true
         @test_logs (:warn, r"not DCP compliant") Convex.NotDcp()
-        
+
+    end
+
+    @testset "`add_constraints!` (#380)" begin
+        x = Variable(3, 3)
+        p = minimize(norm_1(x))
+        y = randn(3, 3)
+        c = (norm2(x-y) < 1)
+        @test length(p.constraints) == 0
+        add_constraint!(p, c)
+        @test length(p.constraints) == 1
+        empty!(p.constraints)
+        add_constraints!(p, c)
+        @test length(p.constraints) == 1
+        empty!(p.constraints)
+        c2 = (norm2(x-rand(3,3)) < 3)
+        add_constraints!(p, [c, c2])
+        @test length(p.constraints) == 2
     end
 end


### PR DESCRIPTION
Closes #380 

The definition of this function hasn't really changed since it was introduced in 2014 in https://github.com/JuliaOpt/Convex.jl/commit/9c346819492f4c3bf551845bc1400fc8eda0c139, but I think it worked at that point since at that point, `+` for constraints called `append!`, so it was more of a `+=` than a `+`, and did the right thing for `add_constraints!` (but I guess the wrong thing for a `+` method). It looks like the `+` method was fixed in https://github.com/JuliaOpt/Convex.jl/commit/337bb96c17d4ce95130473cf7547ba2648a4bed0 (also in 2014) to append to an empty array, which then broke `add_constraints!`.

Quite an old bug! This must have been frustrating for some users over the years. Thanks @riccardomurri for reporting it.